### PR TITLE
feat(solutions): add all-in-one and module deep-dive pages

### DIFF
--- a/src/components/AIAvatar.astro
+++ b/src/components/AIAvatar.astro
@@ -15,6 +15,9 @@ const AI_EMPLOYEE_AVATARS: Record<string, { displayName: string; avatar: string 
   cole: { displayName: 'Cole', avatar: 'nocobase-036-female' },
   ellis: { displayName: 'Ellis', avatar: 'nocobase-057-female' },
   dara: { displayName: 'Dara', avatar: 'nocobase-048-female' },
+  // All-in-One Suite additional builtins
+  atlas: { displayName: 'Atlas', avatar: 'nocobase-044-male' },
+  lina: { displayName: 'Lina', avatar: 'nocobase-052-female' },
   // Ticket System AI Employees
   grace: { displayName: 'Grace', avatar: 'nocobase-052-female' },
   max: { displayName: 'Max', avatar: 'nocobase-034-female' },

--- a/src/layouts/BaseCN.astro
+++ b/src/layouts/BaseCN.astro
@@ -46,7 +46,8 @@ if (urlEN === '/en') {
   urlEN = '/';
 }
 
-const { title, description, keywords, image } = Astro.props;
+const { title, description, keywords, image, canonical } = Astro.props;
+const canonicalPath = canonical || urlCN;
 
 const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
@@ -76,7 +77,7 @@ const meta = {
     <link rel="sitemap" href={'/sitemap.xml'} />
 
     <!-- Canonical -->
-    <link rel="canonical" href={new URL(urlCN, Astro.site)} />
+    <link rel="canonical" href={new URL(canonicalPath, Astro.site)} />
 
     <link rel="alternate" href={new URL(urlEN, Astro.site)} hreflang="en-us">
     <link rel="alternate" href={new URL(urlES, Astro.site)} hreflang="es-es">
@@ -473,21 +474,6 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-lightbulb-alt fs-6 align-middle"></i> NocoBase 亮点</li>
-                    <li><a href="/cn/highlights/data-source" title="数据源" class="sub-menu-item">数据源</a></li>
-                    <li><a href="/cn/highlights/block-action" title="区块与操作" class="sub-menu-item">区块与操作</a></li>
-                    <li><a href="/cn/highlights/ai-employee" title="AI 员工" class="sub-menu-item">AI 员工</a></li>
-                    <li><a href="/cn/highlights/permissions" title="权限" class="sub-menu-item">权限</a></li>
-                    <li><a href="/cn/highlights/workflow" title="工作流" class="sub-menu-item">工作流</a></li>
-                    <!-- <li><a href="javascript:void(0)" title="多应用" class="sub-menu-item" style="color: #CCC!important;">多应用</a></li>
-                    <li><a href="javascript:void(0)" title="多空间" class="sub-menu-item" style="color:#CCC!important;">多空间</a></li>
-                    <li><a href="javascript:void(0)" title="历史与日志" class="sub-menu-item" style="color:#CCC!important;">历史与日志</a></li>
-                    <li><a href="javascript:void(0)" title="发布管理" class="sub-menu-item" style="color:#CCC!important;">发布管理</a></li>
-                    <li><a href="javascript:void(0)" title="可扩展性" class="sub-menu-item" style="color:#CCC!important;">可扩展性</a></li> -->
-                  </ul>
-                </li>
-                <li>
-                  <ul>
                     <li class="megamenu-head"><i class="uil uil-puzzle-piece fs-6 align-middle"></i> 探索</li>
                     <li><a href="https://v2.docs.nocobase.com/cn/get-started/how-nocobase-works" target="_blank" class="sub-menu-item">NocoBase 如何工作 <i class="uil uil-external-link-alt"></i></a></li>
                     <li><a href="https://demo.nocobase.com/new" target="_blank" class="sub-menu-item">Live Demo <i class="uil uil-external-link-alt"></i> <span class="badge text-bg-success ms-2">在线体验</span></a></li>
@@ -510,12 +496,19 @@ const meta = {
                 <li>
                   <ul>
                     <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> 解决方案</li>
-                    <li><a href="/cn/solutions/crm" title="NocoBase CRM解决方案" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
-                    <li><a href="/cn/solutions/crm-v2" title="NocoBase AI智能CRM系统" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
-                    <li><a href="/cn/solutions/ticketing" title="NocoBase 工单系统解决方案" class="sub-menu-item">工单系统 <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
-                    <li><a href="/cn/solutions/ticketing-v2" title="NocoBase AI智能工单系统" class="sub-menu-item">工单系统 <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
-                    <li><a href="/cn/solutions/project-management" title="NocoBase 项目管理解决方案" class="sub-menu-item">项目管理 <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
+                    <li><a href="/cn/solutions/all-in-one" title="NocoBase 一体化业务管理系统" class="sub-menu-item">一体化业务管理系统 <span class="badge bg-soft-success ms-1" style="font-size: 0.7em;">new</span></a></li>
+                  </ul>
+                </li>
 
+                <li>
+                  <ul>
+                    <li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> 业务模块</li>
+                    <li><a href="/cn/solutions/crm-v2" title="开源 CRM 客户管理系统" class="sub-menu-item">CRM 客户管理</a></li>
+                    <li><a href="/cn/solutions/sales-management" title="销售管理系统:报价/订单/发票" class="sub-menu-item">销售管理</a></li>
+                    <li><a href="/cn/solutions/ticketing-v2" title="客服工单系统" class="sub-menu-item">工单系统</a></li>
+                    <li><a href="/cn/solutions/project-management" title="项目管理系统" class="sub-menu-item">项目管理</a></li>
+                    <li><a href="/cn/solutions/asset-management" title="固定资产管理 / IT 资产管理" class="sub-menu-item">固定资产管理</a></li>
+                    <li><a href="/cn/solutions/hr-management" title="HR 人事管理 / 人力资源管理系统" class="sub-menu-item">HR 人事管理</a></li>
                   </ul>
                 </li>
 

--- a/src/layouts/BaseDE.astro
+++ b/src/layouts/BaseDE.astro
@@ -496,7 +496,7 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Anwendungsfaelle</li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Lösungen</li>
                     <li><a href="/de/solutions/crm" title="NocoBase CRM solution" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/de/solutions/crm-v2" title="NocoBase AI-powered CRM system" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                     <li><a href="/de/solutions/ticketing" title="NocoBase-Ticketing-Loesung" class="sub-menu-item">Ticketsystem <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -505,6 +505,18 @@ const meta = {
 
                   </ul>
                 </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Module</li>
+<li><a href="/de/solutions/crm-v2" title="Open-Source-CRM zur Kundenverwaltung" class="sub-menu-item">CRM</a></li>
+<li><a href="/de/solutions/sales-management" title="Vertriebsmanagement: Angebote / Aufträge / Rechnungen" class="sub-menu-item">Vertriebsmanagement</a></li>
+<li><a href="/de/solutions/ticketing-v2" title="Helpdesk & Kundenservice-Tickets" class="sub-menu-item">Helpdesk</a></li>
+<li><a href="/de/solutions/project-management" title="Projektmanagement-Software" class="sub-menu-item">Projektmanagement</a></li>
+<li><a href="/de/solutions/asset-management" title="IT- & Anlagenverwaltung" class="sub-menu-item">Anlagenverwaltung</a></li>
+<li><a href="/de/solutions/hr-management" title="HR / Personalverwaltungssystem" class="sub-menu-item">HR / Personal</a></li>
+</ul>
+</li>
 
                 <li>
                   <ul>

--- a/src/layouts/BaseEN.astro
+++ b/src/layouts/BaseEN.astro
@@ -46,7 +46,8 @@ if (urlEN === '/en') {
   urlEN = '/';
 }
 
-const { title, description, keywords, image } = Astro.props;
+const { title, description, keywords, image, canonical } = Astro.props;
+const canonicalPath = canonical || urlEN;
 
 const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
@@ -76,7 +77,7 @@ const meta = {
     <link rel="sitemap" href={'/sitemap.xml'} />
 
     <!-- Canonical -->
-    <link rel="canonical" href={new URL(urlEN, Astro.site)} />
+    <link rel="canonical" href={new URL(canonicalPath, Astro.site)} />
 
     <link rel="alternate" href={new URL(urlEN, Astro.site)} hreflang="en-us">
     <link rel="alternate" href={new URL(urlES, Astro.site)} hreflang="es-es">
@@ -449,21 +450,6 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-lightbulb-alt fs-6 align-middle"></i> NocoBase Highlights</li>
-                    <li><a href="/en/highlights/data-source" title="Data Source" class="sub-menu-item">Data Source</a></li>
-                    <li><a href="/en/highlights/block-action" title="Block & Action" class="sub-menu-item">Block & Action</a></li>
-                    <li><a href="/en/highlights/ai-employee" title="AI Employee" class="sub-menu-item">AI Employee</a></li>
-                    <li><a href="/en/highlights/permissions" title="Permission" class="sub-menu-item">Permission</a></li>
-                    <li><a href="/en/highlights/workflow" title="Workflow" class="sub-menu-item">Workflow</a></li>
-                    <!-- <li><a href="javascript:void(0)" title="Multi-App" class="sub-menu-item" style="color: #CCC!important;">Multi-App</a></li>
-                    <li><a href="javascript:void(0)" title="Multi-Space" class="sub-menu-item" style="color: #CCC!important;">Multi-Space</a></li>
-                    <li><a href="javascript:void(0)" title="History & Log" class="sub-menu-item" style="color: #CCC!important;">History & Log</a></li>
-                    <li><a href="javascript:void(0)" title="Release Management" class="sub-menu-item" style="color: #CCC!important;">Release Management</a></li>
-                    <li><a href="javascript:void(0)" title="Extensibility" class="sub-menu-item" style="color: #CCC!important;">Extensibility</a></li> -->
-                  </ul>
-                </li>
-                <li>
-                  <ul>
                     <li class="megamenu-head"><i class="uil uil-puzzle-piece fs-6 align-middle"></i> Explore</li>
                     <li><a href="https://v2.docs.nocobase.com/get-started/how-nocobase-works" target="_blank" class="sub-menu-item">See how it works <i class="uil uil-external-link-alt"></i></a></li>
                     <li><a href="https://demo.nocobase.com/new" target="_blank" class="sub-menu-item">Live Demo <i class="uil uil-external-link-alt"></i> <span class="badge text-bg-success ms-2">Try it out</span></a></li>
@@ -484,13 +470,20 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Use Cases</li>
-                    <li><a href="/en/solutions/crm" title="NocoBase CRM solution" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
-                    <li><a href="/en/solutions/crm-v2" title="NocoBase AI-powered CRM system" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
-                    <li><a href="/en/solutions/ticketing" title="NocoBase ticketing system solution" class="sub-menu-item">Ticketing system <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
-                    <li><a href="/en/solutions/ticketing-v2" title="NocoBase AI-powered ticketing system" class="sub-menu-item">Ticketing system <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
-                    <li><a href="/en/solutions/project-management" title="NocoBase project management solution" class="sub-menu-item">Project management <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Solutions</li>
+                    <li><a href="/en/solutions/all-in-one" title="NocoBase All-in-One Business Suite" class="sub-menu-item">All-in-One Business Suite <span class="badge bg-soft-success ms-1" style="font-size: 0.7em;">new</span></a></li>
+                  </ul>
+                </li>
 
+                <li>
+                  <ul>
+                    <li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Modules</li>
+                    <li><a href="/en/solutions/crm-v2" title="Open-source CRM customer management" class="sub-menu-item">CRM</a></li>
+                    <li><a href="/en/solutions/sales-management" title="Sales management: quotes / orders / invoices" class="sub-menu-item">Sales Management</a></li>
+                    <li><a href="/en/solutions/ticketing-v2" title="Help desk & customer support ticketing" class="sub-menu-item">Help Desk</a></li>
+                    <li><a href="/en/solutions/project-management" title="Project management software" class="sub-menu-item">Project Management</a></li>
+                    <li><a href="/en/solutions/asset-management" title="IT & fixed asset management" class="sub-menu-item">IT Asset Management</a></li>
+                    <li><a href="/en/solutions/hr-management" title="HR / human resources management system" class="sub-menu-item">HR Management</a></li>
                   </ul>
                 </li>
 

--- a/src/layouts/BaseES.astro
+++ b/src/layouts/BaseES.astro
@@ -486,7 +486,7 @@ const meta = {
           <ul class="submenu megamenu">
             <li>
               <ul>
-                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Casos de uso</li>
+                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Soluciones</li>
                 <li><a href="/es/solutions/crm" title="Solución CRM de NocoBase" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                 <li><a href="/es/solutions/crm-v2" title="CRM con IA de NocoBase" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                 <li><a href="/es/solutions/ticketing" title="Solución de ticketing de NocoBase" class="sub-menu-item">Sistema de tickets <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -496,9 +496,21 @@ const meta = {
               </ul>
             </li>
 
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Módulos</li>
+<li><a href="/es/solutions/crm-v2" title="CRM open source para gestión de clientes" class="sub-menu-item">CRM</a></li>
+<li><a href="/es/solutions/sales-management" title="Gestión de ventas: cotizaciones / pedidos / facturas" class="sub-menu-item">Ventas</a></li>
+<li><a href="/es/solutions/ticketing-v2" title="Help Desk y tickets de soporte al cliente" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/es/solutions/project-management" title="Software de gestión de proyectos" class="sub-menu-item">Gestión de Proyectos</a></li>
+<li><a href="/es/solutions/asset-management" title="Gestión de activos TI y fijos" class="sub-menu-item">Gestión de Activos</a></li>
+<li><a href="/es/solutions/hr-management" title="RRHH / sistema de gestión de recursos humanos" class="sub-menu-item">RRHH</a></li>
+</ul>
+</li>
+
             <li>
               <ul>
-                <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> Partners</li>
+                <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> Socios</li>
                 <li><a href="/es/find-partner" class="sub-menu-item">Encontrar un partner de NocoBase</a></li>
                 <li><a href="/es/partner" class="sub-menu-item">Hazte partner</a></li>
               </ul>

--- a/src/layouts/BaseFR.astro
+++ b/src/layouts/BaseFR.astro
@@ -486,7 +486,7 @@ const meta = {
           <ul class="submenu megamenu">
             <li>
               <ul>
-                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Cas d'usage</li>
+                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Solutions</li>
                 <li><a href="/fr/solutions/crm" title="Solution CRM NocoBase" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                 <li><a href="/fr/solutions/ticketing" title="Solution de ticketing NocoBase" class="sub-menu-item">Système de ticketing <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                 <li><a href="/fr/solutions/ticketing-v2" title="Système de ticketing IA NocoBase" class="sub-menu-item">Système de ticketing <span style="color: #2f55d4; font-size: 0.85em;">2.0</span> <span class="badge coming-soon-badge ms-2">En dev</span></a></li>
@@ -494,6 +494,18 @@ const meta = {
 
               </ul>
             </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Modules</li>
+<li><a href="/fr/solutions/crm-v2" title="CRM open source pour la gestion des clients" class="sub-menu-item">CRM</a></li>
+<li><a href="/fr/solutions/sales-management" title="Gestion commerciale : devis / commandes / factures" class="sub-menu-item">Ventes</a></li>
+<li><a href="/fr/solutions/ticketing-v2" title="Help Desk et tickets de support client" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/fr/solutions/project-management" title="Logiciel de gestion de projet" class="sub-menu-item">Gestion de Projet</a></li>
+<li><a href="/fr/solutions/asset-management" title="Gestion des actifs IT et immobilisations" class="sub-menu-item">Gestion d'Actifs</a></li>
+<li><a href="/fr/solutions/hr-management" title="RH / système de gestion des ressources humaines" class="sub-menu-item">RH</a></li>
+</ul>
+</li>
 
             <li>
               <ul>

--- a/src/layouts/BaseID.astro
+++ b/src/layouts/BaseID.astro
@@ -496,7 +496,7 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Skenario penggunaan</li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Solusi</li>
                     <li><a href="/id/solutions/crm" title="NocoBase CRM solution" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/id/solutions/crm-v2" title="NocoBase AI-powered CRM system" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                     <li><a href="/id/solutions/ticketing" title="Solusi sistem tiket NocoBase" class="sub-menu-item">Sistem tiket <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -505,6 +505,18 @@ const meta = {
 
                   </ul>
                 </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Modul</li>
+<li><a href="/id/solutions/crm-v2" title="CRM open source untuk manajemen pelanggan" class="sub-menu-item">CRM</a></li>
+<li><a href="/id/solutions/sales-management" title="Manajemen penjualan: quotation / pesanan / faktur" class="sub-menu-item">Penjualan</a></li>
+<li><a href="/id/solutions/ticketing-v2" title="Help Desk & tiket dukungan pelanggan" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/id/solutions/project-management" title="Software manajemen proyek" class="sub-menu-item">Manajemen Proyek</a></li>
+<li><a href="/id/solutions/asset-management" title="Manajemen aset TI & tetap" class="sub-menu-item">Manajemen Aset</a></li>
+<li><a href="/id/solutions/hr-management" title="HR / sistem manajemen sumber daya manusia" class="sub-menu-item">HR / SDM</a></li>
+</ul>
+</li>
 
                 <li>
                   <ul>

--- a/src/layouts/BaseJA.astro
+++ b/src/layouts/BaseJA.astro
@@ -466,7 +466,7 @@ const meta = {
                     <ul class="submenu megamenu">
                         <li>
                             <ul>
-                                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> 活用事例</li>
+                                <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> ソリューション</li>
                                 <li><a href="/ja/solutions/crm" title="NocoBase CRMソリューション" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                                 <li><a href="/ja/solutions/crm-v2" title="NocoBase AI CRMシステム" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                                 <li><a href="/ja/solutions/ticketing" title="NocoBase チケットシステムソリューション" class="sub-menu-item">チケットシステム <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -475,6 +475,18 @@ const meta = {
 
                             </ul>
                         </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> モジュール</li>
+<li><a href="/ja/solutions/crm-v2" title="オープンソース CRM 顧客管理" class="sub-menu-item">CRM</a></li>
+<li><a href="/ja/solutions/sales-management" title="販売管理:見積/注文/請求書" class="sub-menu-item">販売管理</a></li>
+<li><a href="/ja/solutions/ticketing-v2" title="ヘルプデスク & カスタマーサポートチケット" class="sub-menu-item">ヘルプデスク</a></li>
+<li><a href="/ja/solutions/project-management" title="プロジェクト管理ソフトウェア" class="sub-menu-item">プロジェクト管理</a></li>
+<li><a href="/ja/solutions/asset-management" title="IT & 固定資産管理" class="sub-menu-item">資産管理</a></li>
+<li><a href="/ja/solutions/hr-management" title="HR / 人事管理システム" class="sub-menu-item">HR / 人事</a></li>
+</ul>
+</li>
 
                         <li>
                             <ul>

--- a/src/layouts/BasePT.astro
+++ b/src/layouts/BasePT.astro
@@ -496,7 +496,7 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Casos de uso</li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Soluções</li>
                     <li><a href="/pt/solutions/crm" title="NocoBase CRM solution" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/pt/solutions/crm-v2" title="NocoBase AI-powered CRM system" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                     <li><a href="/pt/solutions/ticketing" title="Solucao de tickets da NocoBase" class="sub-menu-item">Sistema de tickets <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -505,6 +505,18 @@ const meta = {
 
                   </ul>
                 </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Módulos</li>
+<li><a href="/pt/solutions/crm-v2" title="CRM open source para gestão de clientes" class="sub-menu-item">CRM</a></li>
+<li><a href="/pt/solutions/sales-management" title="Gestão de vendas: orçamentos / pedidos / faturas" class="sub-menu-item">Vendas</a></li>
+<li><a href="/pt/solutions/ticketing-v2" title="Help Desk e tickets de suporte ao cliente" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/pt/solutions/project-management" title="Software de gestão de projetos" class="sub-menu-item">Gestão de Projetos</a></li>
+<li><a href="/pt/solutions/asset-management" title="Gestão de ativos de TI e fixos" class="sub-menu-item">Gestão de Ativos</a></li>
+<li><a href="/pt/solutions/hr-management" title="RH / sistema de gestão de recursos humanos" class="sub-menu-item">RH</a></li>
+</ul>
+</li>
 
                 <li>
                   <ul>

--- a/src/layouts/BaseRU.astro
+++ b/src/layouts/BaseRU.astro
@@ -512,7 +512,7 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Сценарии</li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Решения</li>
                     <li><a href="/ru/solutions/crm" title="NocoBase CRM система" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/ru/solutions/ticketing" title="NocoBase Служба поддержки" class="sub-menu-item">Служба поддержки <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/ru/solutions/ticketing-v2" title="NocoBase AI-система поддержки" class="sub-menu-item">Служба поддержки <span style="color: #2f55d4; font-size: 0.85em;">2.0</span> </a></li>
@@ -520,6 +520,18 @@ const meta = {
 
                   </ul>
                 </li>
+
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Модули</li>
+<li><a href="/ru/solutions/crm-v2" title="Open-source CRM для управления клиентами" class="sub-menu-item">CRM</a></li>
+<li><a href="/ru/solutions/sales-management" title="Управление продажами: КП / заказы / счета" class="sub-menu-item">Продажи</a></li>
+<li><a href="/ru/solutions/ticketing-v2" title="Help Desk и тикеты поддержки" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/ru/solutions/project-management" title="Программа для управления проектами" class="sub-menu-item">Управление проектами</a></li>
+<li><a href="/ru/solutions/asset-management" title="Управление IT и основными активами" class="sub-menu-item">Управление активами</a></li>
+<li><a href="/ru/solutions/hr-management" title="HR / система управления персоналом" class="sub-menu-item">HR / Кадры</a></li>
+</ul>
+</li>
 
                 <li>
                   <ul>

--- a/src/layouts/BaseTW.astro
+++ b/src/layouts/BaseTW.astro
@@ -534,9 +534,21 @@ const meta = {
                   </ul>
                 </li>
 
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> 業務模組</li>
+<li><a href="/tw/solutions/crm-v2" title="開源 CRM 客戶管理系統" class="sub-menu-item">CRM 客戶管理</a></li>
+<li><a href="/tw/solutions/sales-management" title="銷售管理系統:報價/訂單/發票" class="sub-menu-item">銷售管理</a></li>
+<li><a href="/tw/solutions/ticketing-v2" title="客服工單系統" class="sub-menu-item">工單系統</a></li>
+<li><a href="/tw/solutions/project-management" title="專案管理系統" class="sub-menu-item">專案管理</a></li>
+<li><a href="/tw/solutions/asset-management" title="固定資產管理 / IT 資產管理" class="sub-menu-item">固定資產管理</a></li>
+<li><a href="/tw/solutions/hr-management" title="HR 人事管理 / 人力資源管理系統" class="sub-menu-item">HR 人事管理</a></li>
+</ul>
+</li>
+
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> 合作伙伴</li>
+                    <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> 合作夥伴</li>
                     <li><a href="/tw/find-partner" class="sub-menu-item">尋找 NocoBase 夥伴</a></li>
                     <!-- <li><a href="https://service-cn.nocobase.com/public-forms/iv0g603rvzp" target="_blank" class="sub-menu-item">成為合作伙伴</a></li> -->
                     <li><a href="/tw/partner" class="sub-menu-item">成為合作伙伴 </a></li>

--- a/src/layouts/BaseVI.astro
+++ b/src/layouts/BaseVI.astro
@@ -496,7 +496,7 @@ const meta = {
               <ul class="submenu megamenu">
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Truong hop su dung</li>
+                    <li class="megamenu-head"><i class="uil uil-briefcase-alt fs-6 align-middle"></i> Giải pháp</li>
                     <li><a href="/vi/solutions/crm" title="NocoBase CRM solution" class="sub-menu-item">CRM <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
                     <li><a href="/vi/solutions/crm-v2" title="NocoBase AI-powered CRM system" class="sub-menu-item">CRM <span style="color: #2f55d4; font-size: 0.85em;">2.0</span></a></li>
                     <li><a href="/vi/solutions/ticketing" title="Giai phap he thong ticket cua NocoBase" class="sub-menu-item">He thong ticket <span style="color: #999; font-size: 0.85em;">1.x</span></a></li>
@@ -506,9 +506,21 @@ const meta = {
                   </ul>
                 </li>
 
+<li>
+<ul>
+<li class="megamenu-head"><i class="uil uil-layer-group fs-6 align-middle"></i> Mô-đun</li>
+<li><a href="/vi/solutions/crm-v2" title="CRM mã nguồn mở quản lý khách hàng" class="sub-menu-item">CRM</a></li>
+<li><a href="/vi/solutions/sales-management" title="Quản lý bán hàng: báo giá / đơn hàng / hóa đơn" class="sub-menu-item">Bán hàng</a></li>
+<li><a href="/vi/solutions/ticketing-v2" title="Help Desk & phiếu hỗ trợ khách hàng" class="sub-menu-item">Help Desk</a></li>
+<li><a href="/vi/solutions/project-management" title="Phần mềm quản lý dự án" class="sub-menu-item">Quản lý Dự án</a></li>
+<li><a href="/vi/solutions/asset-management" title="Quản lý tài sản CNTT & cố định" class="sub-menu-item">Quản lý Tài sản</a></li>
+<li><a href="/vi/solutions/hr-management" title="HR / hệ thống quản lý nhân sự" class="sub-menu-item">HR / Nhân sự</a></li>
+</ul>
+</li>
+
                 <li>
                   <ul>
-                    <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> Doi tac</li>
+                    <li class="megamenu-head"><i class="uil uil-users-alt fs-6 align-middle"></i> Đối tác</li>
                     <li><a href="/vi/find-partner" class="sub-menu-item">Tim doi tac NocoBase</a></li>
                     <!-- <li><a href="https://service-en.nocobase.com/public-forms/tthwhf3ykqz" target="_blank" class="sub-menu-item">Become a partner</a></li> -->
                     <li><a href="/vi/partner" class="sub-menu-item">Tro thanh doi tac</a></li>

--- a/src/pages/cn/solutions/all-in-one.astro
+++ b/src/pages/cn/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseCN from "../../../layouts/BaseCN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseCN
+  title="一体化业务管理系统 - CRM / 工单 / 项目管理 / 固定资产 / HR | NocoBase"
+  description="开源一体化业务管理系统:CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理 6 大模块全面整合。基于 NocoBase 无代码平台,开箱即用,适合中小团队快速上线。"
+  keywords="一体化业务管理系统, CRM 系统, 开源 CRM, 工单系统, 客服工单系统, 项目管理系统, 固定资产管理系统, IT 资产管理, HR 人事管理系统, 人力资源管理系统, 销售管理系统, 无代码 ERP, 多合一管理系统, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">一体化<br/>业务管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建,涵盖 <strong>CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理</strong> 六大模块。
+              开箱即用,无需复杂选型与多套系统集成。
+            </p>
+
+            <!-- 核心价值 -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">多系统整合</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">20+ 语种内置支持</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI 员工 + 工作流</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">开源免费</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 适用场景标签 -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景：</span>
+                  <span class="badge bg-soft-primary me-2">初创公司</span>
+                  <span class="badge bg-soft-primary me-2">多业务线门店</span>
+                  <span class="badge bg-soft-primary me-2">业务探索期</span>
+                  <span class="badge bg-soft-primary">教学与培训</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>立即体验 Demo
+              </a>
+              <a href="/cn/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>联系咨询
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="一体化业务管理系统" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 模块协同</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理,全部业务流程在同一系统内闭环</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- 客户管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM 客户管理</h5>
+              <p class="text-muted mt-2">开源 CRM 系统：线索、跟进、转化、合并去重的完整流程；客户 360 视图聚合订单、工单、项目、资产等历史记录。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>线索阶段管理与转化</li>
+                <li><i class="uil uil-check text-primary me-1"></i>客户 360 详情视图</li>
+                <li><i class="uil uil-check text-primary me-1"></i>合并/去重工具</li>
+              </ul>
+              <a href="/cn/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 销售套件 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">销售管理</h5>
+              <p class="text-muted mt-2">销售订单管理:报价、订单、发票、收款的完整链路;内置审批流程与应收账款分析。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>多币种报价</li>
+                <li><i class="uil uil-check text-primary me-1"></i>订单审批工作流</li>
+                <li><i class="uil uil-check text-primary me-1"></i>逾期账款 KPI</li>
+              </ul>
+              <a href="/cn/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 工单系统 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工单系统</h5>
+              <p class="text-muted mt-2">客服工单系统:客户报障、分派、处理与满意度评价;支持 SLA 计时、优先级管理与等待原因细分。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>SLA 自动计时与超期通知</li>
+                <li><i class="uil uil-check text-primary me-1"></i>工单仪表盘 + 团队工作台</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 级优先级 + AI 智能分类</li>
+              </ul>
+              <a href="/cn/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 项目管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">项目管理</h5>
+              <p class="text-muted mt-2">轻量项目管理系统:项目与任务的两级管理;涵盖负责人、进度、里程碑与延期预警。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>项目状态看板</li>
+                <li><i class="uil uil-check text-primary me-1"></i>任务负责人工作量</li>
+                <li><i class="uil uil-check text-primary me-1"></i>延期项目提醒</li>
+              </ul>
+              <a href="/cn/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 资产管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">固定资产管理</h5>
+              <p class="text-muted mt-2">IT 资产与办公资产的全生命周期管理,涵盖采购、分配、维护、报废,配套供应商台账。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>资产分配 / 归还</li>
+                <li><i class="uil uil-check text-primary me-1"></i>维护工单</li>
+                <li><i class="uil uil-check text-primary me-1"></i>采购供应商分析</li>
+              </ul>
+              <a href="/cn/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR 人事 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR 人事管理</h5>
+              <p class="text-muted mt-2">人力资源管理系统:员工台账,入职、离职、请假、试用期跟踪,配合岗位与部门组织结构。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>入职 / 离职清单</li>
+                <li><i class="uil uil-check text-primary me-1"></i>请假审批</li>
+                <li><i class="uil uil-check text-primary me-1"></i>试用期员工看板</li>
+              </ul>
+              <a href="/cn/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">平台底座能力</h4>
+            <p class="para-desc mx-auto text-muted mb-0">基于 NocoBase 2.x，内置 AI、工作流、多语言与多空间能力</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI 员工</h5>
+            <p class="text-muted small">Lina（本地化）、Lexi（翻译）、Atlas（协作）等内置 AI 角色，按业务场景调用。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>多语言支持</h5>
+            <p class="text-muted small">中、英、日、韩、德、法等 20+ 语种内置支持，全量 UI 已完成翻译。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>工作流引擎</h5>
+            <p class="text-muted small">审批、通知、SLA 计时、定时触发；可视化编排，无需编码即可配置规则。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>多空间隔离</h5>
+            <p class="text-muted small">一套系统服务多个团队或门店，数据相互隔离，权限独立管理。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI 协作</span>
+            <h4 class="title mb-4">内置 AI 员工</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 位预置 AI 员工覆盖典型业务角色，支持通过 MCP 协议接入外部 Agent 扩展能力</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">团队负责人 — 任务分派与协作编排</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">前端工程师 — 界面与 JS 块代码生成</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">可视化设计 — 图表与看板搭建</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">洞察分析 — 趋势识别与 KPI 解读</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">调研分析 — 信息收集与摘要</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">数据整理 — 清洗合并与批量整理</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">翻译沟通 — 多语种客户对话与邮件</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">本地化工程师 — 界面文案与 i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">邮件助手 — 意图分析与回复草拟</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">自定义 AI 员工</h6>
+              <p class="text-muted small mb-0">按业务需要创建专属角色 / 提示词 / 技能组合</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">外部 Agent 接入</h6>
+              <p class="text-muted small mb-0">MCP 协议连接你自己的 Agent / 工具链</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">适用场景</h4>
+            <p class="para-desc mx-auto text-muted mb-0">整合方案在以下场景中尤为适用</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>跨业务线全局管理</h5>
+                  <p class="text-muted mb-0">业务横跨销售、客服、项目多条线，需要在统一系统中查看全局，避免在多套独立工具间切换。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>多业务线门店</h5>
+                  <p class="text-muted mb-0">门店同时承担销售、售后与项目交付，业务条线繁多但规模有限，独立方案的协同成本较高。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>业务探索阶段</h5>
+                  <p class="text-muted mb-0">业务尚未定型，避免过早锁定特定方案；整合平台可先行投入使用，再根据需求迭代。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>教学 / 培训 / POC</h5>
+                  <p class="text-muted mb-0">作为 NocoBase 平台能力的完整示例，可用于内部培训、方案演示或概念验证，覆盖典型业务流程。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">如何使用？</h4>
+            <p class="para-desc mx-auto text-muted mb-0">三步完成部署，开始使用一体化业务管理系统</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>安装 NocoBase</h5>
+                <p class="text-muted mt-2">按照官方安装文档，将 NocoBase 部署到本地或服务器环境</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装文档</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">还原后即可使用全套预置数据,完整 6 大模块</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">开始使用一体化业务管理系统</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            基于 NocoBase 2.x 构建的整合型业务系统。模板支持直接复用与扩展；如需面向特定业务的深度定制，欢迎联系我们。
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>立即体验 Demo
+            </a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>联系咨询
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseCN>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/cn/solutions/all-in-one.astro
+++ b/src/pages/cn/solutions/all-in-one.astro
@@ -6,7 +6,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
 
 <BaseCN
   title="一体化业务管理系统 - CRM / 工单 / 项目管理 / 固定资产 / HR | NocoBase"
-  description="开源一体化业务管理系统:CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理 6 大模块全面整合。基于 NocoBase 无代码平台,开箱即用,适合中小团队快速上线。"
+  description="开源一体化业务管理系统：CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理 6 大模块全面整合。基于 NocoBase 无代码平台，开箱即用，适合中小团队快速上线。"
   keywords="一体化业务管理系统, CRM 系统, 开源 CRM, 工单系统, 客服工单系统, 项目管理系统, 固定资产管理系统, IT 资产管理, HR 人事管理系统, 人力资源管理系统, 销售管理系统, 无代码 ERP, 多合一管理系统, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -17,8 +17,8 @@ import AIAvatar from "../../../components/AIAvatar.astro";
           <div class="title-heading">
             <h1 class="fw-bold mt-2 mb-3">一体化<br/>业务管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建,涵盖 <strong>CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理</strong> 六大模块。
-              开箱即用,无需复杂选型与多套系统集成。
+              基于 NocoBase 无代码平台构建，涵盖 <strong>CRM 客户管理、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理</strong> 六大模块。
+              开箱即用，无需复杂选型与多套系统集成。
             </p>
 
             <!-- 核心价值 -->
@@ -90,7 +90,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">6 模块协同</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理,全部业务流程在同一系统内闭环</p>
+            <p class="para-desc mx-auto text-muted mb-0">CRM、销售管理、工单系统、项目管理、固定资产管理、HR 人事管理，全部业务流程在同一系统内闭环</p>
           </div>
         </div>
       </div>
@@ -124,7 +124,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
             </div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">销售管理</h5>
-              <p class="text-muted mt-2">销售订单管理:报价、订单、发票、收款的完整链路;内置审批流程与应收账款分析。</p>
+              <p class="text-muted mt-2">销售订单管理：报价、订单、发票、收款的完整链路；内置审批流程与应收账款分析。</p>
               <ul class="list-unstyled text-muted mt-2 small">
                 <li><i class="uil uil-check text-primary me-1"></i>多币种报价</li>
                 <li><i class="uil uil-check text-primary me-1"></i>订单审批工作流</li>
@@ -144,7 +144,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
             </div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">工单系统</h5>
-              <p class="text-muted mt-2">客服工单系统:客户报障、分派、处理与满意度评价;支持 SLA 计时、优先级管理与等待原因细分。</p>
+              <p class="text-muted mt-2">客服工单系统：客户报障、分派、处理与满意度评价；支持 SLA 计时、优先级管理与等待原因细分。</p>
               <ul class="list-unstyled text-muted mt-2 small">
                 <li><i class="uil uil-check text-primary me-1"></i>SLA 自动计时与超期通知</li>
                 <li><i class="uil uil-check text-primary me-1"></i>工单仪表盘 + 团队工作台</li>
@@ -164,7 +164,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
             </div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">项目管理</h5>
-              <p class="text-muted mt-2">轻量项目管理系统:项目与任务的两级管理;涵盖负责人、进度、里程碑与延期预警。</p>
+              <p class="text-muted mt-2">轻量项目管理系统：项目与任务的两级管理；涵盖负责人、进度、里程碑与延期预警。</p>
               <ul class="list-unstyled text-muted mt-2 small">
                 <li><i class="uil uil-check text-primary me-1"></i>项目状态看板</li>
                 <li><i class="uil uil-check text-primary me-1"></i>任务负责人工作量</li>
@@ -184,7 +184,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
             </div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">固定资产管理</h5>
-              <p class="text-muted mt-2">IT 资产与办公资产的全生命周期管理,涵盖采购、分配、维护、报废,配套供应商台账。</p>
+              <p class="text-muted mt-2">IT 资产与办公资产的全生命周期管理，涵盖采购、分配、维护、报废，配套供应商台账。</p>
               <ul class="list-unstyled text-muted mt-2 small">
                 <li><i class="uil uil-check text-primary me-1"></i>资产分配 / 归还</li>
                 <li><i class="uil uil-check text-primary me-1"></i>维护工单</li>
@@ -204,7 +204,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
             </div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">HR 人事管理</h5>
-              <p class="text-muted mt-2">人力资源管理系统:员工台账,入职、离职、请假、试用期跟踪,配合岗位与部门组织结构。</p>
+              <p class="text-muted mt-2">人力资源管理系统：员工台账，入职、离职、请假、试用期跟踪，配合岗位与部门组织结构。</p>
               <ul class="list-unstyled text-muted mt-2 small">
                 <li><i class="uil uil-check text-primary me-1"></i>入职 / 离职清单</li>
                 <li><i class="uil uil-check text-primary me-1"></i>请假审批</li>
@@ -517,7 +517,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
               </div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -535,7 +535,7 @@ import AIAvatar from "../../../components/AIAvatar.astro";
               </div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">还原后即可使用全套预置数据,完整 6 大模块</p>
+                <p class="text-muted mt-2">还原后即可使用全套预置数据，完整 6 大模块</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>

--- a/src/pages/cn/solutions/asset-management.astro
+++ b/src/pages/cn/solutions/asset-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseCN from "../../../layouts/BaseCN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseCN
+  title="固定资产管理系统 — 开源 IT 资产与办公资产管理 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源固定资产管理系统:采购、分配、维护、报废全生命周期管理,涵盖 IT 资产、办公资产,内置供应商台账、维护工单、采购分析。"
+  keywords="固定资产管理, IT 资产管理, 资产管理系统, 开源资产管理, 办公资产管理, 固定资产管理系统, 资产生命周期, 设备管理系统, 资产盘点, 供应商管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">固定资产管理模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">固定资产管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。<strong>采购 → 分配 → 维护 → 报废</strong> 的全生命周期管理,覆盖 IT 资产与办公资产,配套供应商台账与维护工单。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">全生命周期</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">维护工单</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">供应商台账</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">IT 资产</span>
+                  <span class="badge bg-soft-primary me-2">办公资产</span>
+                  <span class="badge bg-soft-primary me-2">设备出租</span>
+                  <span class="badge bg-soft-primary">资产盘点</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="固定资产管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">资产生命周期</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从采购入库到报废注销的完整闭环,每件资产可追溯</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">采购</div>
+                  <div class="small text-muted">关联供应商</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">入库</div>
+                  <div class="small text-muted">资产卡片</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">分配</div>
+                  <div class="small text-muted">签字留痕</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">维护</div>
+                  <div class="small text-muted">工单关联</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">报废</div>
+                  <div class="small opacity-75">残值留档</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">采购</td>
+                      <td class="py-3 text-muted">采购单关联供应商与价格;支持多品类、多数量</td>
+                      <td class="py-3 text-muted">采购单、供应商、采购金额</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入库</td>
+                      <td class="py-3 text-muted">入库自动生成资产卡片(编号、序列号、保修期一次录入)</td>
+                      <td class="py-3 text-muted">资产卡片、唯一编号、保修期</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">分配</td>
+                      <td class="py-3 text-muted">资产借给员工/客户/部门,签字确认</td>
+                      <td class="py-3 text-muted">分配记录、使用人、起止日期</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">维护</td>
+                      <td class="py-3 text-muted">故障/保养发起维护工单,关联资产卡片</td>
+                      <td class="py-3 text-muted">维护工单、累计成本</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">报废</td>
+                      <td class="py-3 text-muted">报废登记原因(损坏/淘汰/出售),记录折旧/残值</td>
+                      <td class="py-3 text-muted">报废记录、残值、处置方式</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从采购到报废的完整固定资产管理</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">资产采购</h5>
+              <p class="text-muted mt-2">采购单关联供应商与价格;入库自动生成资产卡片,资产编号、序列号、保修期一次录入。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分配 / 归还</h5>
+              <p class="text-muted mt-2">资产借给员工/客户,签字留痕;归还登记自动释放;每件资产的"使用历史"完整追溯。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">维护工单</h5>
+              <p class="text-muted mt-2">资产故障/保养发起维护工单,关联资产卡片;维护记录累计成本,辅助报废决策。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">报废 / 出售</h5>
+              <p class="text-muted mt-2">资产报废登记原因(损坏/淘汰/出售);折旧/残值记录留档,与财务对账一致。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">供应商台账</h5>
+              <p class="text-muted mt-2">供应商档案 + 历史采购记录;采购金额、品类、付款条件一目了然,辅助招采决策。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">资产看板</h5>
+              <p class="text-muted mt-2">资产总数、在用、维护中、报废分布;按类型、按部门、按使用人聚合,盘点数据一键导出。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中:资产盘点、折旧自动计算、二维码扫码、借用申请审批</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、项目管理、HR 协同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseCN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/cn/solutions/asset-management.astro
+++ b/src/pages/cn/solutions/asset-management.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="固定资产管理系统 — 开源 IT 资产与办公资产管理 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源固定资产管理系统:采购、分配、维护、报废全生命周期管理,涵盖 IT 资产、办公资产,内置供应商台账、维护工单、采购分析。"
+  description="基于 NocoBase 无代码平台的开源固定资产管理系统：采购、分配、维护、报废全生命周期管理，涵盖 IT 资产、办公资产，内置供应商台账、维护工单、采购分析。"
   keywords="固定资产管理, IT 资产管理, 资产管理系统, 开源资产管理, 办公资产管理, 固定资产管理系统, 资产生命周期, 设备管理系统, 资产盘点, 供应商管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">固定资产管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。<strong>采购 → 分配 → 维护 → 报废</strong> 的全生命周期管理,覆盖 IT 资产与办公资产,配套供应商台账与维护工单。
+              基于 NocoBase 无代码平台构建。<strong>采购 → 分配 → 维护 → 报废</strong> 的全生命周期管理，覆盖 IT 资产与办公资产，配套供应商台账与维护工单。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">IT 资产</span>
                   <span class="badge bg-soft-primary me-2">办公资产</span>
                   <span class="badge bg-soft-primary me-2">设备出租</span>
@@ -65,7 +65,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">资产生命周期</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从采购入库到报废注销的完整闭环,每件资产可追溯</p>
+            <p class="para-desc mx-auto text-muted mb-0">从采购入库到报废注销的完整闭环，每件资产可追溯</p>
           </div>
         </div>
       </div>
@@ -118,27 +118,27 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">采购</td>
-                      <td class="py-3 text-muted">采购单关联供应商与价格;支持多品类、多数量</td>
+                      <td class="py-3 text-muted">采购单关联供应商与价格；支持多品类、多数量</td>
                       <td class="py-3 text-muted">采购单、供应商、采购金额</td>
                     </tr>
                     <tr>
                       <td class="py-3">入库</td>
-                      <td class="py-3 text-muted">入库自动生成资产卡片(编号、序列号、保修期一次录入)</td>
+                      <td class="py-3 text-muted">入库自动生成资产卡片（编号、序列号、保修期一次录入）</td>
                       <td class="py-3 text-muted">资产卡片、唯一编号、保修期</td>
                     </tr>
                     <tr>
                       <td class="py-3">分配</td>
-                      <td class="py-3 text-muted">资产借给员工/客户/部门,签字确认</td>
+                      <td class="py-3 text-muted">资产借给员工/客户/部门，签字确认</td>
                       <td class="py-3 text-muted">分配记录、使用人、起止日期</td>
                     </tr>
                     <tr>
                       <td class="py-3">维护</td>
-                      <td class="py-3 text-muted">故障/保养发起维护工单,关联资产卡片</td>
+                      <td class="py-3 text-muted">故障/保养发起维护工单，关联资产卡片</td>
                       <td class="py-3 text-muted">维护工单、累计成本</td>
                     </tr>
                     <tr>
                       <td class="py-3">报废</td>
-                      <td class="py-3 text-muted">报废登记原因(损坏/淘汰/出售),记录折旧/残值</td>
+                      <td class="py-3 text-muted">报废登记原因（损坏/淘汰/出售），记录折旧/残值</td>
                       <td class="py-3 text-muted">报废记录、残值、处置方式</td>
                     </tr>
                   </tbody>
@@ -170,7 +170,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">资产采购</h5>
-              <p class="text-muted mt-2">采购单关联供应商与价格;入库自动生成资产卡片,资产编号、序列号、保修期一次录入。</p>
+              <p class="text-muted mt-2">采购单关联供应商与价格；入库自动生成资产卡片，资产编号、序列号、保修期一次录入。</p>
             </div>
           </div>
         </div>
@@ -180,7 +180,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">分配 / 归还</h5>
-              <p class="text-muted mt-2">资产借给员工/客户,签字留痕;归还登记自动释放;每件资产的"使用历史"完整追溯。</p>
+              <p class="text-muted mt-2">资产借给员工/客户，签字留痕；归还登记自动释放；每件资产的"使用历史"完整追溯。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">维护工单</h5>
-              <p class="text-muted mt-2">资产故障/保养发起维护工单,关联资产卡片;维护记录累计成本,辅助报废决策。</p>
+              <p class="text-muted mt-2">资产故障/保养发起维护工单，关联资产卡片；维护记录累计成本，辅助报废决策。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">报废 / 出售</h5>
-              <p class="text-muted mt-2">资产报废登记原因(损坏/淘汰/出售);折旧/残值记录留档,与财务对账一致。</p>
+              <p class="text-muted mt-2">资产报废登记原因（损坏/淘汰/出售）；折旧/残值记录留档，与财务对账一致。</p>
             </div>
           </div>
         </div>
@@ -210,7 +210,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">供应商台账</h5>
-              <p class="text-muted mt-2">供应商档案 + 历史采购记录;采购金额、品类、付款条件一目了然,辅助招采决策。</p>
+              <p class="text-muted mt-2">供应商档案 + 历史采购记录；采购金额、品类、付款条件一目了然，辅助招采决策。</p>
             </div>
           </div>
         </div>
@@ -220,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">资产看板</h5>
-              <p class="text-muted mt-2">资产总数、在用、维护中、报废分布;按类型、按部门、按使用人聚合,盘点数据一键导出。</p>
+              <p class="text-muted mt-2">资产总数、在用、维护中、报废分布；按类型、按部门、按使用人聚合，盘点数据一键导出。</p>
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="text-muted mb-2">功能完善中</h5>
-              <p class="text-muted small mt-2 mb-0">更多能力规划中:资产盘点、折旧自动计算、二维码扫码、借用申请审批</p>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中：资产盘点、折旧自动计算、二维码扫码、借用申请审批</p>
             </div>
           </div>
         </div>
@@ -246,7 +246,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -257,7 +257,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -272,7 +272,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -292,7 +292,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、项目管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、销售管理、工单系统、项目管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/crm-v2.astro
+++ b/src/pages/cn/solutions/crm-v2.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="CRM 客户管理系统 — 开源、可自部署 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源 CRM 系统:线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用,支持自部署。"
+  description="基于 NocoBase 无代码平台的开源 CRM 系统：线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用，支持自部署。"
   keywords="CRM 系统, 开源 CRM, 客户管理系统, 客户关系管理, 线索管理, 客户跟进, 客户 360, 无代码 CRM, 自部署 CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">CRM<br/>客户管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程,客户 360 视图聚合订单、工单、项目、资产历史记录。
+              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程，客户 360 视图聚合订单、工单、项目、资产历史记录。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">B2B 销售</span>
                   <span class="badge bg-soft-primary me-2">项目型销售</span>
                   <span class="badge bg-soft-primary me-2">外贸</span>
@@ -65,7 +65,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">客户管理流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图,数据全链路打通</p>
+            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图，数据全链路打通</p>
           </div>
         </div>
       </div>
@@ -118,22 +118,22 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">线索</td>
-                      <td class="py-3 text-muted">表单/导入/手动录入,标记来源与归属销售</td>
+                      <td class="py-3 text-muted">表单/导入/手动录入，标记来源与归属销售</td>
                       <td class="py-3 text-muted">线索池、来源标签、阶段流转</td>
                     </tr>
                     <tr>
                       <td class="py-3">联系跟进</td>
-                      <td class="py-3 text-muted">电话、邮件、拜访登记,设置下次跟进时间</td>
+                      <td class="py-3 text-muted">电话、邮件、拜访登记，设置下次跟进时间</td>
                       <td class="py-3 text-muted">跟进时间轴、下次提醒</td>
                     </tr>
                     <tr>
                       <td class="py-3">转化客户</td>
-                      <td class="py-3 text-muted">线索转客户,填充客户档案(行业/规模/联系人)</td>
+                      <td class="py-3 text-muted">线索转客户，填充客户档案（行业/规模/联系人）</td>
                       <td class="py-3 text-muted">客户表、联系人表、关联线索</td>
                     </tr>
                     <tr>
                       <td class="py-3">客户 360</td>
-                      <td class="py-3 text-muted">查看客户全貌:订单、工单、项目、资产</td>
+                      <td class="py-3 text-muted">查看客户全貌：订单、工单、项目、资产</td>
                       <td class="py-3 text-muted">嵌入式区块、跨模块关联</td>
                     </tr>
                     <tr>
@@ -159,7 +159,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">核心功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板,完整覆盖客户关系管理日常</p>
+            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板，完整覆盖客户关系管理日常</p>
           </div>
         </div>
       </div>
@@ -170,7 +170,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">线索导入</h5>
-              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式;字段映射可视化配置,导入冲突自动去重。</p>
+              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式；字段映射可视化配置，导入冲突自动去重。</p>
             </div>
           </div>
         </div>
@@ -180,7 +180,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">阶段流转</h5>
-              <p class="text-muted mt-2">线索阶段(新建/已联系/已转化/已放弃)可视化配置;阶段变更自动留痕,转化率统计自动跑。</p>
+              <p class="text-muted mt-2">线索阶段（新建/已联系/已转化/已放弃）可视化配置；阶段变更自动留痕，转化率统计自动跑。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">跟进记录</h5>
-              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录;时间轴查看完整沟通历史,接手交接零摩擦。</p>
+              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录；时间轴查看完整沟通历史，接手交接零摩擦。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">跟进提醒</h5>
-              <p class="text-muted mt-2">下次跟进时间到期前自动通知;长期未联系的客户列入"待激活"看板,避免遗忘。</p>
+              <p class="text-muted mt-2">下次跟进时间到期前自动通知；长期未联系的客户列入"待激活"看板，避免遗忘。</p>
             </div>
           </div>
         </div>
@@ -210,7 +210,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">客户 360 视图</h5>
-              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录;一屏看清客户全貌,不用切多个系统。</p>
+              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录；一屏看清客户全貌，不用切多个系统。</p>
             </div>
           </div>
         </div>
@@ -220,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">分类与标签</h5>
-              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签;支持按标签筛选、聚合分析。</p>
+              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签；支持按标签筛选、聚合分析。</p>
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">合并去重</h5>
-              <p class="text-muted mt-2">同一客户多次录入自动识别;一键合并,历史跟进与关联记录无损归并。</p>
+              <p class="text-muted mt-2">同一客户多次录入自动识别；一键合并，历史跟进与关联记录无损归并。</p>
             </div>
           </div>
         </div>
@@ -250,7 +250,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">字段与行级权限</h5>
-              <p class="text-muted mt-2">基于角色配置可见字段;销售员只看自己负责客户,管理者看全部。</p>
+              <p class="text-muted mt-2">基于角色配置可见字段；销售员只看自己负责客户，管理者看全部。</p>
             </div>
           </div>
         </div>
@@ -266,7 +266,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -277,7 +277,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -292,7 +292,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -312,7 +312,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/crm-v2.astro
+++ b/src/pages/cn/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
 import BaseCN from "../../../layouts/BaseCN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
 <BaseCN
-  title="CRM 2.0 销售管理系统 - NocoBase"
-  description="基于 NocoBase 无代码平台的 CRM 2.0 销售管理系统，模块可拆解，完整销售闭环。支持线索评分、商机赢率预测等 AI 辅助功能。"
-  keywords="NocoBase CRM, AI CRM, 销售管理, 商机管理, 客户关系管理, 线索管理, 无代码 CRM"
+  title="CRM 客户管理系统 — 开源、可自部署 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源 CRM 系统:线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用,支持自部署。"
+  keywords="CRM 系统, 开源 CRM, 客户管理系统, 客户关系管理, 线索管理, 客户跟进, 客户 360, 无代码 CRM, 自部署 CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>销售管理系统</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM 模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>客户管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建，模块可拆解，完整销售闭环。工作流自动化处理日常任务，AI 辅助线索评分、商机分析等工作。
+              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程,客户 360 视图聚合订单、工单、项目、资产历史记录。
             </p>
 
-            <!-- 核心价值 -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">线索智能评分</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">商机赢率预测</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">客户健康监控</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">模块可拆解</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">线索阶段管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">客户 360 视图</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">合并 / 去重</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
             </div>
 
-            <!-- 适用场景标签 -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景：</span>
+                  <span class="text-muted me-2">适用场景:</span>
                   <span class="badge bg-soft-primary me-2">B2B 销售</span>
                   <span class="badge bg-soft-primary me-2">项目型销售</span>
-                  <span class="badge bg-soft-primary me-2">外贸销售</span>
-                  <span class="badge bg-soft-primary">全行业</span>
+                  <span class="badge bg-soft-primary me-2">外贸</span>
+                  <span class="badge bg-soft-primary">中小团队</span>
                 </div>
               </div>
             </div>
 
-            <!-- 按钮 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>如何使用
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 系统界面"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">您是否面临这些问题？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">销售团队在日常运营中面临多重挑战</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 客户管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">线索质量参差不齐</h5>
-              </div>
-              <p class="text-muted mb-0">市场获取的大量线索质量不一，销售浪费大量时间在低质量线索上，高价值线索却被忽略。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">商机跟进不及时</h5>
-              </div>
-              <p class="text-muted mb-0">商机长时间未推进，销售经理难以掌握团队商机健康度，错失最佳成交时机。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">客户信息分散</h5>
-              </div>
-              <p class="text-muted mb-0">客户数据散落在邮件、聊天、文档中，无法形成完整画像，难以进行精准营销。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">销售预测不准确</h5>
-              </div>
-              <p class="text-muted mb-0">凭经验预测业绩，缺乏数据支撑，预测偏差大，影响公司资源配置和决策。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">SaaS 成本高昂</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce、HubSpot 等 SaaS CRM 按人头收费，定制开发周期长、成本难以预估。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">数据安全顾虑</h5>
-              </div>
-              <p class="text-muted mb-0">客户信息、商机数据存储在第三方云端，不符合数据本地化和隐私保护的合规要求。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">我们的解决方案</h4>
-            <p class="para-desc mx-auto text-muted mb-0">基于 NocoBase 无代码平台构建的 CRM 2.0 系统，工作流自动化 + AI 辅助</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 核心模块 -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">线索智能评分</h5>
-              <p class="text-muted mt-2">自动评估线索质量，优先分配高价值线索，推荐最佳联系时间</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">商机赢率预测</h5>
-              <p class="text-muted mt-2">基于历史数据预测成交概率，识别风险商机，提供阶段推进建议</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">客户健康监控</h5>
-              <p class="text-muted mt-2">360 度客户画像，健康度评分，流失风险预警，主动维护关系</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">模块可拆解</h5>
-              <p class="text-muted mt-2">各模块独立设计，最小配置仅需客户+商机，按需裁剪成不同规模方案</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">核心设计</span>
-            <h4 class="title mb-4">完整销售闭环流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从线索获取到客户成功，全链路数据贯通，AI 辅助每个环节</p>
+            <h4 class="title mb-4">客户管理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图,数据全链路打通</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- 流程图 -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">线索</div>
-                  <div class="small text-muted">AI 评分</div>
+                  <div class="small text-muted">多渠道接入</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">客户</div>
-                  <div class="small text-muted">360 画像</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">联系跟进</div>
+                  <div class="small text-muted">记录留痕</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">商机</div>
-                  <div class="small text-muted">赢率预测</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">转化客户</div>
+                  <div class="small text-muted">建立档案</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">报价</div>
-                  <div class="small text-muted">多币种</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">客户 360</div>
+                  <div class="small text-muted">全貌聚合</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">订单</div>
-                  <div class="small opacity-75">回款跟踪</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">数据沉淀</div>
+                  <div class="small opacity-75">销售看板</div>
                 </div>
               </div>
 
-              <!-- 阶段说明 -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">阶段转化</th>
-                      <th class="border-0 py-3">触发条件</th>
-                      <th class="border-0 py-3">AI 辅助</th>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">线索 → 客户</td>
-                      <td class="py-3 text-muted">确认为有效商机</td>
-                      <td class="py-3 text-primary">AI 评分达标自动提醒转化</td>
+                      <td class="py-3">线索</td>
+                      <td class="py-3 text-muted">表单/导入/手动录入,标记来源与归属销售</td>
+                      <td class="py-3 text-muted">线索池、来源标签、阶段流转</td>
                     </tr>
                     <tr>
-                      <td class="py-3">客户 → 商机</td>
-                      <td class="py-3 text-muted">识别到明确需求</td>
-                      <td class="py-3 text-primary">AI 分析客户意向，推荐创建商机</td>
+                      <td class="py-3">联系跟进</td>
+                      <td class="py-3 text-muted">电话、邮件、拜访登记,设置下次跟进时间</td>
+                      <td class="py-3 text-muted">跟进时间轴、下次提醒</td>
                     </tr>
                     <tr>
-                      <td class="py-3">商机 → 报价</td>
-                      <td class="py-3 text-muted">进入方案报价阶段</td>
-                      <td class="py-3 text-primary">AI 智能定价、竞品对比、阶梯报价建议</td>
+                      <td class="py-3">转化客户</td>
+                      <td class="py-3 text-muted">线索转客户,填充客户档案(行业/规模/联系人)</td>
+                      <td class="py-3 text-muted">客户表、联系人表、关联线索</td>
                     </tr>
                     <tr>
-                      <td class="py-3">报价 → 订单</td>
-                      <td class="py-3 text-muted">客户接受报价</td>
-                      <td class="py-3 text-primary">自动生成订单，带入产品明细和价格</td>
+                      <td class="py-3">客户 360</td>
+                      <td class="py-3 text-muted">查看客户全貌:订单、工单、项目、资产</td>
+                      <td class="py-3 text-muted">嵌入式区块、跨模块关联</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">数据沉淀</td>
+                      <td class="py-3 text-muted">销售看板按销售员/地区/类型聚合 KPI</td>
+                      <td class="py-3 text-muted">图表、明细钻取、导出</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI 辅助</span>
-            <h4 class="title mb-4">AI 辅助能力</h4>
-            <p class="para-desc mx-auto text-muted mb-0">通过工作流 AI 节点，辅助完成评分、分析、写作等重复性工作</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板,完整覆盖客户关系管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">工作流节点</span></h5>
-              <span class="badge bg-soft-primary mb-2">销售侦察</span>
-              <p class="text-muted mt-2 small">商机深度分析、赢率预测、竞争情报分析、交易策略建议</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">线索导入</h5>
+              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式;字段映射可视化配置,导入冲突自动去重。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">洞察分析师</span>
-              <p class="text-muted mt-2 small">线索智能评分、客户健康评估、销售数据分析、管道预测</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">阶段流转</h5>
+              <p class="text-muted mt-2">线索阶段(新建/已联系/已转化/已放弃)可视化配置;阶段变更自动留痕,转化率统计自动跑。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">编辑助手</span>
-              <p class="text-muted mt-2 small">邮件情感/意图分析、回复草拟、沟通记录摘要</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟进记录</h5>
+              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录;时间轴查看完整沟通历史,接手交接零摩擦。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">日程规划</span>
-              <p class="text-muted mt-2 small">每日优先事项、下一步行动建议、跟进计划制定</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟进提醒</h5>
+              <p class="text-muted mt-2">下次跟进时间到期前自动通知;长期未联系的客户列入"待激活"看板,避免遗忘。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻译官</span>
-              <p class="text-muted mt-2 small">多语言客户沟通、内容翻译、外贸邮件处理</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客户 360 视图</h5>
+              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录;一屏看清客户全貌,不用切多个系统。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- 更多员工 -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">更多 AI 员工</h5>
-              <span class="badge bg-soft-secondary mb-2">持续扩展</span>
-              <p class="text-muted mt-2 small">根据业务需求，可扩展更多专业 AI 员工</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分类与标签</h5>
+              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签;支持按标签筛选、聚合分析。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">灵活架构</span>
-            <h4 class="title mb-4">模块可拆解设计</h4>
-            <p class="para-desc mx-auto text-muted mb-0">各模块独立设计，可单独开关，企业可按需裁剪成不同规模的方案</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">模块</th>
-                  <th class="border-0 py-3">必需</th>
-                  <th class="border-0 py-3">说明</th>
-                  <th class="border-0 py-3">AI 能力</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">客户管理</td>
-                  <td class="py-3"><span class="badge bg-success">必需</span></td>
-                  <td class="py-3 text-muted">客户档案、联系人、客户层级、决策链</td>
-                  <td class="py-3 text-primary">健康评分、流失预警</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">商机管理</td>
-                  <td class="py-3"><span class="badge bg-success">必需</span></td>
-                  <td class="py-3 text-muted">销售漏斗、阶段推进、活动记录</td>
-                  <td class="py-3 text-primary">赢率预测、风险识别</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">线索管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可选</span></td>
-                  <td class="py-3 text-muted">线索录入、状态流转、转化跟踪</td>
-                  <td class="py-3 text-primary">智能评分、最佳联系时间</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">报价管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可选</span></td>
-                  <td class="py-3 text-muted">多币种、阶梯定价、版本管理、审批流程</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">订单管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可选</span></td>
-                  <td class="py-3 text-muted">订单生成、回款跟踪</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">产品管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可选</span></td>
-                  <td class="py-3 text-muted">产品目录、分类、阶梯价格</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">邮件集成</td>
-                  <td class="py-3"><span class="badge bg-secondary">可选</span></td>
-                  <td class="py-3 text-muted">邮件收发、CRM 关联</td>
-                  <td class="py-3 text-primary">摘要生成、情感分析</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- 方案裁剪示例 -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">完整版</span>
-                  <p class="small text-muted mb-0">全部 7 个模块<br/>流程完整的 B2B 销售团队</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">标准版</span>
-                  <p class="small text-muted mb-0">客户+商机+报价+订单<br/>中小企业销售管理</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">轻量版</span>
-                  <p class="small text-muted mb-0">客户+商机<br/>简单的客户和商机跟踪</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">外贸版</span>
-                  <p class="small text-muted mb-0">客户+商机+报价+邮件<br/>外贸型企业</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">合并去重</h5>
+              <p class="text-muted mt-2">同一客户多次录入自动识别;一键合并,历史跟进与关联记录无损归并。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">销售看板</h5>
+              <p class="text-muted mt-2">按销售员、地区、客户类型聚合 KPI;新增客户数、转化率、活跃客户分布。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">字段与行级权限</h5>
+              <p class="text-muted mt-2">基于角色配置可见字段;销售员只看自己负责客户,管理者看全部。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">自动化带来的价值</h4>
-            <p class="para-desc mx-auto text-muted mb-0">工作流自动化 + AI 辅助，减少重复工作，让销售专注于客户关系</p>
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">线索筛选效率提升</h5>
-              <p class="text-muted small mb-0">AI 自动评分减少人工筛选时间</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">商机跟进效率提升</h5>
-              <p class="text-muted small mb-0">赢率预测帮助聚焦高价值商机</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">客户流失率降低</h5>
-              <p class="text-muted small mb-0">健康评估提前识别流失风险</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">销售转化率提升</h5>
-              <p class="text-muted small mb-0">AI 策略建议加速成交</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">为什么选择我们？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">与传统 SaaS CRM 和自研系统的对比</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">对比维度</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">自研系统</th>
-                  <th class="border-0 py-3 text-primary">NocoBase 方案</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">上线速度</td>
-                  <td class="py-3 text-muted">开箱即用</td>
-                  <td class="py-3 text-muted">数月开发</td>
-                  <td class="py-3 text-primary">配置即用，快速上线</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">定制能力</td>
-                  <td class="py-3 text-muted">受限</td>
-                  <td class="py-3 text-muted">完全可控</td>
-                  <td class="py-3 text-primary">无代码灵活定制</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">数据安全</td>
-                  <td class="py-3 text-muted">云端托管</td>
-                  <td class="py-3 text-muted">私有部署</td>
-                  <td class="py-3 text-primary">私有部署，数据完全掌控</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI 辅助</td>
-                  <td class="py-3 text-muted">有限/加价</td>
-                  <td class="py-3 text-muted">需自行开发</td>
-                  <td class="py-3 text-primary">工作流 AI 节点，按需使用</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">模块灵活性</td>
-                  <td class="py-3 text-muted">功能捆绑</td>
-                  <td class="py-3 text-muted">需代码修改</td>
-                  <td class="py-3 text-primary">模块可拆解，按需裁剪</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">总体成本</td>
-                  <td class="py-3 text-muted">按人头订阅</td>
-                  <td class="py-3 text-muted">开发成本高</td>
-                  <td class="py-3 text-primary">一次购买，长期使用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三个步骤快速部署 CRM 2.0 系统到你的环境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安装 NocoBase</h5>
-                <p class="text-muted mt-2">按照我们的安装文档，部署 NocoBase 到你的服务器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装文档</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>了解方案</h5>
-                <p class="text-muted mt-2">阅读方案介绍文档，了解系统功能、架构设计和使用场景</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/crm/" target="_blank" class="btn btn-outline-primary">方案介绍</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>还原到系统</h5>
-                <p class="text-muted mt-2">按照还原教程，将 CRM 2.0 系统部署到你的 NocoBase 环境</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/crm/installation" target="_blank" class="btn btn-outline-primary">还原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">开始使用 CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            基于 NocoBase 2.x 构建的模块化 CRM 系统。如果您有定制需求或想了解更多细节，欢迎联系我们。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/cn/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>联系我们
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseCN>
 
 <style>
-/* CRM 2.0 页面样式 */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI 员工头像样式 */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/cn/solutions/crm.astro
+++ b/src/pages/cn/solutions/crm.astro
@@ -1,55 +1,13 @@
 ---
 import BaseCN from "../../../layouts/BaseCN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// 导入交互演示数据
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-cn.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-cn.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-cn.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-cn.json";
-
-// 获取插件数据
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定义CRM中使用的插件名称映射
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// 根据插件名称匹配插件数据
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 获取CRM相关插件
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 调试信息
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseCN
-  title="无代码、灵活且强大的 CRM 基座"
-  description="开箱即用。提供极致的定制能力，且完全保障数据主权。你可以在此基础上任意扩展字段、区块、功能及页面，使其完全符合你的业务需求。"
-  keywords="NocoBase CRM, 客户关系管理, 无代码CRM, 开源CRM, 自定义CRM"
+  title="CRM 客户管理系统 — 开源、可自部署 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源 CRM 系统:线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用,支持自部署。"
+  keywords="CRM 系统, 开源 CRM, 客户管理系统, 客户关系管理, 线索管理, 客户跟进, 客户 360, 无代码 CRM, 自部署 CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -57,949 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">无代码、灵活且强大的<br/>CRM 基座</h1>
-
-            <p class="para-desc text-muted">开箱即用。提供极致的定制能力，且完全保障数据主权。你可以在此基础上任意扩展字段、区块、功能及页面，使其完全符合你的业务需求。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基于 NocoBase 1.x 搭建（2.0 准备中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM 模块</span>
             </div>
-            
-            <!-- 标签 -->
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>客户管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程,客户 360 视图聚合订单、工单、项目、资产历史记录。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">线索阶段管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">客户 360 视图</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">合并 / 去重</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
+            </div>
+
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">适用行业：</span>
-                  <span class="badge bg-soft-primary">全行业</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">B2B 销售</span>
+                  <span class="badge bg-soft-primary me-2">项目型销售</span>
+                  <span class="badge bg-soft-primary me-2">外贸</span>
+                  <span class="badge bg-soft-primary">中小团队</span>
                 </div>
               </div>
             </div>
 
-            <!-- 开发者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">开发者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- 按钮 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>复制到自己的环境
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM 预览视频 -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-cn-compress.mp4" type="video/mp4">
-                你的浏览器不支持 HTML5 视频。
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 客户管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase CRM 的独特之处</h4>
-            <p class="para-desc mx-auto text-muted mb-0">与 SaaS 和其他 CRM 系统不同，NocoBase CRM 灵活且完全掌控</p>
+            <h4 class="title mb-4">客户管理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图,数据全链路打通</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完全无代码构建</h5>
-              <p class="text-muted mt-2">无需编程技能，也能对 CRM 进行个性化改造</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">涵盖市面上 CRM 常用功能</h5>
-              <p class="text-muted mt-2">客户管理、销售管道、商机跟进、联系人管理、邮件沟通、 审批流程等功能模块</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">可以任意修改且极易扩展</h5>
-              <p class="text-muted mt-2">支持自定义字段、流程和业务逻辑，灵活的架构设计让"二次开发"变得简单</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">开源，数据完全掌控</h5>
-              <p class="text-muted mt-2">对系统代码和系统数据完全掌控，确保企业数据安全</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">试试 NocoBase CRM 的功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">几次点击，快速体验</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">仪表板数据展示</h5>
-              <!-- 交互演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- 背景图片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按钮 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>互动演示
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">线索</div>
+                  <div class="small text-muted">多渠道接入</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">联系跟进</div>
+                  <div class="small text-muted">记录留痕</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">转化客户</div>
+                  <div class="small text-muted">建立档案</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">客户 360</div>
+                  <div class="small text-muted">全貌聚合</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">数据沉淀</div>
+                  <div class="small opacity-75">销售看板</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">线索转化流程</h5>
-              <!-- 线索转化演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- 背景图片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按钮 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>互动演示
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">商机转化为订单</h5>
-              <!-- 商机转化演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- 背景图片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按钮 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>互动演示
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Try CRM Extension Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- 使用扩展功能交互演示 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即体验
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>复制到自己的环境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try CRM Extension End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM 开发与扩展教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">学习如何使用 NocoBase 构建和扩展专业的 CRM 系统</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">基础搭建与自定义</h5>
-                <p class="text-muted text-center">学习创建数据模型、自定义字段关系、配置权限和界面布局</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">数据分析与可视化</h5>
-                <p class="text-muted text-center">构建销售数据分析仪表板，实现业绩监控和数据可视化</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">流程自动化</h5>
-                <p class="text-muted text-center">设置工作流实现销售流程、审批流程和业务规则自动化</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">系统集成与扩展</h5>
-                <p class="text-muted text-center">集成第三方系统、移动端适配和其他高级扩展功能</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM 中所用到的商业插件</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 核心开源，商业插件丰富功能</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 动态生成插件卡片 -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">详情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用, 1 年升级</span><br>
-                          <a href="/cn/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用和升级</span><br>
-                          <a class="text-muted" href="/cn/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- 占位卡片，保持布局整齐 -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">更多插件即将推出</h6>
-                  <p class="text-muted small">我们正在开发更多有用的商业插件，敬请期待</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">线索</td>
+                      <td class="py-3 text-muted">表单/导入/手动录入,标记来源与归属销售</td>
+                      <td class="py-3 text-muted">线索池、来源标签、阶段流转</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">联系跟进</td>
+                      <td class="py-3 text-muted">电话、邮件、拜访登记,设置下次跟进时间</td>
+                      <td class="py-3 text-muted">跟进时间轴、下次提醒</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">转化客户</td>
+                      <td class="py-3 text-muted">线索转客户,填充客户档案(行业/规模/联系人)</td>
+                      <td class="py-3 text-muted">客户表、联系人表、关联线索</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">客户 360</td>
+                      <td class="py-3 text-muted">查看客户全貌:订单、工单、项目、资产</td>
+                      <td class="py-3 text-muted">嵌入式区块、跨模块关联</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">数据沉淀</td>
+                      <td class="py-3 text-muted">销售看板按销售员/地区/类型聚合 KPI</td>
+                      <td class="py-3 text-muted">图表、明细钻取、导出</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/cn/plugins-commercial" class="btn btn-primary me-3">查看全部商业插件</a>
-          <a href="/cn/commercial" class="btn btn-outline-primary">了解定价详情</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三个步骤快速部署 NocoBase CRM 到你的环境</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板,完整覆盖客户关系管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安装 NocoBase</h5>
-                <p class="text-muted mt-2">按照我们的安装文档，部署 NocoBase 到你的服务器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装文档</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">线索导入</h5>
+              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式;字段映射可视化配置,导入冲突自动去重。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>下载 CRM 模板文件</h5>
-                <p class="text-muted mt-2">获取 NocoBase CRM 系统的完整模板文件，支持两种格式</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下载 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下载备份文件 (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">阶段流转</h5>
+              <p class="text-muted mt-2">线索阶段(新建/已联系/已转化/已放弃)可视化配置;阶段变更自动留痕,转化率统计自动跑。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系统内还原</h5>
-                <p class="text-muted mt-2">将模板文件导入到你的 NocoBase 系统中完成部署</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/cn/solution/crm/v1" class="btn btn-outline-primary">还原教程</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟进记录</h5>
+              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录;时间轴查看完整沟通历史,接手交接零摩擦。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟进提醒</h5>
+              <p class="text-muted mt-2">下次跟进时间到期前自动通知;长期未联系的客户列入"待激活"看板,避免遗忘。</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客户 360 视图</h5>
+              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录;一屏看清客户全貌,不用切多个系统。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分类与标签</h5>
+              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签;支持按标签筛选、聚合分析。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">合并去重</h5>
+              <p class="text-muted mt-2">同一客户多次录入自动识别;一键合并,历史跟进与关联记录无损归并。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">销售看板</h5>
+              <p class="text-muted mt-2">按销售员、地区、客户类型聚合 KPI;新增客户数、转化率、活跃客户分布。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">字段与行级权限</h5>
+              <p class="text-muted mt-2">基于角色配置可见字段;销售员只看自己负责客户,管理者看全部。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">准备好使用 NocoBase CRM 了吗？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分钟时间部署一个专属 CRM demo。从配置数据结构，到界面布局，再到流程逻辑，这一切都是通过 NocoBase 的可视化配置完成，无需写一行代码。
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>复制到自己的环境
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseCN>
 
 <style>
-/* CRM Demo Styles - 参考首页样式 */
-#crm-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-#crm-steps-wrap {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.demo_step {
-  position: absolute;
-  display: none;
-}
-
-.demo_step.demo_step_start {
-  display: block;
-}
-
-.demo_step img {
-  width: 100%;
-  border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-}
-
-.button {
-  position: absolute;
-  cursor: pointer;
-  z-index: 2;
-}
-
-.demo_tooltip {
-  position: relative;
-}
-
-/* 步骤导航样式 */
-.steps-title {
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.steps-title:hover {
-  transform: translateY(-2px);
-}
-
-.steps-title.active {
-  background-color: #f8f9fa;
-  border-radius: 8px;
-}
-
-/* 工作流程箭头 */
-.process-arrow:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: -45px;
-  width: 0;
-  height: 0;
-  border-left: 20px solid #e9ecef;
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.d-none-arrow:before {
-  display: none;
-}
-
-@media (max-width: 768px) {
-  .process-arrow:before {
-    display: none;
-  }
-}
-
-/* 商业插件卡片样式 */
-.plugin-card {
-  transition: all 0.3s ease;
-}
-
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
-}
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-/* 开发者logo样式 */
-.developer-logo {
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-}
-
-.developer-logo:hover {
-  opacity: 0.8;
-}
-
-/* 交互演示卡片样式 */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
-}
-
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* 弹窗样式 */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close {
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow: hidden;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* 弹窗内交互演示的基础样式 */
-.demo-content-wrapper {
-  margin-top: 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-/* 弹窗内图片自适应 - 由JavaScript控制 */
-.demo-modal img {
-  max-width: 100%;
-  height: auto;
-}
-
-/* 响应式弹窗 */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
-}
-
-@media (max-height: 600px) {
-  .demo-modal-header {
-    padding: 0.5rem 1rem;
-  }
-  
-  .demo-modal-body {
-    padding: 0.5rem;
-  }
-}
-
-
 </style>
-
-<script is:inline>
-// 弹窗控制函数 - 定义在全局作用域
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待弹窗显示后初始化交互演示
-    setTimeout(function() {
-      // 为弹窗内的演示创建独立实例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// 线索转化演示弹窗控制函数
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待弹窗显示后初始化交互演示
-    setTimeout(function() {
-      // 为弹窗内的演示创建独立实例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// 商机转化演示弹窗控制函数
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待弹窗显示后初始化交互演示
-    setTimeout(function() {
-      // 为弹窗内的演示创建独立实例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // 只在初始状态点击大播放按钮时触发播放
-  playButton.addEventListener('click', function() {
-    // 添加控制栏
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // 开始播放并隐藏播放按钮
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // 视频结束时显示播放按钮，移除控制栏
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC键关闭弹窗
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/cn/solutions/crm.astro
+++ b/src/pages/cn/solutions/crm.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="CRM 客户管理系统 — 开源、可自部署 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源 CRM 系统:线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用,支持自部署。"
+  description="基于 NocoBase 无代码平台的开源 CRM 系统：线索管理、客户跟进、转化、合并去重、客户 360 视图。开箱即用，支持自部署。"
   keywords="CRM 系统, 开源 CRM, 客户管理系统, 客户关系管理, 线索管理, 客户跟进, 客户 360, 无代码 CRM, 自部署 CRM, NocoBase"
   canonical="/cn/solutions/crm-v2"
 >
@@ -22,7 +22,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">CRM<br/>客户管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程,客户 360 视图聚合订单、工单、项目、资产历史记录。
+              基于 NocoBase 无代码平台构建。覆盖线索、跟进、转化、合并去重的完整流程，客户 360 视图聚合订单、工单、项目、资产历史记录。
             </p>
 
             <div class="row mt-4 g-3">
@@ -35,7 +35,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">B2B 销售</span>
                   <span class="badge bg-soft-primary me-2">项目型销售</span>
                   <span class="badge bg-soft-primary me-2">外贸</span>
@@ -66,7 +66,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">客户管理流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图,数据全链路打通</p>
+            <p class="para-desc mx-auto text-muted mb-0">从线索接入到客户 360 视图，数据全链路打通</p>
           </div>
         </div>
       </div>
@@ -119,22 +119,22 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">线索</td>
-                      <td class="py-3 text-muted">表单/导入/手动录入,标记来源与归属销售</td>
+                      <td class="py-3 text-muted">表单/导入/手动录入，标记来源与归属销售</td>
                       <td class="py-3 text-muted">线索池、来源标签、阶段流转</td>
                     </tr>
                     <tr>
                       <td class="py-3">联系跟进</td>
-                      <td class="py-3 text-muted">电话、邮件、拜访登记,设置下次跟进时间</td>
+                      <td class="py-3 text-muted">电话、邮件、拜访登记，设置下次跟进时间</td>
                       <td class="py-3 text-muted">跟进时间轴、下次提醒</td>
                     </tr>
                     <tr>
                       <td class="py-3">转化客户</td>
-                      <td class="py-3 text-muted">线索转客户,填充客户档案(行业/规模/联系人)</td>
+                      <td class="py-3 text-muted">线索转客户，填充客户档案（行业/规模/联系人）</td>
                       <td class="py-3 text-muted">客户表、联系人表、关联线索</td>
                     </tr>
                     <tr>
                       <td class="py-3">客户 360</td>
-                      <td class="py-3 text-muted">查看客户全貌:订单、工单、项目、资产</td>
+                      <td class="py-3 text-muted">查看客户全貌：订单、工单、项目、资产</td>
                       <td class="py-3 text-muted">嵌入式区块、跨模块关联</td>
                     </tr>
                     <tr>
@@ -160,7 +160,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">核心功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板,完整覆盖客户关系管理日常</p>
+            <p class="para-desc mx-auto text-muted mb-0">线索、客户、跟进、看板，完整覆盖客户关系管理日常</p>
           </div>
         </div>
       </div>
@@ -171,7 +171,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">线索导入</h5>
-              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式;字段映射可视化配置,导入冲突自动去重。</p>
+              <p class="text-muted mt-2">Excel 批量导入、表单收集、API 接入三种方式；字段映射可视化配置，导入冲突自动去重。</p>
             </div>
           </div>
         </div>
@@ -181,7 +181,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">阶段流转</h5>
-              <p class="text-muted mt-2">线索阶段(新建/已联系/已转化/已放弃)可视化配置;阶段变更自动留痕,转化率统计自动跑。</p>
+              <p class="text-muted mt-2">线索阶段（新建/已联系/已转化/已放弃）可视化配置；阶段变更自动留痕，转化率统计自动跑。</p>
             </div>
           </div>
         </div>
@@ -191,7 +191,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">跟进记录</h5>
-              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录;时间轴查看完整沟通历史,接手交接零摩擦。</p>
+              <p class="text-muted mt-2">每次拜访、电话、邮件留下记录；时间轴查看完整沟通历史，接手交接零摩擦。</p>
             </div>
           </div>
         </div>
@@ -201,7 +201,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">跟进提醒</h5>
-              <p class="text-muted mt-2">下次跟进时间到期前自动通知;长期未联系的客户列入"待激活"看板,避免遗忘。</p>
+              <p class="text-muted mt-2">下次跟进时间到期前自动通知；长期未联系的客户列入"待激活"看板，避免遗忘。</p>
             </div>
           </div>
         </div>
@@ -211,7 +211,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">客户 360 视图</h5>
-              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录;一屏看清客户全貌,不用切多个系统。</p>
+              <p class="text-muted mt-2">客户详情聚合订单、工单、项目、资产记录；一屏看清客户全貌，不用切多个系统。</p>
             </div>
           </div>
         </div>
@@ -221,7 +221,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">分类与标签</h5>
-              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签;支持按标签筛选、聚合分析。</p>
+              <p class="text-muted mt-2">客户类型、行业、规模、来源多维度标签；支持按标签筛选、聚合分析。</p>
             </div>
           </div>
         </div>
@@ -231,7 +231,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">合并去重</h5>
-              <p class="text-muted mt-2">同一客户多次录入自动识别;一键合并,历史跟进与关联记录无损归并。</p>
+              <p class="text-muted mt-2">同一客户多次录入自动识别；一键合并，历史跟进与关联记录无损归并。</p>
             </div>
           </div>
         </div>
@@ -251,7 +251,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">字段与行级权限</h5>
-              <p class="text-muted mt-2">基于角色配置可见字段;销售员只看自己负责客户,管理者看全部。</p>
+              <p class="text-muted mt-2">基于角色配置可见字段；销售员只看自己负责客户，管理者看全部。</p>
             </div>
           </div>
         </div>
@@ -267,7 +267,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -278,7 +278,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -293,7 +293,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -313,7 +313,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与销售管理、工单系统、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/hr-management.astro
+++ b/src/pages/cn/solutions/hr-management.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="HR 人事管理系统 — 开源人力资源管理 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源 HR 人事管理系统:员工台账、入职、离职、请假、试用期跟踪、岗位与部门组织结构。轻量、可自部署,适合中小企业 HR 团队。"
+  description="基于 NocoBase 无代码平台的开源 HR 人事管理系统：员工台账、入职、离职、请假、试用期跟踪、岗位与部门组织结构。轻量、可自部署，适合中小企业 HR 团队。"
   keywords="HR 人事管理系统, 人力资源管理系统, 开源 HR 系统, 员工管理系统, 入职管理, 离职管理, 请假审批, 试用期管理, 组织架构管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">HR 人事管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。员工台账,<strong>入职、离职、请假、试用期</strong> 全流程跟踪,配合岗位与部门组织结构。
+              基于 NocoBase 无代码平台构建。员工台账，<strong>入职、离职、请假、试用期</strong> 全流程跟踪，配合岗位与部门组织结构。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">中小企业</span>
                   <span class="badge bg-soft-primary me-2">连锁门店</span>
                   <span class="badge bg-soft-primary me-2">行业 HR</span>
@@ -118,12 +118,12 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">招聘</td>
-                      <td class="py-3 text-muted">候选人录入、面试评估;通过后转为员工档案</td>
+                      <td class="py-3 text-muted">候选人录入、面试评估；通过后转为员工档案</td>
                       <td class="py-3 text-muted">候选人表、面试评分</td>
                     </tr>
                     <tr>
                       <td class="py-3">入职</td>
-                      <td class="py-3 text-muted">入职任务清单(签合同、办工牌、领设备、开账号)</td>
+                      <td class="py-3 text-muted">入职任务清单（签合同、办工牌、领设备、开账号）</td>
                       <td class="py-3 text-muted">入职清单、合同档案</td>
                     </tr>
                     <tr>
@@ -138,7 +138,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                     </tr>
                     <tr>
                       <td class="py-3">离职</td>
-                      <td class="py-3 text-muted">离职清单:交接、归还资产、停账号、办手续</td>
+                      <td class="py-3 text-muted">离职清单：交接、归还资产、停账号、办手续</td>
                       <td class="py-3 text-muted">离职记录、资产释放</td>
                     </tr>
                   </tbody>
@@ -170,7 +170,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">员工台账</h5>
-              <p class="text-muted mt-2">员工基本信息、工号、入职日期、岗位、部门 — 统一档案,按多维度检索。</p>
+              <p class="text-muted mt-2">员工基本信息、工号、入职日期、岗位、部门 — 统一档案，按多维度检索。</p>
             </div>
           </div>
         </div>
@@ -180,7 +180,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">员工生命周期</h5>
-              <p class="text-muted mt-2">待入职 → 试用 → 在职 → 离职中 → 已离职,5 个状态贯穿员工档案;按状态过滤一目了然。</p>
+              <p class="text-muted mt-2">待入职 → 试用 → 在职 → 离职中 → 已离职，5 个状态贯穿员工档案；按状态过滤一目了然。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">部门组织结构</h5>
-              <p class="text-muted mt-2">树形组织架构:部门→子部门,基于 NocoBase 内置 departments 插件,与权限联动。</p>
+              <p class="text-muted mt-2">树形组织架构：部门→子部门，基于 NocoBase 内置 departments 插件，与权限联动。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">岗位档案</h5>
-              <p class="text-muted mt-2">岗位定义与职级(初级/中级/高级/专家);员工挂岗位,便于晋升路径与权限管理。</p>
+              <p class="text-muted mt-2">岗位定义与职级（初级/中级/高级/专家）；员工挂岗位，便于晋升路径与权限管理。</p>
             </div>
           </div>
         </div>
@@ -210,7 +210,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">请假审批</h5>
-              <p class="text-muted mt-2">8 种假期类型(年假/病假/事假/调休/婚假/产假/丧假/其他);按部门/直属上级配审批流。</p>
+              <p class="text-muted mt-2">8 种假期类型（年假/病假/事假/调休/婚假/产假/丧假/其他）；按部门/直属上级配审批流。</p>
             </div>
           </div>
         </div>
@@ -220,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">字段级权限</h5>
-              <p class="text-muted mt-2">HR 看薪资字段,主管看团队成员基础信息;基于 NocoBase 角色权限灵活配置。</p>
+              <p class="text-muted mt-2">HR 看薪资字段，主管看团队成员基础信息；基于 NocoBase 角色权限灵活配置。</p>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="text-muted mb-2">功能完善中</h5>
-              <p class="text-muted small mt-2 mb-0">更多能力规划中:入职/离职清单、试用期评估、合同/社保管理、招聘候选人、调岗/晋升记录</p>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中：入职/离职清单、试用期评估、合同/社保管理、招聘候选人、调岗/晋升记录</p>
             </div>
           </div>
         </div>
@@ -245,7 +245,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -256,7 +256,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -271,7 +271,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -291,7 +291,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、项目管理、固定资产管理 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、销售管理、工单系统、项目管理、固定资产管理 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/hr-management.astro
+++ b/src/pages/cn/solutions/hr-management.astro
@@ -1,0 +1,348 @@
+---
+import BaseCN from "../../../layouts/BaseCN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseCN
+  title="HR 人事管理系统 — 开源人力资源管理 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源 HR 人事管理系统:员工台账、入职、离职、请假、试用期跟踪、岗位与部门组织结构。轻量、可自部署,适合中小企业 HR 团队。"
+  keywords="HR 人事管理系统, 人力资源管理系统, 开源 HR 系统, 员工管理系统, 入职管理, 离职管理, 请假审批, 试用期管理, 组织架构管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">HR 人事模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR 人事管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。员工台账,<strong>入职、离职、请假、试用期</strong> 全流程跟踪,配合岗位与部门组织结构。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">入职 / 离职清单</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">请假审批</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">试用期看板</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">中小企业</span>
+                  <span class="badge bg-soft-primary me-2">连锁门店</span>
+                  <span class="badge bg-soft-primary me-2">行业 HR</span>
+                  <span class="badge bg-soft-primary">跨部门协作</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="HR 人事管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">员工全周期</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从招聘到离职的完整人力资源管理闭环</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">招聘</div>
+                  <div class="small text-muted">候选人</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">入职</div>
+                  <div class="small text-muted">清单跟踪</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">在职管理</div>
+                  <div class="small text-muted">考勤请假</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">评估</div>
+                  <div class="small text-muted">转正/调岗</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">离职</div>
+                  <div class="small opacity-75">交接归档</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">招聘</td>
+                      <td class="py-3 text-muted">候选人录入、面试评估;通过后转为员工档案</td>
+                      <td class="py-3 text-muted">候选人表、面试评分</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入职</td>
+                      <td class="py-3 text-muted">入职任务清单(签合同、办工牌、领设备、开账号)</td>
+                      <td class="py-3 text-muted">入职清单、合同档案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">在职管理</td>
+                      <td class="py-3 text-muted">日常考勤、请假、调休、加班审批</td>
+                      <td class="py-3 text-muted">请假记录、假期余额</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">评估</td>
+                      <td class="py-3 text-muted">试用期评估、转正、调岗、晋升</td>
+                      <td class="py-3 text-muted">评估表、岗位变更</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">离职</td>
+                      <td class="py-3 text-muted">离职清单:交接、归还资产、停账号、办手续</td>
+                      <td class="py-3 text-muted">离职记录、资产释放</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从入职到离职的完整人力资源管理</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">员工台账</h5>
+              <p class="text-muted mt-2">员工基本信息、工号、入职日期、岗位、部门 — 统一档案,按多维度检索。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">员工生命周期</h5>
+              <p class="text-muted mt-2">待入职 → 试用 → 在职 → 离职中 → 已离职,5 个状态贯穿员工档案;按状态过滤一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">部门组织结构</h5>
+              <p class="text-muted mt-2">树形组织架构:部门→子部门,基于 NocoBase 内置 departments 插件,与权限联动。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">岗位档案</h5>
+              <p class="text-muted mt-2">岗位定义与职级(初级/中级/高级/专家);员工挂岗位,便于晋升路径与权限管理。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">请假审批</h5>
+              <p class="text-muted mt-2">8 种假期类型(年假/病假/事假/调休/婚假/产假/丧假/其他);按部门/直属上级配审批流。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">字段级权限</h5>
+              <p class="text-muted mt-2">HR 看薪资字段,主管看团队成员基础信息;基于 NocoBase 角色权限灵活配置。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中:入职/离职清单、试用期评估、合同/社保管理、招聘候选人、调岗/晋升记录</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、项目管理、固定资产管理 协同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseCN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/cn/solutions/project-management.astro
+++ b/src/pages/cn/solutions/project-management.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="项目管理系统 — 开源轻量项目协作 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源项目管理系统:项目+任务两级管理、负责人、进度、里程碑、延期预警、工作量分布。轻量、可自部署,适合中小团队与跨部门项目协作。"
+  description="基于 NocoBase 无代码平台的开源项目管理系统：项目+任务两级管理、负责人、进度、里程碑、延期预警、工作量分布。轻量、可自部署，适合中小团队与跨部门项目协作。"
   keywords="项目管理系统, 项目管理软件, 任务管理系统, 开源项目管理, 轻量项目管理, 任务管理, 项目协作, 项目跟踪, 里程碑管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">项目管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。<strong>项目 + 任务</strong> 两级管理,涵盖负责人、进度、里程碑、延期预警与工作量分布,轻量、可自部署。
+              基于 NocoBase 无代码平台构建。<strong>项目 + 任务</strong> 两级管理，涵盖负责人、进度、里程碑、延期预警与工作量分布，轻量、可自部署。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">交付项目</span>
                   <span class="badge bg-soft-primary me-2">内部 IT</span>
                   <span class="badge bg-soft-primary me-2">跨部门协作</span>
@@ -65,7 +65,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">项目流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从立项到结项的完整跟踪闭环,里程碑与延期预警自动跑</p>
+            <p class="para-desc mx-auto text-muted mb-0">从立项到结项的完整跟踪闭环，里程碑与延期预警自动跑</p>
           </div>
         </div>
       </div>
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">里程碑</div>
                   <div class="small text-muted">阶段交付</div>
                 </div>
@@ -118,27 +118,27 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">立项</td>
-                      <td class="py-3 text-muted">创建项目,关联客户(交付项目)或资产(IT 项目),指定项目经理</td>
+                      <td class="py-3 text-muted">创建项目，关联客户（交付项目）或资产（IT 项目），指定项目经理</td>
                       <td class="py-3 text-muted">项目档案、客户关联、负责人</td>
                     </tr>
                     <tr>
                       <td class="py-3">任务拆分</td>
-                      <td class="py-3 text-muted">拆解任务,设负责人、起止时间、依赖关系</td>
+                      <td class="py-3 text-muted">拆解任务，设负责人、起止时间、依赖关系</td>
                       <td class="py-3 text-muted">任务表、负责人、依赖图</td>
                     </tr>
                     <tr>
                       <td class="py-3">进度跟踪</td>
-                      <td class="py-3 text-muted">成员更新任务进度;超期任务自动标红</td>
+                      <td class="py-3 text-muted">成员更新任务进度；超期任务自动标红</td>
                       <td class="py-3 text-muted">进度百分比、延期标记</td>
                     </tr>
                     <tr>
                       <td class="py-3">里程碑</td>
-                      <td class="py-3 text-muted">关键节点定义为里程碑(评审/内测/上线);阶段交付物登记</td>
+                      <td class="py-3 text-muted">关键节点定义为里程碑（评审/内测/上线）；阶段交付物登记</td>
                       <td class="py-3 text-muted">里程碑列表、交付物附件</td>
                     </tr>
                     <tr>
                       <td class="py-3">结项</td>
-                      <td class="py-3 text-muted">项目完成结项归档,记录工时与成本</td>
+                      <td class="py-3 text-muted">项目完成结项归档，记录工时与成本</td>
                       <td class="py-3 text-muted">结项报告、工时汇总</td>
                     </tr>
                   </tbody>
@@ -170,17 +170,17 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">项目+任务两级</h5>
-              <p class="text-muted mt-2">一个项目下拆分多个任务,任务负责人、起止时间、进度独立维护;项目看板纵览所有任务状态。</p>
+              <p class="text-muted mt-2">一个项目下拆分多个任务，任务负责人、起止时间、进度独立维护；项目看板纵览所有任务状态。</p>
             </div>
           </div>
         </div>
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">里程碑管理</h5>
-              <p class="text-muted mt-2">关键节点定义为里程碑(原型评审、内测、上线);项目进度按里程碑节奏呈现。</p>
+              <p class="text-muted mt-2">关键节点定义为里程碑（原型评审、内测、上线）；项目进度按里程碑节奏呈现。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">延期预警</h5>
-              <p class="text-muted mt-2">任务超过预定截止日自动标红,延期项目列表实时刷新,管理者一眼看到风险点。</p>
+              <p class="text-muted mt-2">任务超过预定截止日自动标红，延期项目列表实时刷新，管理者一眼看到风险点。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">负责人与工作量</h5>
-              <p class="text-muted mt-2">按负责人聚合任务数与工作量;谁手上活多、谁闲、谁延期次数高,管理者一目了然。</p>
+              <p class="text-muted mt-2">按负责人聚合任务数与工作量；谁手上活多、谁闲、谁延期次数高，管理者一目了然。</p>
             </div>
           </div>
         </div>
@@ -220,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">关联客户与订单</h5>
-              <p class="text-muted mt-2">项目可关联客户与销售订单;客户详情页可看到关联项目历史与交付情况。</p>
+              <p class="text-muted mt-2">项目可关联客户与销售订单；客户详情页可看到关联项目历史与交付情况。</p>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="text-muted mb-2">功能完善中</h5>
-              <p class="text-muted small mt-2 mb-0">更多能力规划中:任务依赖图、工时记录与成本、交付物归档、甘特图视图</p>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中：任务依赖图、工时记录与成本、交付物归档、甘特图视图</p>
             </div>
           </div>
         </div>
@@ -245,7 +245,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -256,7 +256,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -271,7 +271,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -291,7 +291,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、销售管理、工单系统、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/project-management.astro
+++ b/src/pages/cn/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
 import BaseCN from "../../../layouts/BaseCN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-cn.json";
-
-// 获取插件数据
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定义项目管理中使用的插件
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// 根据插件名称匹配插件数据
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 获取项目管理相关插件
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 调试信息
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseCN
-  title="全面的研发项目管理解决方案"
-  description="NocoBase 研发项目管理系统提供完整的研发项目生命周期管理能力。从需求规划、任务分配、进度跟踪到质量管理，实现研发全流程数字化管理和团队协作。"
-  keywords="NocoBase 研发项目管理, 任务管理, 团队协作, 敏捷开发, 质量管理"
+  title="项目管理系统 — 开源轻量项目协作 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源项目管理系统:项目+任务两级管理、负责人、进度、里程碑、延期预警、工作量分布。轻量、可自部署,适合中小团队与跨部门项目协作。"
+  keywords="项目管理系统, 项目管理软件, 任务管理系统, 开源项目管理, 轻量项目管理, 任务管理, 项目协作, 项目跟踪, 里程碑管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,457 +14,335 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">全面的<br/>研发项目管理解决方案</h1>
-            <p class="para-desc text-muted">基于 NocoBase 构建的强大、灵活的研发项目管理平台。支持敏捷、瀑布和混合等多种开发方法。在一个平台上管理需求、任务、团队、迭代和质量。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基于 NocoBase 1.x 搭建（2.0 准备中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">项目管理模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">项目管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。<strong>项目 + 任务</strong> 两级管理,涵盖负责人、进度、里程碑、延期预警与工作量分布,轻量、可自部署。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">项目+任务两级</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">延期预警</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">里程碑跟踪</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
             </div>
 
-            <!-- 标签 -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">适用行业：</span>
-                  <span class="badge bg-soft-primary">研发</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">交付项目</span>
+                  <span class="badge bg-soft-primary me-2">内部 IT</span>
+                  <span class="badge bg-soft-primary me-2">跨部门协作</span>
+                  <span class="badge bg-soft-primary">中小团队</span>
                 </div>
               </div>
             </div>
 
-            <!-- 开发者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">开发者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="项目管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">项目流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从立项到结项的完整跟踪闭环,里程碑与延期预警自动跑</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">立项</div>
+                  <div class="small text-muted">关联客户</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">任务拆分</div>
+                  <div class="small text-muted">负责人</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">进度跟踪</div>
+                  <div class="small text-muted">延期预警</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">里程碑</div>
+                  <div class="small text-muted">阶段交付</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">结项</div>
+                  <div class="small opacity-75">复盘归档</div>
                 </div>
               </div>
-            </div>
 
-            <!-- 按钮 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>在线演示
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>部署到您的环境
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- 项目管理预览 -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase 研发项目管理系统预览" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase 项目管理的独特之处</h4>
-            <p class="para-desc mx-auto text-muted mb-0">适应您的项目管理方法论的综合解决方案</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完整研发生命周期</h5>
-              <p class="text-muted mt-2">从需求分析、设计开发到测试、上线、维护，管理研发的每个阶段</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">敏捷开发管理</h5>
-              <p class="text-muted mt-2">支持 Scrum 冲刺、看板、燃尽图，实现迭代开发和持续交付</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">团队协作与质量管理</h5>
-              <p class="text-muted mt-2">高效管理开发团队、跟踪代码质量、处理缺陷和问题，确保产品质量</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">极易修改与扩展</h5>
-              <p class="text-muted mt-2">基于NocoBase的无代码特性，轻松自定义字段、流程和业务逻辑，对系统完全掌控</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- 使用扩展功能交互演示 -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即体验
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>复制到自己的环境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">项目管理开发教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">学习如何使用 NocoBase 从零开始构建专业的研发项目管理系统</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">数据模型设计</h5>
-                <p class="text-muted text-center">学习如何创建项目、任务、团队的基础数据结构及其关系</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">立项</td>
+                      <td class="py-3 text-muted">创建项目,关联客户(交付项目)或资产(IT 项目),指定项目经理</td>
+                      <td class="py-3 text-muted">项目档案、客户关联、负责人</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">任务拆分</td>
+                      <td class="py-3 text-muted">拆解任务,设负责人、起止时间、依赖关系</td>
+                      <td class="py-3 text-muted">任务表、负责人、依赖图</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">进度跟踪</td>
+                      <td class="py-3 text-muted">成员更新任务进度;超期任务自动标红</td>
+                      <td class="py-3 text-muted">进度百分比、延期标记</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">里程碑</td>
+                      <td class="py-3 text-muted">关键节点定义为里程碑(评审/内测/上线);阶段交付物登记</td>
+                      <td class="py-3 text-muted">里程碑列表、交付物附件</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">结项</td>
+                      <td class="py-3 text-muted">项目完成结项归档,记录工时与成本</td>
+                      <td class="py-3 text-muted">结项报告、工时汇总</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">工作流配置</h5>
-                <p class="text-muted text-center">设置任务分配、状态流转和自动化项目工作流</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">冲刺与跟踪</h5>
-                <p class="text-muted text-center">配置冲刺、燃尽图和进度跟踪功能</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">通过商业插件增强功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">使用强大的商业插件扩展您的项目管理能力</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">立项到结项的完整轻量项目跟踪</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- 动态生成的插件卡片 -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">由 <span>{plugin.developer || 'NocoBase'}</span> 提供</div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">详情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">终身使用，一年升级</span><br>
-                          <a href="/cn/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">终身使用和升级</span><br>
-                          <a class="text-muted" href="/cn/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">项目+任务两级</h5>
+              <p class="text-muted mt-2">一个项目下拆分多个任务,任务负责人、起止时间、进度独立维护;项目看板纵览所有任务状态。</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/cn/plugins-commercial" class="btn btn-primary me-3">查看所有商业插件</a>
-          <a href="/cn/commercial" class="btn btn-outline-primary">了解定价</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">里程碑管理</h5>
+              <p class="text-muted mt-2">关键节点定义为里程碑(原型评审、内测、上线);项目进度按里程碑节奏呈现。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">延期预警</h5>
+              <p class="text-muted mt-2">任务超过预定截止日自动标红,延期项目列表实时刷新,管理者一眼看到风险点。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">负责人与工作量</h5>
+              <p class="text-muted mt-2">按负责人聚合任务数与工作量;谁手上活多、谁闲、谁延期次数高,管理者一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">项目状态看板</h5>
+              <p class="text-muted mt-2">按项目类型、状态、负责人聚合 KPI;进行中、已结项、延期项目分类呈现。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">关联客户与订单</h5>
+              <p class="text-muted mt-2">项目可关联客户与销售订单;客户详情页可看到关联项目历史与交付情况。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中:任务依赖图、工时记录与成本、交付物归档、甘特图视图</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三个步骤快速将带有项目管理功能的 NocoBase CRM 系统部署到您的环境</p>
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>安装 NocoBase 系统</h5>
-                <p class="text-muted mt-2">按照我们的安装文档将 NocoBase 系统部署到您的服务器</p>
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装指南</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>下载 CRM 系统模板</h5>
-                <p class="text-muted mt-2">下载完整的 CRM 模板以获得项目管理功能</p>
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下载 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下载备份文件 (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系统中恢复</h5>
-                <p class="text-muted mt-2">将 CRM 模板文件导入到您的 NocoBase 系统中，获得 CRM 和项目管理功能</p>
-              </div>
-              <div class="mt-3">
-                <a href="/cn/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">恢复教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 项目管理功能说明 -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">提示</h6>
-                <p class="mb-0 text-muted">研发项目管理系统作为综合模块完全集成到 CRM 模板中。部署后，您可以直接在 CRM 系统中使用完整的研发项目管理功能，实现需求、开发、测试的全流程管理。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">准备好使用 NocoBase 研发项目管理系统了吗？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分钟时间部署一个专属研发管理 demo。从需求规划到任务分配，再到进度跟踪和质量管控，这一切都是通过 NocoBase 的可视化配置完成，无需写一行代码。
-          </p>
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、工单系统、固定资产管理、HR 协同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>复制到自己的环境
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseCN>
 
 <style>
-/* 项目管理系统样式 - 参考 ticketing 页面样式 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* 插件卡片样式 */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/cn/solutions/sales-management.astro
+++ b/src/pages/cn/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseCN from "../../../layouts/BaseCN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseCN
+  title="销售管理系统 — 开源销售订单与应收管理 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源销售管理系统:报价单、销售订单、发票、收款的完整链路,内置审批流、多币种、应收账款 KPI 与逾期分析。"
+  keywords="销售管理系统, 销售订单管理, 报价单, 发票管理, 应收账款管理, 收款管理, 销售流程, 销售审批, 开源销售管理, 多币种报价, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">销售管理模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">销售管理系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。<strong>报价 → 订单 → 发票 → 收款</strong> 的完整链路,内置销售审批工作流、多币种报价、应收账款 KPI 与逾期分析。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">多币种报价</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">订单审批流</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">应收 KPI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">B2B 销售</span>
+                  <span class="badge bg-soft-primary me-2">外贸订单</span>
+                  <span class="badge bg-soft-primary me-2">设备销售</span>
+                  <span class="badge bg-soft-primary">应收管理</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="销售管理系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">销售流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从报价到收款的完整闭环,审批与应收 KPI 全链路打通</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">报价</div>
+                  <div class="small text-muted">多币种</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">订单</div>
+                  <div class="small text-muted">审批流</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">发货</div>
+                  <div class="small text-muted">物流跟踪</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">发票</div>
+                  <div class="small text-muted">客户预填</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">收款</div>
+                  <div class="small opacity-75">应收 KPI</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">报价</td>
+                      <td class="py-3 text-muted">选客户/产品,生成多币种报价单,支持折扣、税率、有效期</td>
+                      <td class="py-3 text-muted">报价单、产品明细、PDF 导出</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">订单</td>
+                      <td class="py-3 text-muted">报价转订单;超额折扣、大额订单触发审批</td>
+                      <td class="py-3 text-muted">销售订单、审批流、订单明细</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">发货</td>
+                      <td class="py-3 text-muted">订单确认后登记发货单,关联物流单号</td>
+                      <td class="py-3 text-muted">发货单、物流单号、状态流转</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">发票</td>
+                      <td class="py-3 text-muted">订单或发货后开票,客户档案税号/地址自动预填</td>
+                      <td class="py-3 text-muted">发票记录、开票状态</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">收款</td>
+                      <td class="py-3 text-muted">分笔收款登记;按账龄聚合应收 KPI</td>
+                      <td class="py-3 text-muted">收款记录、应收余额、账龄分桶</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">报价、订单、发票、收款全链路 + 审批与应收分析</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">报价单管理</h5>
+              <p class="text-muted mt-2">多币种报价,支持折扣、税率、有效期;一键导出 PDF 发给客户;支持转化为销售订单。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">销售订单</h5>
+              <p class="text-muted mt-2">订单状态流转(草稿/审核中/已确认/已发货/已结案),客户与产品关联,订单明细可分行编辑。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">订单审批工作流</h5>
+              <p class="text-muted mt-2">超额折扣、大额订单、特殊条款触发审批;按部门、岗位、金额阈值灵活配置审批节点。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">发票管理</h5>
+              <p class="text-muted mt-2">订单生成发票,跟踪开票状态;客户档案税号、地址、备注自动预填,减少手输错误。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">收款记录</h5>
+              <p class="text-muted mt-2">分笔收款、部分到账;自动计算应收余额;按客户、按订单聚合付款状态。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">应收账款 KPI</h5>
+              <p class="text-muted mt-2">逾期账款列表、账龄分析(30/60/90 天分桶);按客户、按销售员聚合,催收一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">多币种与汇率</h5>
+              <p class="text-muted mt-2">USD/EUR/CNY 多币种报价与订单;汇率维护表支持手动或导入;本币汇总自动换算。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">发货与物流</h5>
+              <p class="text-muted mt-2">发货单关联订单与物流单号;支持多次发货、部分发货;状态自动同步到订单。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">销售看板</h5>
+              <p class="text-muted mt-2">按销售员、地区、产品聚合销售额、订单数、回款率;月度/季度趋势一目了然。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、工单系统、项目管理、固定资产管理、HR 协同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseCN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/cn/solutions/sales-management.astro
+++ b/src/pages/cn/solutions/sales-management.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="销售管理系统 — 开源销售订单与应收管理 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源销售管理系统:报价单、销售订单、发票、收款的完整链路,内置审批流、多币种、应收账款 KPI 与逾期分析。"
+  description="基于 NocoBase 无代码平台的开源销售管理系统：报价单、销售订单、发票、收款的完整链路，内置审批流、多币种、应收账款 KPI 与逾期分析。"
   keywords="销售管理系统, 销售订单管理, 报价单, 发票管理, 应收账款管理, 收款管理, 销售流程, 销售审批, 开源销售管理, 多币种报价, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">销售管理系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。<strong>报价 → 订单 → 发票 → 收款</strong> 的完整链路,内置销售审批工作流、多币种报价、应收账款 KPI 与逾期分析。
+              基于 NocoBase 无代码平台构建。<strong>报价 → 订单 → 发票 → 收款</strong> 的完整链路，内置销售审批工作流、多币种报价、应收账款 KPI 与逾期分析。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">B2B 销售</span>
                   <span class="badge bg-soft-primary me-2">外贸订单</span>
                   <span class="badge bg-soft-primary me-2">设备销售</span>
@@ -65,7 +65,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">销售流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从报价到收款的完整闭环,审批与应收 KPI 全链路打通</p>
+            <p class="para-desc mx-auto text-muted mb-0">从报价到收款的完整闭环，审批与应收 KPI 全链路打通</p>
           </div>
         </div>
       </div>
@@ -118,27 +118,27 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">报价</td>
-                      <td class="py-3 text-muted">选客户/产品,生成多币种报价单,支持折扣、税率、有效期</td>
+                      <td class="py-3 text-muted">选客户/产品，生成多币种报价单，支持折扣、税率、有效期</td>
                       <td class="py-3 text-muted">报价单、产品明细、PDF 导出</td>
                     </tr>
                     <tr>
                       <td class="py-3">订单</td>
-                      <td class="py-3 text-muted">报价转订单;超额折扣、大额订单触发审批</td>
+                      <td class="py-3 text-muted">报价转订单；超额折扣、大额订单触发审批</td>
                       <td class="py-3 text-muted">销售订单、审批流、订单明细</td>
                     </tr>
                     <tr>
                       <td class="py-3">发货</td>
-                      <td class="py-3 text-muted">订单确认后登记发货单,关联物流单号</td>
+                      <td class="py-3 text-muted">订单确认后登记发货单，关联物流单号</td>
                       <td class="py-3 text-muted">发货单、物流单号、状态流转</td>
                     </tr>
                     <tr>
                       <td class="py-3">发票</td>
-                      <td class="py-3 text-muted">订单或发货后开票,客户档案税号/地址自动预填</td>
+                      <td class="py-3 text-muted">订单或发货后开票，客户档案税号/地址自动预填</td>
                       <td class="py-3 text-muted">发票记录、开票状态</td>
                     </tr>
                     <tr>
                       <td class="py-3">收款</td>
-                      <td class="py-3 text-muted">分笔收款登记;按账龄聚合应收 KPI</td>
+                      <td class="py-3 text-muted">分笔收款登记；按账龄聚合应收 KPI</td>
                       <td class="py-3 text-muted">收款记录、应收余额、账龄分桶</td>
                     </tr>
                   </tbody>
@@ -170,7 +170,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">报价单管理</h5>
-              <p class="text-muted mt-2">多币种报价,支持折扣、税率、有效期;一键导出 PDF 发给客户;支持转化为销售订单。</p>
+              <p class="text-muted mt-2">多币种报价，支持折扣、税率、有效期；一键导出 PDF 发给客户；支持转化为销售订单。</p>
             </div>
           </div>
         </div>
@@ -180,7 +180,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">销售订单</h5>
-              <p class="text-muted mt-2">订单状态流转(草稿/审核中/已确认/已发货/已结案),客户与产品关联,订单明细可分行编辑。</p>
+              <p class="text-muted mt-2">订单状态流转（草稿/审核中/已确认/已发货/已结案），客户与产品关联，订单明细可分行编辑。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">订单审批工作流</h5>
-              <p class="text-muted mt-2">超额折扣、大额订单、特殊条款触发审批;按部门、岗位、金额阈值灵活配置审批节点。</p>
+              <p class="text-muted mt-2">超额折扣、大额订单、特殊条款触发审批；按部门、岗位、金额阈值灵活配置审批节点。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">发票管理</h5>
-              <p class="text-muted mt-2">订单生成发票,跟踪开票状态;客户档案税号、地址、备注自动预填,减少手输错误。</p>
+              <p class="text-muted mt-2">订单生成发票，跟踪开票状态；客户档案税号、地址、备注自动预填，减少手输错误。</p>
             </div>
           </div>
         </div>
@@ -210,37 +210,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">收款记录</h5>
-              <p class="text-muted mt-2">分笔收款、部分到账;自动计算应收余额;按客户、按订单聚合付款状态。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">应收账款 KPI</h5>
-              <p class="text-muted mt-2">逾期账款列表、账龄分析(30/60/90 天分桶);按客户、按销售员聚合,催收一目了然。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">多币种与汇率</h5>
-              <p class="text-muted mt-2">USD/EUR/CNY 多币种报价与订单;汇率维护表支持手动或导入;本币汇总自动换算。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">发货与物流</h5>
-              <p class="text-muted mt-2">发货单关联订单与物流单号;支持多次发货、部分发货;状态自动同步到订单。</p>
+              <p class="text-muted mt-2">分笔收款、部分到账；自动计算应收余额；按客户、按订单聚合付款状态。</p>
             </div>
           </div>
         </div>
@@ -250,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">销售看板</h5>
-              <p class="text-muted mt-2">按销售员、地区、产品聚合销售额、订单数、回款率;月度/季度趋势一目了然。</p>
+              <p class="text-muted mt-2">按销售员、地区、产品聚合销售额、订单数、回款率；月度/季度趋势一目了然。</p>
             </div>
           </div>
         </div>
@@ -266,7 +236,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -277,7 +247,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -292,7 +262,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -312,7 +282,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、工单系统、项目管理、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、工单系统、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/ticketing-v2.astro
+++ b/src/pages/cn/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
 import BaseCN from "../../../layouts/BaseCN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
 <BaseCN
-  title="AI 驱动的智能工单系统 - NocoBase"
-  description="基于 NocoBase 的 AI 驱动智能工单系统，T型数据架构支持多业务场景，AI 员工团队自动分类、智能回复、知识推荐，SLA 全程监控，实现工单全生命周期智能化管理。"
-  keywords="NocoBase 工单系统, AI 工单, 智能客服, SLA管理, 知识库, 工单分类"
+  title="工单系统 — 开源客服工单管理 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源工单系统:客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用,适合中小客服团队与售后服务团队。"
+  keywords="工单系统, 客服工单系统, 开源工单, help desk, ticketing 系统, 工单管理, SLA 管理, 售后系统, 客户服务系统, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,335 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI 驱动的<br/>智能工单系统</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">工单系统模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">工单系统</h1>
             <p class="para-desc text-muted">
-              让客服更专注于解决问题，而非繁琐的流程操作。基于 NocoBase 无代码平台，采用 T 型数据架构统一管理多种业务场景，AI 员工团队贯穿工单全生命周期，实现从创建到闭环的智能化管理。
+              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路,内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
             </p>
 
-            <!-- 核心价值 -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">多源统一接入</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI 智能分流</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">SLA 全程监控</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">知识自动沉淀</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自动计时</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 级优先级</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 智能分类</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
             </div>
 
-            <!-- 适用场景标签 -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景：</span>
-                  <span class="badge bg-soft-primary me-2">设备维修</span>
-                  <span class="badge bg-soft-primary me-2">IT 支持</span>
-                  <span class="badge bg-soft-primary me-2">客户投诉</span>
-                  <span class="badge bg-soft-primary">咨询建议</span>
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">客服售后</span>
+                  <span class="badge bg-soft-primary me-2">IT 服务台</span>
+                  <span class="badge bg-soft-primary me-2">设备维保</span>
+                  <span class="badge bg-soft-primary">SaaS 客服</span>
                 </div>
               </div>
             </div>
 
-            <!-- 按钮 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>如何使用
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha 版本已上线，欢迎体验，功能持续更新中
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="通用工单追踪系统界面"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="工单系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">您是否面临这些问题？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">企业在日常运营中面临多种服务请求，来源分散、流程各异、缺乏统一管理</p>
+            <h4 class="title mb-4">工单处理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环,SLA 全程计时</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">成本高、定制慢</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS 工单系统价格高昂，定制开发周期长、成本难以预估，业务需求变化时难以快速调整。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">系统割裂、数据孤岛</h5>
-              </div>
-              <p class="text-muted mb-0">设备维修、IT支持、客户投诉等请求分散在不同系统，难以统一分析和决策。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">响应慢、过程不透明</h5>
-              </div>
-              <p class="text-muted mb-0">请求在系统间流转效率低，客户无法追踪进度，频繁询问增加客服压力。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">质量难保障</h5>
-              </div>
-              <p class="text-muted mb-0">缺乏 SLA 监控机制，超时和差评无法及时预警，服务质量参差不齐。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">知识无法沉淀</h5>
-              </div>
-              <p class="text-muted mb-0">解决方案散落在各处，新人上手慢，同样的问题反复解决，效率低下。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">AI 能力缺失</h5>
-              </div>
-              <p class="text-muted mb-0">传统系统缺乏 AI 辅助，人工分类耗时费力，无法实现智能推荐和自动回复。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">我们的解决方案</h4>
-            <p class="para-desc mx-auto text-muted mb-0">基于 NocoBase 无代码平台构建的通用工单中台，实现统一入口、智能分发、多态业务、闭环反馈</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 核心模块 -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">多源统一接入</h5>
-              <p class="text-muted mt-2">公开表单、客户门户、邮件解析、API/Webhook，所有渠道统一管理，自动去重检查</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI 智能分流</h5>
-              <p class="text-muted mt-2">自动识别意图、分析情绪、评估紧急度，结合技能匹配和负载均衡智能分派</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">SLA 全程监控</h5>
-              <p class="text-muted mt-2">P0-P3 四级优先级，响应/解决时效自动追踪，超时预警和升级机制</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">闭环反馈</h5>
-              <p class="text-muted mt-2">多维度满意度评价、NPS 评分、差评预警和跟进，持续提升服务质量</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T型架构 Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">核心设计</span>
-            <h4 class="title mb-4">T 型数据架构</h4>
-            <p class="para-desc mx-auto text-muted mb-0">所有工单共享主表统一流转，业务特有字段下沉附表，新增业务类型只需添加附表</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T 型架构图 -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>工单主表 (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">工单号 | 标题 | 状态 | 优先级 | 处理人 | SLA | AI分析结果</div>
-                </div>
-              </div>
-
-              <!-- 连接线 -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- 业务附表 -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">设备维修</strong>
-                  <div class="small text-muted mt-2">设备序列号 | 故障码<br/>备件清单 | 现场照片</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT 支持</strong>
-                  <div class="small text-muted mt-2">资产编号 | OS版本<br/>远程地址 | 错误代码</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">客户投诉</strong>
-                  <div class="small text-muted mt-2">涉及订单 | 投诉等级<br/>赔偿方案 | 根本原因</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">更多业务...</strong>
-                  <div class="small text-muted mt-2">按需扩展<br/>主流程不变</div>
-                </div>
-              </div>
-
-              <!-- 优势说明 -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">统一报表</h6>
-                  <p class="text-muted small mb-0">一张主表统计所有工单</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">流程复用</h6>
-                  <p class="text-muted small mb-0">核心流程只改一处</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">灵活扩展</h6>
-                  <p class="text-muted small mb-0">新业务只需加附表</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T型架构 End -->
-
-  <!-- AI 员工 Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI 原生</span>
-            <h4 class="title mb-4">AI 员工团队</h4>
-            <p class="para-desc mx-auto text-muted mb-0">不是"加个 AI 按钮"，而是 AI 员工融入每个环节。每位 AI 有明确的角色、职责、性格</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">服务台主管</span>
-              <p class="text-muted mt-2 small">工单分流、优先级评估、升级决策、SLA风险识别</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">触发：工单创建时自动</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">客户成功专家</span>
-              <p class="text-muted mt-2 small">回复生成、语气调整、投诉处理、情商防火墙</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">触发：点击"AI回复"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">知识助手</span>
-              <p class="text-muted mt-2 small">相似案例、知识推荐、解决方案综合、知识生成</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">触发：工单详情页自动</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻译官</span>
-              <p class="text-muted mt-2 small">多语言翻译、质量审核、敏感信息拦截</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">触发：检测到外语自动</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 情商防火墙示例 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace 的情商防火墙</h5>
-              <p class="text-muted mb-3">自动检测并优化客服回复中的负面表达，避免二次投诉</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">原文</span>
-                    <p class="mb-0 small">"这不是我们的问题，你自己设置错了"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">优化后</span>
-                    <p class="mb-0 small">"经过排查，问题出在配置环节。我来帮您一起调整设置，确保正常使用"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI 员工 End -->
-
-  <!-- 知识循环 Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">知识管理</span>
-            <h4 class="title mb-4">知识自循环体系</h4>
-            <p class="para-desc mx-auto text-muted mb-0">工单解决后自动沉淀为知识，下次遇到相似问题时 AI 自动推荐，形成知识沉淀-知识应用的闭环</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- 循环流程图 -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">工单解决</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI 评估价值</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">生成知识文章</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">人工审核发布</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">知识库</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">相似工单</div>
+                  <div class="small fw-medium">创建</div>
+                  <div class="small text-muted">多渠道</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI 推荐知识</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">智能分类</div>
+                  <div class="small text-muted">AI 识别</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">快速解决</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">分派</div>
+                  <div class="small text-muted">按组规则</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">处理</div>
+                  <div class="small text-muted">SLA 计时</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">评价</div>
+                  <div class="small opacity-75">结案归档</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">创建</td>
+                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交;关联客户与产品</td>
+                      <td class="py-3 text-muted">工单单号、来源、客户档案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">智能分类</td>
+                      <td class="py-3 text-muted">AI 识别问题类别(账号/功能/Bug),自动设优先级</td>
+                      <td class="py-3 text-muted">分类标签、优先级、置信度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">分派</td>
+                      <td class="py-3 text-muted">按规则分给对应小组/客服员,紧急工单自动通知值班</td>
+                      <td class="py-3 text-muted">负责人、分派记录、组队列</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">处理</td>
+                      <td class="py-3 text-muted">客服处理、与客户沟通;SLA 计时,超期前自动告警</td>
+                      <td class="py-3 text-muted">处理日志、SLA 状态、等待原因</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">评价</td>
+                      <td class="py-3 text-muted">结案推送客户评价(1-5 星+文字),按客服/产品聚合</td>
+                      <td class="py-3 text-muted">满意度记录、归档工单、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- 知识转化条件 -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">描述完整</h6>
-                  <p class="text-muted small mb-0">描述 ≥ 200 字符</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">沟通充分</h6>
-                  <p class="text-muted small mb-0">评论 ≥ 2 条</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">质量达标</h6>
-                  <p class="text-muted small mb-0">AI 评分 ≥ 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 知识循环 End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA 服务级别管理</h4>
-            <p class="para-desc mx-auto text-muted mb-0">按优先级设置响应和解决时间，自动监控、预警、升级，挂起时 SLA 自动暂停</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从受理到结案的完整客服工单管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">优先级</th>
-                  <th class="border-0 py-3">响应时间</th>
-                  <th class="border-0 py-3">解决时间</th>
-                  <th class="border-0 py-3">典型场景</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 紧急</span></td>
-                  <td class="py-3">15 分钟</td>
-                  <td class="py-3">2 小时</td>
-                  <td class="py-3 text-muted small">系统宕机、生产线停止</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 高</span></td>
-                  <td class="py-3">1 小时</td>
-                  <td class="py-3">8 小时</td>
-                  <td class="py-3 text-muted small">重要功能故障、影响较大</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 中</span></td>
-                  <td class="py-3">4 小时</td>
-                  <td class="py-3">24 小时</td>
-                  <td class="py-3 text-muted small">一般问题、有替代方案</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 低</span></td>
-                  <td class="py-3">8 小时</td>
-                  <td class="py-3">72 小时</td>
-                  <td class="py-3 text-muted small">优化建议、功能咨询</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">提前预警</h6>
-                  <p class="text-muted small mb-0">剩余时间 &lt; 20% 时通知处理人</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">超时预警</h6>
-                  <p class="text-muted small mb-0">超时后通知处理人+主管</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">自动升级</h6>
-                  <p class="text-muted small mb-0">超时 1 小时通知部门经理</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 计时与告警</h5>
+              <p class="text-muted mt-2">按优先级自动计算响应/解决时限;超期前自动告警,超期工单置红色;SLA 达成率可看板呈现。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- 价值量化 Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 级优先级</h5>
+              <p class="text-muted mt-2">紧急、高、中、低四级,匹配不同响应时长;紧急工单自动置顶并通知值班人员。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 智能分类</h5>
+              <p class="text-muted mt-2">新工单 AI 自动识别问题类别(账号问题/功能咨询/Bug 报告等),按规则分派给对应小组。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">等待原因细分</h5>
+              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期,公平合理。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客服工作台</h5>
+              <p class="text-muted mt-2">客服登录直接看到分给自己的工单;按到期时间排序,一屏看待处理、处理中、即将超期。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工单仪表盘</h5>
+              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布;按客服员、客户、产品线聚合,管理者纵览全局。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中:满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">AI 带来的价值</h4>
-            <p class="para-desc mx-auto text-muted mb-0">人与 AI 协同，而非 AI 替代人。让 AI 处理重复工作，让人专注于创造价值</p>
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">分拣效率提升</h5>
-              <p class="text-muted small mb-0">AI 自动分类减少人工分拣时间</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">二次投诉减少</h5>
-              <p class="text-muted small mb-0">情商防火墙优化回复语气</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">超时率降低</h5>
-              <p class="text-muted small mb-0">SLA 预警提前干预</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">首解率提升</h5>
-              <p class="text-muted small mb-0">知识推荐加速问题解决</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 价值量化 End -->
-
-  <!-- 差异化优势 Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">为什么选择我们？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">与传统 SaaS 工单系统和自研系统的对比</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">对比维度</th>
-                  <th class="border-0 py-3">SaaS 工单</th>
-                  <th class="border-0 py-3">自研系统</th>
-                  <th class="border-0 py-3 text-primary">NocoBase 方案</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">上线速度</td>
-                  <td class="py-3 text-muted">开箱即用</td>
-                  <td class="py-3 text-muted">数月开发</td>
-                  <td class="py-3 text-primary">配置即用，快速上线</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">定制能力</td>
-                  <td class="py-3 text-muted">受限</td>
-                  <td class="py-3 text-muted">完全可控</td>
-                  <td class="py-3 text-primary">无代码灵活定制</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">数据安全</td>
-                  <td class="py-3 text-muted">云端托管</td>
-                  <td class="py-3 text-muted">私有部署</td>
-                  <td class="py-3 text-primary">私有部署，数据完全掌控</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI 集成</td>
-                  <td class="py-3 text-muted">有限/加价</td>
-                  <td class="py-3 text-muted">需自行开发</td>
-                  <td class="py-3 text-primary">AI 原生，深度集成</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">扩展性</td>
-                  <td class="py-3 text-muted">功能固定</td>
-                  <td class="py-3 text-muted">需代码修改</td>
-                  <td class="py-3 text-primary">T型架构，按需扩展</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">总体成本</td>
-                  <td class="py-3 text-muted">订阅费用高</td>
-                  <td class="py-3 text-muted">开发成本高</td>
-                  <td class="py-3 text-primary">一次购买，长期使用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 差异化优势 End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三个步骤快速部署智能工单系统到你的环境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安装 NocoBase</h5>
-                <p class="text-muted mt-2">按照我们的安装文档，部署 NocoBase 到你的服务器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装文档</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>了解方案</h5>
-                <p class="text-muted mt-2">阅读方案介绍文档，了解系统功能、架构设计和使用场景</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">方案介绍</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>还原到系统</h5>
-                <p class="text-muted mt-2">按照还原教程，将智能工单系统部署到你的 NocoBase 环境</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">还原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">让 AI 重新定义工单管理</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            基于 NocoBase 2.x 构建的 AI 驱动智能工单系统。如果您有定制需求或想了解更多细节，欢迎联系我们。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/cn/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>联系我们
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseCN>
 
 <style>
-/* 工单 2.0 页面样式 */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI 员工头像样式 */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/cn/solutions/ticketing-v2.astro
+++ b/src/pages/cn/solutions/ticketing-v2.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="工单系统 — 开源客服工单管理 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源工单系统:客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用,适合中小客服团队与售后服务团队。"
+  description="基于 NocoBase 无代码平台的开源工单系统：客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用，适合中小客服团队与售后服务团队。"
   keywords="工单系统, 客服工单系统, 开源工单, help desk, ticketing 系统, 工单管理, SLA 管理, 售后系统, 客户服务系统, NocoBase"
 >
   <!-- Hero/Banner Start -->
@@ -21,7 +21,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">工单系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路,内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
+              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路，内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
             </p>
 
             <div class="row mt-4 g-3">
@@ -34,7 +34,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">客服售后</span>
                   <span class="badge bg-soft-primary me-2">IT 服务台</span>
                   <span class="badge bg-soft-primary me-2">设备维保</span>
@@ -65,7 +65,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">工单处理流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环,SLA 全程计时</p>
+            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环，SLA 全程计时</p>
           </div>
         </div>
       </div>
@@ -118,27 +118,27 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">创建</td>
-                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交;关联客户与产品</td>
+                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交；关联客户与产品</td>
                       <td class="py-3 text-muted">工单单号、来源、客户档案</td>
                     </tr>
                     <tr>
                       <td class="py-3">智能分类</td>
-                      <td class="py-3 text-muted">AI 识别问题类别(账号/功能/Bug),自动设优先级</td>
+                      <td class="py-3 text-muted">AI 识别问题类别（账号/功能/Bug），自动设优先级</td>
                       <td class="py-3 text-muted">分类标签、优先级、置信度</td>
                     </tr>
                     <tr>
                       <td class="py-3">分派</td>
-                      <td class="py-3 text-muted">按规则分给对应小组/客服员,紧急工单自动通知值班</td>
+                      <td class="py-3 text-muted">按规则分给对应小组/客服员，紧急工单自动通知值班</td>
                       <td class="py-3 text-muted">负责人、分派记录、组队列</td>
                     </tr>
                     <tr>
                       <td class="py-3">处理</td>
-                      <td class="py-3 text-muted">客服处理、与客户沟通;SLA 计时,超期前自动告警</td>
+                      <td class="py-3 text-muted">客服处理、与客户沟通；SLA 计时，超期前自动告警</td>
                       <td class="py-3 text-muted">处理日志、SLA 状态、等待原因</td>
                     </tr>
                     <tr>
                       <td class="py-3">评价</td>
-                      <td class="py-3 text-muted">结案推送客户评价(1-5 星+文字),按客服/产品聚合</td>
+                      <td class="py-3 text-muted">结案推送客户评价（1-5 星+文字），按客服/产品聚合</td>
                       <td class="py-3 text-muted">满意度记录、归档工单、KPI</td>
                     </tr>
                   </tbody>
@@ -170,7 +170,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">SLA 计时与告警</h5>
-              <p class="text-muted mt-2">按优先级自动计算响应/解决时限;超期前自动告警,超期工单置红色;SLA 达成率可看板呈现。</p>
+              <p class="text-muted mt-2">按优先级自动计算响应/解决时限；超期前自动告警，超期工单置红色；SLA 达成率可看板呈现。</p>
             </div>
           </div>
         </div>
@@ -180,7 +180,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">4 级优先级</h5>
-              <p class="text-muted mt-2">紧急、高、中、低四级,匹配不同响应时长;紧急工单自动置顶并通知值班人员。</p>
+              <p class="text-muted mt-2">紧急、高、中、低四级，匹配不同响应时长；紧急工单自动置顶并通知值班人员。</p>
             </div>
           </div>
         </div>
@@ -190,7 +190,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">AI 智能分类</h5>
-              <p class="text-muted mt-2">新工单 AI 自动识别问题类别(账号问题/功能咨询/Bug 报告等),按规则分派给对应小组。</p>
+              <p class="text-muted mt-2">新工单 AI 自动识别问题类别（账号问题/功能咨询/Bug 报告等），按规则分派给对应小组。</p>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">等待原因细分</h5>
-              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期,公平合理。</p>
+              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期，公平合理。</p>
             </div>
           </div>
         </div>
@@ -210,7 +210,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">客服工作台</h5>
-              <p class="text-muted mt-2">客服登录直接看到分给自己的工单;按到期时间排序,一屏看待处理、处理中、即将超期。</p>
+              <p class="text-muted mt-2">客服登录直接看到分给自己的工单；按到期时间排序，一屏看待处理、处理中、即将超期。</p>
             </div>
           </div>
         </div>
@@ -220,7 +220,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">工单仪表盘</h5>
-              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布;按客服员、客户、产品线聚合,管理者纵览全局。</p>
+              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布；按客服员、客户、产品线聚合，管理者纵览全局。</p>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="text-muted mb-2">功能完善中</h5>
-              <p class="text-muted small mt-2 mb-0">更多能力规划中:满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中：满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
             </div>
           </div>
         </div>
@@ -245,7 +245,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -256,7 +256,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -271,7 +271,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -291,7 +291,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/cn/solutions/ticketing.astro
+++ b/src/pages/cn/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
 import BaseCN from "../../../layouts/BaseCN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// 导入交互演示数据
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-cn.json";
-
-// 获取插件数据
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定义工单系统中使用的插件名称映射
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// 根据插件名称匹配插件数据
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 获取工单系统相关插件
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 调试信息
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseCN
-  title="高效便捷的工单管理系统"
-  description="NocoBase 工单管理系统作为 CRM 的重要补充，提供完整的工单生命周期管理，从客户联系人创建到工单分配处理，全流程数字化管理。"
-  keywords="NocoBase 工单系统, 工单管理, 客服系统, 售后服务, 工单分配"
+  title="工单系统 — 开源客服工单管理 | NocoBase"
+  description="基于 NocoBase 无代码平台的开源工单系统:客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用,适合中小客服团队与售后服务团队。"
+  keywords="工单系统, 客服工单系统, 开源工单, help desk, ticketing 系统, 工单管理, SLA 管理, 售后系统, 客户服务系统, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,567 +15,335 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">高效便捷的<br/>工单管理系统</h1>
-            <p class="para-desc text-muted">NocoBase 工单管理系统作为 CRM 的重要补充，提供完整的工单生命周期管理。从客户联系人创建到工单录入、分配、处理和跟踪，实现售后服务的全流程数字化管理。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基于 NocoBase 1.x 搭建（2.0 准备中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/cn/solutions/all-in-one" class="text-muted small text-decoration-none">一体化业务管理系统</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">工单系统模块</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">工单系统</h1>
+            <p class="para-desc text-muted">
+              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路,内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自动计时</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 级优先级</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 智能分类</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">开源免费</span></div></div>
             </div>
 
-            <!-- 标签 -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">适用场景：</span>
-                  <span class="badge bg-soft-primary me-2">客户服务</span>
-                  <span class="badge bg-soft-primary">售后支持</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="badge bg-soft-primary me-2">客服售后</span>
+                  <span class="badge bg-soft-primary me-2">IT 服务台</span>
+                  <span class="badge bg-soft-primary me-2">设备维保</span>
+                  <span class="badge bg-soft-primary">SaaS 客服</span>
                 </div>
               </div>
             </div>
 
-            <!-- 开发者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">开发者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- 按钮 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>复制到自己的环境
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+              <a href="/cn/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- 工单系统预览图 -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase 工单管理系统预览" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="工单系统界面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase 工单管理系统功能特点</h4>
-            <p class="para-desc mx-auto text-muted mb-0">作为 CRM 系统的重要补充，提供专业的客户服务和售后支持管理</p>
+            <h4 class="title mb-4">工单处理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环,SLA 全程计时</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完整的工单生命周期</h5>
-              <p class="text-muted mt-2">从工单创建、分配、处理到关闭，全流程管理，确保每个工单都得到妥善处理</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">智能分配与跟踪</h5>
-              <p class="text-muted mt-2">根据工单类型和团队成员技能自动分配任务，实时跟踪处理进度和状态</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">多渠道沟通记录</h5>
-              <p class="text-muted mt-2">通过 API 同步邮件、电话、在线聊天等多种沟通渠道，统一管理客户交流记录</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">开源，数据完全掌控</h5>
-              <p class="text-muted mt-2">开源代码，数据私有部署，确保企业数据安全和自主控制</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- 使用扩展功能交互演示 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即体验
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>复制到自己的环境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">工单系统开发教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从零开始学习如何使用 NocoBase 构建专业的工单管理系统</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">数据模型设计</h5>
-                <p class="text-muted text-center">学习如何创建工单、客户、分类等基础数据结构和关系</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">工作流配置</h5>
-                <p class="text-muted text-center">设置工单分配、状态流转和自动化处理流程</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">通知与提醒</h5>
-                <p class="text-muted text-center">配置邮件和系统通知，确保工单及时处理</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即将推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">工单系统中所使用的商业插件介绍</h4>
-            <p class="para-desc mx-auto text-muted mb-0">了解如何通过商业插件获得更强大的功能，提升工单系统的专业性和易用性</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 动态生成插件卡片 -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">详情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用, 1 年升级</span><br>
-                          <a href="/cn/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用和升级</span><br>
-                          <a class="text-muted" href="/cn/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">创建</div>
+                  <div class="small text-muted">多渠道</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">智能分类</div>
+                  <div class="small text-muted">AI 识别</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">分派</div>
+                  <div class="small text-muted">按组规则</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">处理</div>
+                  <div class="small text-muted">SLA 计时</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">评价</div>
+                  <div class="small opacity-75">结案归档</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- 占位卡片，保持布局整齐 -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">更多插件即将推出</h6>
-                  <p class="text-muted small">我们正在开发更多有用的商业插件，敬请期待</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">阶段</th>
+                      <th class="border-0 py-3">关键动作</th>
+                      <th class="border-0 py-3">系统记录</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">创建</td>
+                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交;关联客户与产品</td>
+                      <td class="py-3 text-muted">工单单号、来源、客户档案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">智能分类</td>
+                      <td class="py-3 text-muted">AI 识别问题类别(账号/功能/Bug),自动设优先级</td>
+                      <td class="py-3 text-muted">分类标签、优先级、置信度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">分派</td>
+                      <td class="py-3 text-muted">按规则分给对应小组/客服员,紧急工单自动通知值班</td>
+                      <td class="py-3 text-muted">负责人、分派记录、组队列</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">处理</td>
+                      <td class="py-3 text-muted">客服处理、与客户沟通;SLA 计时,超期前自动告警</td>
+                      <td class="py-3 text-muted">处理日志、SLA 状态、等待原因</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">评价</td>
+                      <td class="py-3 text-muted">结案推送客户评价(1-5 星+文字),按客服/产品聚合</td>
+                      <td class="py-3 text-muted">满意度记录、归档工单、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/cn/plugins-commercial" class="btn btn-primary me-3">查看全部商业插件</a>
-          <a href="/cn/commercial" class="btn btn-outline-primary">了解定价详情</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三个步骤快速部署包含工单管理功能的 NocoBase CRM 系统到您的环境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安装 NocoBase 系统</h5>
-                <p class="text-muted mt-2">按照我们的安装文档，部署 NocoBase 系统到您的服务器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安装文档</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>下载 CRM 系统模板文件</h5>
-                <p class="text-muted mt-2">下载完整的 CRM 模板即可获得工单管理能力</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下载 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下载备份文件 (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系统内还原</h5>
-                <p class="text-muted mt-2">将 CRM 模板文件导入到您的 NocoBase 系统中，即可同时获得 CRM 和工单管理功能</p>
-              </div>
-              <div class="mt-3">
-                <a href="/cn/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">还原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 工单功能说明 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">提示</h6>
-                <p class="mb-0 text-muted">工单管理系统作为 CRM 的重要补充模块，已完全集成在 CRM 模板中。部署完成后，您可以在 CRM 系统中直接使用完整的工单管理功能，实现客户服务的全流程管理。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何扩展？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">根据业务需求进一步扩展和定制您的工单管理系统</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">从受理到结案的完整客服工单管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">工单类型与分类管理</h5>
-                  <p class="text-muted mb-3">根据业务需要创建不同类型的工单分类和处理规则</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即将推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 计时与告警</h5>
+              <p class="text-muted mt-2">按优先级自动计算响应/解决时限;超期前自动告警,超期工单置红色;SLA 达成率可看板呈现。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">团队协作功能</h5>
-                  <p class="text-muted mb-3">设置团队角色、权限和协作工作流</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即将推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 级优先级</h5>
+              <p class="text-muted mt-2">紧急、高、中、低四级,匹配不同响应时长;紧急工单自动置顶并通知值班人员。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">统计报表分析</h5>
-                  <p class="text-muted mb-3">构建工单处理情况和效率分析报表</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即将推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 智能分类</h5>
+              <p class="text-muted mt-2">新工单 AI 自动识别问题类别(账号问题/功能咨询/Bug 报告等),按规则分派给对应小组。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM 系统集成</h5>
-                  <p class="text-muted mb-3">与现有 CRM 系统无缝集成，实现数据共享</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即将推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">等待原因细分</h5>
+              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期,公平合理。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客服工作台</h5>
+              <p class="text-muted mt-2">客服登录直接看到分给自己的工单;按到期时间排序,一屏看待处理、处理中、即将超期。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工单仪表盘</h5>
+              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布;按客服员、客户、产品线聚合,管理者纵览全局。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中:满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">准备好使用 NocoBase 工单管理系统了吗？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分钟时间部署一个专属工单管理 demo。作为 CRM 的重要补充，实现完整的客户服务体系，提升客户满意度和服务效率。
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>复制到自己的环境
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下载与部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下载备份模板</h5>
+                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下载 SQL 压缩包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安装文档</h5>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即将推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">开始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
+            <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseCN>
 
 <style>
-/* 工单管理系统样式 - 参考 CRM 页面样式 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* 商业插件卡片样式 */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
 </style>
-
- 

--- a/src/pages/cn/solutions/ticketing.astro
+++ b/src/pages/cn/solutions/ticketing.astro
@@ -5,7 +5,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
 <BaseCN
   title="工单系统 — 开源客服工单管理 | NocoBase"
-  description="基于 NocoBase 无代码平台的开源工单系统:客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用,适合中小客服团队与售后服务团队。"
+  description="基于 NocoBase 无代码平台的开源工单系统：客户报障、智能分派、SLA 计时、优先级、AI 分类、满意度评价、客服工作台。开箱即用，适合中小客服团队与售后服务团队。"
   keywords="工单系统, 客服工单系统, 开源工单, help desk, ticketing 系统, 工单管理, SLA 管理, 售后系统, 客户服务系统, NocoBase"
   canonical="/cn/solutions/ticketing-v2"
 >
@@ -22,7 +22,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             </div>
             <h1 class="fw-bold mt-2 mb-3">工单系统</h1>
             <p class="para-desc text-muted">
-              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路,内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
+              基于 NocoBase 无代码平台构建。<strong>客户报障 → 智能分派 → 处理 → 满意度评价</strong> 的完整链路，内置 SLA 计时、优先级管理、AI 智能分类与客服工作台。
             </p>
 
             <div class="row mt-4 g-3">
@@ -35,7 +35,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">适用场景:</span>
+                  <span class="text-muted me-2">适用场景：</span>
                   <span class="badge bg-soft-primary me-2">客服售后</span>
                   <span class="badge bg-soft-primary me-2">IT 服务台</span>
                   <span class="badge bg-soft-primary me-2">设备维保</span>
@@ -66,7 +66,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">工单处理流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环,SLA 全程计时</p>
+            <p class="para-desc mx-auto text-muted mb-0">从客户报障到结案评价的完整闭环，SLA 全程计时</p>
           </div>
         </div>
       </div>
@@ -119,27 +119,27 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                   <tbody>
                     <tr>
                       <td class="py-3">创建</td>
-                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交;关联客户与产品</td>
+                      <td class="py-3 text-muted">客户邮件、表单、IM 多渠道提交；关联客户与产品</td>
                       <td class="py-3 text-muted">工单单号、来源、客户档案</td>
                     </tr>
                     <tr>
                       <td class="py-3">智能分类</td>
-                      <td class="py-3 text-muted">AI 识别问题类别(账号/功能/Bug),自动设优先级</td>
+                      <td class="py-3 text-muted">AI 识别问题类别（账号/功能/Bug），自动设优先级</td>
                       <td class="py-3 text-muted">分类标签、优先级、置信度</td>
                     </tr>
                     <tr>
                       <td class="py-3">分派</td>
-                      <td class="py-3 text-muted">按规则分给对应小组/客服员,紧急工单自动通知值班</td>
+                      <td class="py-3 text-muted">按规则分给对应小组/客服员，紧急工单自动通知值班</td>
                       <td class="py-3 text-muted">负责人、分派记录、组队列</td>
                     </tr>
                     <tr>
                       <td class="py-3">处理</td>
-                      <td class="py-3 text-muted">客服处理、与客户沟通;SLA 计时,超期前自动告警</td>
+                      <td class="py-3 text-muted">客服处理、与客户沟通；SLA 计时，超期前自动告警</td>
                       <td class="py-3 text-muted">处理日志、SLA 状态、等待原因</td>
                     </tr>
                     <tr>
                       <td class="py-3">评价</td>
-                      <td class="py-3 text-muted">结案推送客户评价(1-5 星+文字),按客服/产品聚合</td>
+                      <td class="py-3 text-muted">结案推送客户评价（1-5 星+文字），按客服/产品聚合</td>
                       <td class="py-3 text-muted">满意度记录、归档工单、KPI</td>
                     </tr>
                   </tbody>
@@ -171,7 +171,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">SLA 计时与告警</h5>
-              <p class="text-muted mt-2">按优先级自动计算响应/解决时限;超期前自动告警,超期工单置红色;SLA 达成率可看板呈现。</p>
+              <p class="text-muted mt-2">按优先级自动计算响应/解决时限；超期前自动告警，超期工单置红色；SLA 达成率可看板呈现。</p>
             </div>
           </div>
         </div>
@@ -181,7 +181,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">4 级优先级</h5>
-              <p class="text-muted mt-2">紧急、高、中、低四级,匹配不同响应时长;紧急工单自动置顶并通知值班人员。</p>
+              <p class="text-muted mt-2">紧急、高、中、低四级，匹配不同响应时长；紧急工单自动置顶并通知值班人员。</p>
             </div>
           </div>
         </div>
@@ -191,7 +191,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">AI 智能分类</h5>
-              <p class="text-muted mt-2">新工单 AI 自动识别问题类别(账号问题/功能咨询/Bug 报告等),按规则分派给对应小组。</p>
+              <p class="text-muted mt-2">新工单 AI 自动识别问题类别（账号问题/功能咨询/Bug 报告等），按规则分派给对应小组。</p>
             </div>
           </div>
         </div>
@@ -201,7 +201,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">等待原因细分</h5>
-              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期,公平合理。</p>
+              <p class="text-muted mt-2">"等待客户回复""等待第三方""需求待评审" — 等待中的工单不计入 SLA 超期，公平合理。</p>
             </div>
           </div>
         </div>
@@ -211,7 +211,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">客服工作台</h5>
-              <p class="text-muted mt-2">客服登录直接看到分给自己的工单;按到期时间排序,一屏看待处理、处理中、即将超期。</p>
+              <p class="text-muted mt-2">客服登录直接看到分给自己的工单；按到期时间排序，一屏看待处理、处理中、即将超期。</p>
             </div>
           </div>
         </div>
@@ -221,7 +221,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">工单仪表盘</h5>
-              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布;按客服员、客户、产品线聚合,管理者纵览全局。</p>
+              <p class="text-muted mt-2">今日新增/结案/待处理/超期分布；按客服员、客户、产品线聚合，管理者纵览全局。</p>
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
             <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="text-muted mb-2">功能完善中</h5>
-              <p class="text-muted small mt-2 mb-0">更多能力规划中:满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
+              <p class="text-muted small mt-2 mb-0">更多能力规划中：满意度评价、转派与升级、模板与快捷回复、知识库联动</p>
             </div>
           </div>
         </div>
@@ -246,7 +246,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
             <h4 class="title mb-4">下载与部署</h4>
-            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中,统一部署</p>
+            <p class="para-desc mx-auto text-muted mb-0">本模块包含在一体化业务管理系统的备份模板中，统一部署</p>
           </div>
         </div>
       </div>
@@ -257,7 +257,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>下载备份模板</h5>
-                <p class="text-muted mt-2">一体化方案备份,还原后包含本模块在内的 6 大模块全部预置数据</p>
+                <p class="text-muted mt-2">一体化方案备份，还原后包含本模块在内的 6 大模块全部预置数据</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下载 .nbdata 备份</a>
@@ -272,7 +272,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
               <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
                 <h5>查看安装文档</h5>
-                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项,正在准备中</p>
+                <p class="text-muted mt-2">详细的还原步骤、常见问题与注意事项，正在准备中</p>
               </div>
               <div class="mt-3 d-flex flex-column gap-2 align-items-center">
                 <button class="btn btn-outline-secondary" disabled>即将推出</button>
@@ -292,7 +292,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
       <div class="row justify-content-center text-center">
         <div class="col-lg-8">
           <h3 class="title mb-4">开始使用</h3>
-          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中,可单独使用,也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
+          <p class="text-muted para-desc mx-auto mb-0">本模块同样集成在 <a href="/cn/solutions/all-in-one">一体化业务管理系统</a> 中，可单独使用，也可与 CRM、销售管理、项目管理、固定资产管理、HR 协同。</p>
           <div class="mt-4">
             <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>在线体验 Demo</a>
             <a href="/cn/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>联系咨询</a>

--- a/src/pages/de/solutions/all-in-one.astro
+++ b/src/pages/de/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseDE from "../../../layouts/BaseDE.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseDE
+  title="All-in-One-Business-System – CRM / Tickets / Projekte / Anlagen / HR | NocoBase"
+  description="Open-Source All-in-One-Business-System: CRM (Kundenverwaltung), Vertriebsmanagement, Helpdesk-Tickets, Projektmanagement, Anlagenverwaltung und HR-Personalverwaltung in einer integrierten Lösung. Auf NocoBase aufgebaut, sofort einsatzbereit, geeignet für KMU."
+  keywords="All-in-One-Business-System, CRM, Open-Source CRM, Helpdesk-Software, Ticketsystem, Projektmanagementsystem, IT-Asset-Management, HR-Software, Personalverwaltung, Vertriebsmanagement, No-Code ERP, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">All-in-One-<br/>Business-System</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Umfasst sechs Module: <strong>CRM (Kundenverwaltung), Vertriebsmanagement, Helpdesk-Tickets, Projektmanagement, Anlagenverwaltung und HR-Personalverwaltung</strong>.
+              Sofort einsatzbereit – ohne aufwendige Auswahl- und Integrationsprojekte mit mehreren Systemen.
+            </p>
+
+            <!-- Kernwert -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Integration mehrerer Systeme</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Über 20 Sprachen integriert</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI-Mitarbeiter + Workflow</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open Source und kostenlos</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Einsatzszenarien -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">Start-ups</span>
+                  <span class="badge bg-soft-primary me-2">Filialen mit mehreren Geschäftsbereichen</span>
+                  <span class="badge bg-soft-primary me-2">Geschäftsmodell-Erprobung</span>
+                  <span class="badge bg-soft-primary">Schulung und Training</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Demo ausprobieren
+              </a>
+              <a href="/de/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Kontakt aufnehmen
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="All-in-One-Business-System" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Sechs Module im Zusammenspiel</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, Vertriebsmanagement, Helpdesk-Tickets, Projektmanagement, Anlagenverwaltung und HR-Personalverwaltung – alle Geschäftsprozesse in einem System geschlossen abgebildet</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- Kundenverwaltung -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Kundenverwaltung)</h5>
+              <p class="text-muted mt-2">Open-Source CRM: vollständiger Prozess von Lead über Nachverfolgung und Konvertierung bis zur Dublettenbereinigung; 360-Grad-Kundenansicht mit aggregierten Aufträgen, Tickets, Projekten und Anlagen.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Lead-Phasen und Konvertierung</li>
+                <li><i class="uil uil-check text-primary me-1"></i>360-Grad-Kundenansicht</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Zusammenführen / Dublettenbereinigung</li>
+              </ul>
+              <a href="/de/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Vertriebs-Suite -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vertriebsmanagement</h5>
+              <p class="text-muted mt-2">Vertriebsauftragsverwaltung: vollständige Kette von Angebot, Auftrag, Rechnung bis Zahlungseingang; integrierte Genehmigungsprozesse und Analyse offener Forderungen.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Mehrwährungs-Angebote</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Auftrags-Genehmigungs-Workflow</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI für überfällige Forderungen</li>
+              </ul>
+              <a href="/de/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Helpdesk-Tickets -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Helpdesk (Tickets)</h5>
+              <p class="text-muted mt-2">Helpdesk-Ticketsystem: Störungsmeldung, Zuweisung, Bearbeitung und Zufriedenheitsbewertung; mit SLA-Zeitmessung, Prioritätsverwaltung und differenzierten Wartegründen.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Automatische SLA-Zeitmessung mit Überfälligkeitsbenachrichtigung</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Ticket-Dashboard + Team-Arbeitsplatz</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 Prioritätsstufen + AI-Klassifizierung</li>
+              </ul>
+              <a href="/de/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Projektmanagement -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Projektmanagement</h5>
+              <p class="text-muted mt-2">Schlankes Projektmanagementsystem: zweistufige Verwaltung auf Projekt- und Aufgabenebene; mit Verantwortlichen, Fortschritt, Meilensteinen und Verzugswarnungen.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Projektstatus-Board</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Arbeitslast je Verantwortlichem</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Erinnerung bei Projektverzug</li>
+              </ul>
+              <a href="/de/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Anlagenverwaltung -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Anlagenverwaltung</h5>
+              <p class="text-muted mt-2">Lebenszyklusverwaltung von IT- und Büroanlagen: Beschaffung, Zuweisung, Wartung und Aussonderung – mit ergänzendem Lieferantenverzeichnis.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Zuweisung und Rückgabe</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Wartungstickets</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Beschaffungs- und Lieferantenanalyse</li>
+              </ul>
+              <a href="/de/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR-Personal -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR / Personalverwaltung</h5>
+              <p class="text-muted mt-2">Personalverwaltungssystem: Mitarbeiterstammdaten, Eintritt, Austritt, Urlaub, Probezeit – verknüpft mit Stellen- und Abteilungsstruktur.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Eintritts- und Austrittscheckliste</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Urlaubsgenehmigung</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Probezeit-Board</li>
+              </ul>
+              <a href="/de/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Mehr erfahren <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Plattformfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Aufgebaut auf NocoBase 2.x – mit integrierter AI, Workflow, Mehrsprachigkeit und Multi-Workspace-Funktionalität</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI-Mitarbeiter</h5>
+            <p class="text-muted small">Lina (Lokalisierung), Lexi (Übersetzung), Atlas (Koordination) und weitere integrierte AI-Rollen, abrufbar nach Anwendungsfall.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Mehrsprachigkeit</h5>
+            <p class="text-muted small">Über 20 Sprachen integriert (Chinesisch, Englisch, Japanisch, Koreanisch, Deutsch, Französisch usw.); vollständige Übersetzung der gesamten Oberfläche.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Workflow-Engine</h5>
+            <p class="text-muted small">Genehmigungen, Benachrichtigungen, SLA-Zeitmessung, zeitgesteuerte Auslösung – visuelle Modellierung, Regeln werden ohne Code konfiguriert.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Multi-Workspace-Isolation</h5>
+            <p class="text-muted small">Ein System bedient mehrere Teams oder Filialen, mit gegenseitiger Datentrennung und unabhängiger Rechteverwaltung.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI-Zusammenarbeit</span>
+            <h4 class="title mb-4">Integrierte AI-Mitarbeiter</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Neun vordefinierte AI-Mitarbeiter decken typische Geschäftsrollen ab; über das MCP-Protokoll lassen sich externe Agenten zur Erweiterung anbinden</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Teamleitung – Aufgabenverteilung und Koordination</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Frontend-Entwickler – Oberfläche und JS-Block-Codegenerierung</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Visualisierung – Aufbau von Diagrammen und Dashboards</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Analytik – Trenderkennung und KPI-Interpretation</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Recherche – Informationsbeschaffung und Zusammenfassung</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Datenaufbereitung – Bereinigung, Zusammenführung und Massenbearbeitung</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Übersetzung – Kundendialoge und E-Mails in mehreren Sprachen</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Lokalisierungs-Engineer – Oberflächentexte und i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">E-Mail-Assistent – Absichtserkennung und Antwortentwurf</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Eigene AI-Mitarbeiter</h6>
+              <p class="text-muted small mb-0">Eigene Rollen, Prompts und Skill-Kombinationen nach Bedarf anlegen</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Externe Agenten anbinden</h6>
+              <p class="text-muted small mb-0">Über MCP eigene Agenten und Toolchains anschließen</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Einsatzszenarien</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Die integrierte Lösung eignet sich besonders für folgende Szenarien</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Übergreifende Steuerung mehrerer Geschäftsbereiche</h5>
+                  <p class="text-muted mb-0">Das Geschäft umfasst Vertrieb, Kundenservice und Projekte; ein einheitliches System zeigt das Gesamtbild und vermeidet ständigen Wechsel zwischen mehreren Tools.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Filialen mit mehreren Geschäftsbereichen</h5>
+                  <p class="text-muted mb-0">Eine Filiale verantwortet Vertrieb, After-Sales und Projektabwicklung gleichzeitig; bei vielen Bereichen, aber begrenztem Umfang verursachen Einzellösungen hohen Abstimmungsaufwand.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Phase der Geschäftsmodell-Erprobung</h5>
+                  <p class="text-muted mb-0">Das Geschäftsmodell ist noch nicht fixiert; eine frühe Festlegung auf eine bestimmte Lösung soll vermieden werden. Die integrierte Plattform kann zuerst eingeführt und später iterativ angepasst werden.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Schulung / Training / Proof of Concept</h5>
+                  <p class="text-muted mb-0">Als vollständiges Anwendungsbeispiel der NocoBase-Plattform für interne Schulungen, Lösungspräsentationen oder Proof of Concepts – mit Abdeckung typischer Geschäftsprozesse.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">So gehen Sie vor</h4>
+            <p class="para-desc mx-auto text-muted mb-0">In drei Schritten zum einsatzbereiten All-in-One-Business-System</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>NocoBase installieren</h5>
+                <p class="text-muted mt-2">Folgen Sie der offiziellen Installationsanleitung und richten Sie NocoBase lokal oder auf einem Server ein</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Installationsanleitung</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Nach dem Restore stehen alle Beispieldaten der sechs Module vollständig zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Mit dem All-in-One-Business-System starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Eine integrierte Geschäftslösung auf Basis von NocoBase 2.x. Die Vorlage ist direkt wiederverwendbar und erweiterbar; für branchenspezifische Anpassungen kontaktieren Sie uns gerne.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Demo ausprobieren
+            </a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Kontakt aufnehmen
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseDE>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/de/solutions/asset-management.astro
+++ b/src/pages/de/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseDE from "../../../layouts/BaseDE.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseDE
+  title="Anlagenverwaltung – Open-Source IT-Asset-Management und Büroanlagen | NocoBase"
+  description="Open-Source Anlagenverwaltung auf Basis der No-Code-Plattform NocoBase: Lebenszyklus von Beschaffung, Zuweisung, Wartung und Aussonderung für IT-Anlagen und Büroanlagen; mit Lieferantenverzeichnis, Wartungstickets und Beschaffungsanalyse."
+  keywords="Anlagenverwaltung, IT-Asset-Management, Asset-Management, Open-Source Anlagenverwaltung, Büroanlagen, Anlagen-Lebenszyklus, Equipment-Management, Inventur, Lieferantenmanagement, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Anlagenverwaltung-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Anlagenverwaltung</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Lebenszyklusverwaltung mit <strong>Beschaffung → Zuweisung → Wartung → Aussonderung</strong>, für IT-Anlagen und Büroanlagen – ergänzt durch Lieferantenverzeichnis und Wartungstickets.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Voller Lebenszyklus</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Wartungstickets</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Lieferantenverzeichnis</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">IT-Anlagen</span>
+                  <span class="badge bg-soft-primary me-2">Büroanlagen</span>
+                  <span class="badge bg-soft-primary me-2">Equipment-Vermietung</span>
+                  <span class="badge bg-soft-primary">Inventur</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Oberfläche der Anlagenverwaltung" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Lebenszyklus einer Anlage</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Geschlossener Kreislauf vom Wareneingang nach Beschaffung bis zur Aussonderung – jede Anlage ist nachvollziehbar</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Beschaffung</div>
+                  <div class="small text-muted">Lieferant verknüpft</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Einlagerung</div>
+                  <div class="small text-muted">Anlagenkarte</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Zuweisung</div>
+                  <div class="small text-muted">Mit Unterschrift</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Wartung</div>
+                  <div class="small text-muted">Ticketverknüpfung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Aussonderung</div>
+                  <div class="small opacity-75">Restwert dokumentiert</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Beschaffung</td>
+                      <td class="py-3 text-muted">Bestellung mit Lieferant und Preis verknüpft; mehrere Kategorien und Mengen möglich</td>
+                      <td class="py-3 text-muted">Bestellung, Lieferant, Beschaffungsbetrag</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Einlagerung</td>
+                      <td class="py-3 text-muted">Beim Wareneingang wird automatisch eine Anlagenkarte erzeugt (Nummer, Seriennummer, Garantiezeit in einem Vorgang erfasst)</td>
+                      <td class="py-3 text-muted">Anlagenkarte, eindeutige Nummer, Garantiezeit</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Zuweisung</td>
+                      <td class="py-3 text-muted">Anlage an Mitarbeitenden, Kunden oder Abteilung ausgeben, mit Unterschrift bestätigt</td>
+                      <td class="py-3 text-muted">Ausgabeprotokoll, Nutzer, Start- und Endtermin</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Wartung</td>
+                      <td class="py-3 text-muted">Bei Störung oder Wartung wird ein Wartungsticket angelegt und mit der Anlagenkarte verknüpft</td>
+                      <td class="py-3 text-muted">Wartungsticket, kumulierte Kosten</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Aussonderung</td>
+                      <td class="py-3 text-muted">Aussonderung mit Grund (Defekt / Ablauf / Verkauf) dokumentieren; Abschreibung und Restwert erfassen</td>
+                      <td class="py-3 text-muted">Aussonderungseintrag, Restwert, Verwendung</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständige Anlagenverwaltung von der Beschaffung bis zur Aussonderung</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Beschaffung</h5>
+              <p class="text-muted mt-2">Bestellungen mit Lieferant und Preis verknüpft; bei Einlagerung entstehen automatisch Anlagenkarten – Nummer, Seriennummer und Garantiezeit werden in einem Schritt erfasst.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Zuweisung / Rückgabe</h5>
+              <p class="text-muted mt-2">Anlagen werden an Mitarbeitende oder Kunden ausgegeben und mit Unterschrift dokumentiert; die Rückgabe gibt die Anlage automatisch wieder frei; die Nutzungshistorie jeder Anlage ist vollständig nachvollziehbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Wartungstickets</h5>
+              <p class="text-muted mt-2">Störungen und Wartungen werden als Tickets angelegt und mit der Anlagenkarte verknüpft; kumulierte Wartungskosten helfen bei Entscheidungen zur Aussonderung.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aussonderung / Verkauf</h5>
+              <p class="text-muted mt-2">Aussonderungen werden mit Grund (Defekt / Ablauf / Verkauf) dokumentiert; Abschreibung und Restwert bleiben hinterlegt und entsprechen der Finanzbuchhaltung.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lieferantenverzeichnis</h5>
+              <p class="text-muted mt-2">Lieferantenstammdaten und Bestellhistorie; Beschaffungsbetrag, Warenkategorien und Zahlungsbedingungen sind auf einen Blick verfügbar und unterstützen Beschaffungsentscheidungen.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Anlagen-Dashboard</h5>
+              <p class="text-muted mt-2">Verteilung von Gesamtanzahl, in Nutzung, in Wartung und ausgesondert; Aggregation nach Typ, Abteilung und Nutzer; Inventurdaten per Klick exportierbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Weitere Funktionen in Entwicklung</h5>
+              <p class="text-muted small mt-2 mb-0">Geplant: Inventur-Aufgaben, automatische Abschreibungsberechnung, QR-Code-Scan, Asset-Anforderungs-Workflow</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Vertriebsmanagement, Helpdesk, Projektmanagement und HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseDE>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/de/solutions/crm-v2.astro
+++ b/src/pages/de/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseDE from "../../../layouts/BaseDE.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 Sales Management System - NocoBase"
-  description="CRM 2.0 sales management system built on NocoBase no-code platform. Modular design with complete sales cycle. Supports AI-assisted lead scoring, opportunity win-rate prediction, and more."
-  keywords="NocoBase CRM, AI CRM, sales management, opportunity management, customer relationship management, lead management, no-code CRM"
+<BaseDE
+  title="CRM (Kundenverwaltung) – Open Source und selbst hostbar | NocoBase"
+  description="Open-Source CRM auf Basis der No-Code-Plattform NocoBase: Lead-Verwaltung, Kundenbetreuung, Konvertierung, Dublettenbereinigung, 360-Grad-Kundenansicht. Sofort einsatzbereit, selbst hostbar."
+  keywords="CRM, Open-Source CRM, Kundenverwaltung, Kundenbeziehungsmanagement, Lead-Verwaltung, Kundennachverfolgung, 360-Grad-Kundenansicht, No-Code CRM, selbst gehostetes CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sales Management System</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>(Kundenverwaltung)</h1>
             <p class="para-desc text-muted">
-              Built on NocoBase no-code platform. Modular design with complete sales cycle. Workflow automation handles routine tasks, AI assists with lead scoring, opportunity analysis, and more.
+              Auf der No-Code-Plattform NocoBase aufgebaut. Deckt den vollständigen Prozess von Lead über Nachverfolgung und Konvertierung bis Dublettenbereinigung ab; die 360-Grad-Kundenansicht bündelt Aufträge, Tickets, Projekte und Anlagen.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Smart Lead Scoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Win-Rate Prediction</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Customer Health Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Modular Design</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Lead-Phasenverwaltung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">360-Grad-Kundenansicht</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Zusammenführen / Dubletten</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">B2B Sales</span>
-                  <span class="badge bg-soft-primary me-2">Project Sales</span>
-                  <span class="badge bg-soft-primary me-2">Foreign Trade</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-Vertrieb</span>
+                  <span class="badge bg-soft-primary me-2">Projektgeschäft</span>
+                  <span class="badge bg-soft-primary me-2">Außenhandel</span>
+                  <span class="badge bg-soft-primary">KMU-Teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Sales teams face multiple challenges in daily operations</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Oberfläche des CRM (Kundenverwaltung)" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inconsistent Lead Quality</h5>
-              </div>
-              <p class="text-muted mb-0">Large volumes of leads with varying quality. Sales waste time on low-quality leads while high-value ones get overlooked.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Delayed Opportunity Follow-up</h5>
-              </div>
-              <p class="text-muted mb-0">Opportunities stall without progress. Sales managers struggle to track team pipeline health, missing optimal closing windows.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Scattered Customer Data</h5>
-              </div>
-              <p class="text-muted mb-0">Customer data scattered across emails, chats, and documents. No complete customer profile for targeted marketing.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inaccurate Sales Forecasts</h5>
-              </div>
-              <p class="text-muted mb-0">Forecasting based on gut feeling without data support. Large prediction gaps affect resource allocation and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High SaaS Costs</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot and other SaaS CRMs charge per seat. Custom development takes long with unpredictable costs.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Data Security Concerns</h5>
-              </div>
-              <p class="text-muted mb-0">Customer and opportunity data stored on third-party clouds, not meeting data localization and privacy compliance requirements.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 system built on NocoBase no-code platform. Workflow automation + AI assistance</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Smart Lead Scoring</h5>
-              <p class="text-muted mt-2">Auto-evaluate lead quality, prioritize high-value leads, recommend optimal contact times</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Win-Rate Prediction</h5>
-              <p class="text-muted mt-2">Predict close probability based on historical data, identify at-risk deals, provide stage progression suggestions</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Customer Health Monitoring</h5>
-              <p class="text-muted mt-2">360-degree customer profile, health scoring, churn risk alerts, proactive relationship maintenance</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Modular Design</h5>
-              <p class="text-muted mt-2">Independent module design, minimal setup requires only Customers + Opportunities, scale as needed</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">Complete Sales Cycle</h4>
-            <p class="para-desc mx-auto text-muted mb-0">From lead acquisition to customer success, unified data flow with AI assistance at every stage</p>
+            <h4 class="title mb-4">Prozess der Kundenverwaltung</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vom Eingang des Leads bis zur 360-Grad-Kundenansicht – die Daten sind durchgängig verbunden</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Mehrkanal-Eingang</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Nachverfolgung</div>
+                  <div class="small text-muted">Dokumentation</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Konvertierung</div>
+                  <div class="small text-muted">Kundenstamm</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">360-Grad-Ansicht</div>
+                  <div class="small text-muted">Gesamtbild</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Datenkonsolidierung</div>
+                  <div class="small opacity-75">Vertriebs-Dashboard</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Stage Conversion</th>
-                      <th class="border-0 py-3">Trigger</th>
-                      <th class="border-0 py-3">AI Assistance</th>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Customer</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Erfassung über Formular, Import oder manuelle Eingabe; Quelle und zuständiger Vertrieb markiert</td>
+                      <td class="py-3 text-muted">Lead-Pool, Quellen-Tags, Phasenstatus</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Customer → Opportunity</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">AI analyzes intent, recommends creating opportunity</td>
+                      <td class="py-3">Nachverfolgung</td>
+                      <td class="py-3 text-muted">Telefonate, E-Mails, Besuche dokumentieren; nächsten Kontakt terminieren</td>
+                      <td class="py-3 text-muted">Aktivitätsverlauf, nächste Erinnerung</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Opportunity → Quote</td>
-                      <td class="py-3 text-muted">Enters proposal stage</td>
-                      <td class="py-3 text-primary">AI pricing suggestions, competitor comparison, tiered pricing</td>
+                      <td class="py-3">Konvertierung</td>
+                      <td class="py-3 text-muted">Lead in Kunden umwandeln; Stammdaten ausfüllen (Branche, Größe, Ansprechpartner)</td>
+                      <td class="py-3 text-muted">Kundentabelle, Ansprechpartner, verknüpfter Lead</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Quote → Order</td>
-                      <td class="py-3 text-muted">Customer accepts quote</td>
-                      <td class="py-3 text-primary">Auto-generate order with product details and pricing</td>
+                      <td class="py-3">360-Grad-Ansicht</td>
+                      <td class="py-3 text-muted">Gesamtüberblick: Aufträge, Tickets, Projekte, Anlagen</td>
+                      <td class="py-3 text-muted">Eingebettete Blöcke, modulübergreifende Verknüpfung</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Datenkonsolidierung</td>
+                      <td class="py-3 text-muted">Vertriebs-Dashboard mit KPIs nach Vertriebler, Region oder Typ</td>
+                      <td class="py-3 text-muted">Diagramme, Drill-down auf Details, Export</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Assistance</span>
-            <h4 class="title mb-4">AI Assistance Capabilities</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Through workflow AI nodes, assist with scoring, analysis, writing, and other repetitive tasks</p>
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, Kunden, Nachverfolgung und Dashboards – die täglichen Aufgaben im Kundenbeziehungsmanagement vollständig abgedeckt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Workflow Node</span></h5>
-              <span class="badge bg-soft-primary mb-2">Sales Scout</span>
-              <p class="text-muted mt-2 small">Deep opportunity analysis, win-rate prediction, competitive intelligence, deal strategy suggestions</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lead-Import</h5>
+              <p class="text-muted mt-2">Drei Wege zum Import: Excel-Stapelimport, Formularerfassung und API; visuelle Feldzuordnung; Dubletten beim Import automatisch erkennen.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Insights Analyst</span>
-              <p class="text-muted mt-2 small">Smart lead scoring, customer health assessment, sales data analysis, pipeline forecasting</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phasensteuerung</h5>
+              <p class="text-muted mt-2">Lead-Phasen (Neu / Kontaktiert / Konvertiert / Verworfen) visuell konfigurierbar; jeder Phasenwechsel wird dokumentiert, Konvertierungsraten werden automatisch berechnet.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Editor Assistant</span>
-              <p class="text-muted mt-2 small">Email sentiment/intent analysis, reply drafting, communication summary</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aktivitätsprotokoll</h5>
+              <p class="text-muted mt-2">Jeder Besuch, jedes Telefonat und jede E-Mail wird dokumentiert; die Zeitachse zeigt den vollständigen Kommunikationsverlauf, eine Übergabe verläuft reibungslos.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Daily Planning</span>
-              <p class="text-muted mt-2 small">Daily priorities, next action suggestions, follow-up planning</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Wiedervorlage-Erinnerung</h5>
+              <p class="text-muted mt-2">Vor Erreichen des Wiedervorlagetermins erfolgt automatisch eine Benachrichtigung; lang nicht kontaktierte Kunden erscheinen im Board "Zu reaktivieren".</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language customer communication, content translation, foreign trade email handling</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">360-Grad-Kundenansicht</h5>
+              <p class="text-muted mt-2">Die Kundendetailseite bündelt Aufträge, Tickets, Projekte und Anlagen; alle Informationen auf einen Blick, kein Wechsel zwischen Systemen nötig.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">More AI Employees</h5>
-              <span class="badge bg-soft-secondary mb-2">Expanding</span>
-              <p class="text-muted mt-2 small">More specialized AI employees can be added based on business needs</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Klassifizierung und Tags</h5>
+              <p class="text-muted mt-2">Mehrdimensionale Tags für Kundentyp, Branche, Größe und Quelle; Filterung und Aggregation nach Tag.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Flexible Architecture</span>
-            <h4 class="title mb-4">Modular Design</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Each module designed independently, can be toggled on/off. Scale your solution to fit your needs</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Module</th>
-                  <th class="border-0 py-3">Required</th>
-                  <th class="border-0 py-3">Description</th>
-                  <th class="border-0 py-3">AI Capabilities</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Customer Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Opportunity Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Lead Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Quote Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Order Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Product Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Email Integration</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Full Suite</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Standard</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Lite</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Trade</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dublettenbereinigung</h5>
+              <p class="text-muted mt-2">Mehrfacheinträge desselben Kunden werden automatisch erkannt; per Klick zusammenführen – Aktivitätsverlauf und Verknüpfungen bleiben erhalten.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vertriebs-Dashboard</h5>
+              <p class="text-muted mt-2">KPI-Aggregation nach Vertriebler, Region und Kundentyp; Neukundenzahl, Konvertierungsrate und Verteilung aktiver Kunden.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Feld- und Datensatzrechte</h5>
+              <p class="text-muted mt-2">Sichtbare Felder pro Rolle konfigurierbar; Vertriebler sehen ausschließlich die ihnen zugewiesenen Kunden, Manager sehen das Gesamtbild.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value from Automation</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Workflow automation + AI assistance reduces repetitive work, letting sales focus on customer relationships</p>
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS CRM and custom development</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimension</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">Custom Dev</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of box</td>
-                  <td class="py-3 text-muted">Months of development</td>
-                  <td class="py-3 text-primary">Configure and go, quick launch</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexible customization</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Assistance</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">Workflow AI nodes, use as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Module Flexibility</td>
-                  <td class="py-3 text-muted">Bundled features</td>
-                  <td class="py-3 text-muted">Code changes needed</td>
-                  <td class="py-3 text-primary">Modular, scale as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">Per-seat subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">One-time purchase, long-term use</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy CRM 2.0 system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/de/solution/crm/" target="_blank" class="btn btn-outline-primary">Solution Docs</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/de/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Restore Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit Vertriebsmanagement, Helpdesk, Projektmanagement, Anlagenverwaltung und HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/de/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseDE>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/de/solutions/crm.astro
+++ b/src/pages/de/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseDE from "../../../layouts/BaseDE.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="Flexible und Leistungsstarke No-Code-CRM-Plattform"
-  description="Sofort einsatzbereit, mit weitreichender Anpassbarkeit und voller Datensouveraenitaet. Erweitern Sie Felder, Bloecke, Funktionen und Seiten, damit das CRM exakt zu Ihrem Unternehmen passt."
-  keywords="NocoBase CRM, No-Code CRM, Open-Source CRM, individuelles CRM, Customer Relationship Management"
+<BaseDE
+  title="CRM (Kundenverwaltung) – Open Source und selbst hostbar | NocoBase"
+  description="Open-Source CRM auf Basis der No-Code-Plattform NocoBase: Lead-Verwaltung, Kundenbetreuung, Konvertierung, Dublettenbereinigung, 360-Grad-Kundenansicht. Sofort einsatzbereit, selbst hostbar."
+  keywords="CRM, Open-Source CRM, Kundenverwaltung, Kundenbeziehungsmanagement, Lead-Verwaltung, Kundennachverfolgung, 360-Grad-Kundenansicht, No-Code CRM, selbst gehostetes CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Flexible und Leistungsstarke<br/>No-Code-CRM-Plattform</h1>
-            <p class="para-desc text-muted">Direkt einsatzbereit und zugleich stark anpassbar fuer Ihre individuellen Anforderungen. Erweitern Sie Felder, Bloecke und Seiten, um die passende Loesung fuer Ihr Unternehmen aufzubauen, waehrend Sie die volle Kontrolle ueber Ihre Daten behalten.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Erstellt mit NocoBase 1.x (2.0 in Entwicklung)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>(Kundenverwaltung)</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Deckt den vollständigen Prozess von Lead über Nachverfolgung und Konvertierung bis Dublettenbereinigung ab; die 360-Grad-Kundenansicht bündelt Aufträge, Tickets, Projekte und Anlagen.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Lead-Phasenverwaltung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">360-Grad-Kundenansicht</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Zusammenführen / Dubletten</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Branchen:</span>
-                  <span class="badge bg-soft-primary">Alle Branchen</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-Vertrieb</span>
+                  <span class="badge bg-soft-primary me-2">Projektgeschäft</span>
+                  <span class="badge bg-soft-primary me-2">Außenhandel</span>
+                  <span class="badge bg-soft-primary">KMU-Teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Entwickler:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live-Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>In Ihrer Umgebung bereitstellen
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Oberfläche des CRM (Kundenverwaltung)" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Was NocoBase CRM Besonders Macht</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Im Unterschied zu SaaS-Produkten und anderen geschlossenen CRM-Systemen ist NocoBase CRM flexibel und vollstaendig unter Ihrer Kontrolle</p>
+            <h4 class="title mb-4">Prozess der Kundenverwaltung</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vom Eingang des Leads bis zur 360-Grad-Kundenansicht – die Daten sind durchgängig verbunden</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Komplett No-Code</h5>
-              <p class="text-muted mt-2">Keine Programmierkenntnisse fuer die Anpassung des CRM erforderlich</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Deckt Typische CRM-Funktionen Ab</h5>
-              <p class="text-muted mt-2">Kundenverwaltung, Vertriebspipeline, Opportunity-Tracking, Kontakte, E-Mail-Kommunikation, Freigaben und mehr</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Leicht Anpassbar und Erweiterbar</h5>
-              <p class="text-muted mt-2">Unterstuetzt benutzerdefinierte Felder, Prozesse und Geschaeftslogik; die flexible Architektur erleichtert Weiterentwicklungen</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source und Volle Datenkontrolle</h5>
-              <p class="text-muted mt-2">Volle Kontrolle ueber Systemcode und Daten fuer mehr Sicherheit und Unabhaengigkeit im Unternehmen</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase CRM Schnell Ausprobieren</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Mit nur wenigen Klicks einen direkten Eindruck gewinnen</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Datenvisualisierung im Dashboard</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Interaktive Demo
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Mehrkanal-Eingang</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Nachverfolgung</div>
+                  <div class="small text-muted">Dokumentation</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Konvertierung</div>
+                  <div class="small text-muted">Kundenstamm</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">360-Grad-Ansicht</div>
+                  <div class="small text-muted">Gesamtbild</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Datenkonsolidierung</div>
+                  <div class="small opacity-75">Vertriebs-Dashboard</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Lead-Conversion-Prozess</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Interaktive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/de/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/de/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Erfassung über Formular, Import oder manuelle Eingabe; Quelle und zuständiger Vertrieb markiert</td>
+                      <td class="py-3 text-muted">Lead-Pool, Quellen-Tags, Phasenstatus</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Nachverfolgung</td>
+                      <td class="py-3 text-muted">Telefonate, E-Mails, Besuche dokumentieren; nächsten Kontakt terminieren</td>
+                      <td class="py-3 text-muted">Aktivitätsverlauf, nächste Erinnerung</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Konvertierung</td>
+                      <td class="py-3 text-muted">Lead in Kunden umwandeln; Stammdaten ausfüllen (Branche, Größe, Ansprechpartner)</td>
+                      <td class="py-3 text-muted">Kundentabelle, Ansprechpartner, verknüpfter Lead</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">360-Grad-Ansicht</td>
+                      <td class="py-3 text-muted">Gesamtüberblick: Aufträge, Tickets, Projekte, Anlagen</td>
+                      <td class="py-3 text-muted">Eingebettete Blöcke, modulübergreifende Verknüpfung</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Datenkonsolidierung</td>
+                      <td class="py-3 text-muted">Vertriebs-Dashboard mit KPIs nach Vertriebler, Region oder Typ</td>
+                      <td class="py-3 text-muted">Diagramme, Drill-down auf Details, Export</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/de/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/de/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, Kunden, Nachverfolgung und Dashboards – die täglichen Aufgaben im Kundenbeziehungsmanagement vollständig abgedeckt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lead-Import</h5>
+              <p class="text-muted mt-2">Drei Wege zum Import: Excel-Stapelimport, Formularerfassung und API; visuelle Feldzuordnung; Dubletten beim Import automatisch erkennen.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phasensteuerung</h5>
+              <p class="text-muted mt-2">Lead-Phasen (Neu / Kontaktiert / Konvertiert / Verworfen) visuell konfigurierbar; jeder Phasenwechsel wird dokumentiert, Konvertierungsraten werden automatisch berechnet.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/de/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aktivitätsprotokoll</h5>
+              <p class="text-muted mt-2">Jeder Besuch, jedes Telefonat und jede E-Mail wird dokumentiert; die Zeitachse zeigt den vollständigen Kommunikationsverlauf, eine Übergabe verläuft reibungslos.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Wiedervorlage-Erinnerung</h5>
+              <p class="text-muted mt-2">Vor Erreichen des Wiedervorlagetermins erfolgt automatisch eine Benachrichtigung; lang nicht kontaktierte Kunden erscheinen im Board "Zu reaktivieren".</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">360-Grad-Kundenansicht</h5>
+              <p class="text-muted mt-2">Die Kundendetailseite bündelt Aufträge, Tickets, Projekte und Anlagen; alle Informationen auf einen Blick, kein Wechsel zwischen Systemen nötig.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Klassifizierung und Tags</h5>
+              <p class="text-muted mt-2">Mehrdimensionale Tags für Kundentyp, Branche, Größe und Quelle; Filterung und Aggregation nach Tag.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dublettenbereinigung</h5>
+              <p class="text-muted mt-2">Mehrfacheinträge desselben Kunden werden automatisch erkannt; per Klick zusammenführen – Aktivitätsverlauf und Verknüpfungen bleiben erhalten.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vertriebs-Dashboard</h5>
+              <p class="text-muted mt-2">KPI-Aggregation nach Vertriebler, Region und Kundentyp; Neukundenzahl, Konvertierungsrate und Verteilung aktiver Kunden.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Feld- und Datensatzrechte</h5>
+              <p class="text-muted mt-2">Sichtbare Felder pro Rolle konfigurierbar; Vertriebler sehen ausschließlich die ihnen zugewiesenen Kunden, Manager sehen das Gesamtbild.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit Vertriebsmanagement, Helpdesk, Projektmanagement, Anlagenverwaltung und HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseDE>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/de/solutions/hr-management.astro
+++ b/src/pages/de/solutions/hr-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseDE from "../../../layouts/BaseDE.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseDE
+  title="HR / Personalverwaltung – Open-Source HR-Software | NocoBase"
+  description="Open-Source HR-Software auf Basis der No-Code-Plattform NocoBase: Mitarbeiterstammdaten, Eintritt, Austritt, Urlaub, Probezeit, Stellen- und Abteilungsstruktur. Schlank und selbst hostbar, geeignet für HR-Teams in KMU."
+  keywords="HR-Software, Personalverwaltung, Open-Source HR, Mitarbeiterverwaltung, Onboarding, Offboarding, Urlaubsgenehmigung, Probezeitverwaltung, Organisationsstruktur, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">HR-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR / Personalverwaltung</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Mitarbeiterstammdaten und vollständige Verfolgung von <strong>Eintritt, Austritt, Urlaub und Probezeit</strong>, verknüpft mit Stellen- und Abteilungsstruktur.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Eintritts- / Austrittscheckliste</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Urlaubsgenehmigung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Probezeit-Board</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">KMU</span>
+                  <span class="badge bg-soft-primary me-2">Filialketten</span>
+                  <span class="badge bg-soft-primary me-2">Branchen-HR</span>
+                  <span class="badge bg-soft-primary">Abteilungsübergreifend</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Oberfläche der HR-Software" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Mitarbeiter-Lebenszyklus</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständiger Kreislauf von der Personalsuche bis zum Austritt</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Recruiting</div>
+                  <div class="small text-muted">Bewerber</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Eintritt</div>
+                  <div class="small text-muted">Checkliste</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Beschäftigung</div>
+                  <div class="small text-muted">Zeit und Urlaub</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Bewertung</div>
+                  <div class="small text-muted">Übernahme / Wechsel</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Austritt</div>
+                  <div class="small opacity-75">Übergabe und Ablage</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Recruiting</td>
+                      <td class="py-3 text-muted">Bewerber erfassen, Interviewbewertungen; bei Zusage in die Mitarbeiterakte überführen</td>
+                      <td class="py-3 text-muted">Bewerbertabelle, Interview-Scores</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Eintritt</td>
+                      <td class="py-3 text-muted">Onboarding-Checkliste (Vertrag, Ausweis, Geräte, Accounts)</td>
+                      <td class="py-3 text-muted">Onboarding-Liste, Vertragsdokumente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Beschäftigung</td>
+                      <td class="py-3 text-muted">Zeiterfassung, Urlaubs- und Überstundenanträge, Genehmigungen</td>
+                      <td class="py-3 text-muted">Urlaubsanträge, Urlaubskonto</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bewertung</td>
+                      <td class="py-3 text-muted">Probezeitbeurteilung, Übernahme, Stellenwechsel, Beförderung</td>
+                      <td class="py-3 text-muted">Bewertungsbogen, Stellenänderungen</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Austritt</td>
+                      <td class="py-3 text-muted">Offboarding-Checkliste: Übergabe, Anlagenrückgabe, Account-Deaktivierung, Formalitäten</td>
+                      <td class="py-3 text-muted">Austrittseintrag, Freigabe von Anlagen</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständige Personalverwaltung vom Eintritt bis zum Austritt</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mitarbeiterstammdaten</h5>
+              <p class="text-muted mt-2">Mitarbeiterprofil mit Personalnummer, Eintrittsdatum, Position, Abteilung — einheitliche Stammdaten, nach mehreren Dimensionen durchsuchbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mitarbeiter-Lebenszyklus</h5>
+              <p class="text-muted mt-2">Wartet auf Onboarding → Probezeit → Aktiv → Offboarding → Inaktiv: 5 Status durchgängig in der Mitarbeiterakte, Filterung nach Status auf einen Blick.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Abteilungsstruktur</h5>
+              <p class="text-muted mt-2">Baumförmiges Organigramm: Abteilung → Unterabteilung, basierend auf dem integrierten departments-Plugin von NocoBase, mit Berechtigungen verknüpft.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Positionsstammdaten</h5>
+              <p class="text-muted mt-2">Positionsdefinitionen mit Karrierestufen (Junior / Mid / Senior / Experte); Mitarbeiter werden Positionen zugeordnet — ideal für Karrierepfade und Berechtigungsverwaltung.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Urlaubsgenehmigung</h5>
+              <p class="text-muted mt-2">8 Urlaubsarten (Jahresurlaub / Krankheit / privat / Freizeitausgleich / Hochzeit / Elternzeit / Trauerfall / sonstige); Genehmigungsprozess konfigurierbar nach Abteilung / direktem Vorgesetzten.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Feldbezogene Berechtigungen</h5>
+              <p class="text-muted mt-2">HR sieht Gehaltsfelder; Vorgesetzte sehen Basisinformationen ihres Teams — flexibel über NocoBase-Rollenberechtigungen konfigurierbar.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Weitere Funktionen in Entwicklung</h5>
+              <p class="text-muted small mt-2 mb-0">Geplant: Onboarding-/Offboarding-Checklisten, Probezeitbewertung, Vertrags- und Sozialversicherungsverwaltung, Bewerberverwaltung, Versetzungs-/Beförderungsverlauf</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Vertriebsmanagement, Helpdesk, Projektmanagement und Anlagenverwaltung.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseDE>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/de/solutions/project-management.astro
+++ b/src/pages/de/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseDE from "../../../layouts/BaseDE.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BaseDE
+  title="Projektmanagement – Open-Source schlanke Projektkollaboration | NocoBase"
+  description="Open-Source Projektmanagementsystem auf Basis der No-Code-Plattform NocoBase: zweistufige Verwaltung auf Projekt- und Aufgabenebene, Verantwortliche, Fortschritt, Meilensteine, Verzugswarnungen, Arbeitslast-Verteilung. Schlank und selbst hostbar, geeignet für KMU-Teams und abteilungsübergreifende Projekte."
+  keywords="Projektmanagement, Projektmanagement-Software, Aufgabenverwaltung, Open-Source Projektmanagement, schlanke Projektsteuerung, Projektkollaboration, Projektverfolgung, Meilensteinmanagement, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,336 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Projektmanagement-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Projektmanagement</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Zweistufige Verwaltung auf <strong>Projekt- und Aufgabenebene</strong>, mit Verantwortlichen, Fortschritt, Meilensteinen, Verzugswarnungen und Verteilung der Arbeitslast – schlank und selbst hostbar.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Zwei Ebenen: Projekt + Aufgabe</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Verzugswarnung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Meilensteinverfolgung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">Dienstleistungsprojekte</span>
+                  <span class="badge bg-soft-primary me-2">Interne IT</span>
+                  <span class="badge bg-soft-primary me-2">Abteilungsübergreifend</span>
+                  <span class="badge bg-soft-primary">KMU-Teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Oberfläche des Projektmanagementsystems" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Projektprozess</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Geschlossene Verfolgung vom Projektstart bis zum Projektabschluss – Meilensteine und Verzugswarnungen laufen automatisch</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Projektstart</div>
+                  <div class="small text-muted">Mit Kunde verknüpft</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Aufgabenaufteilung</div>
+                  <div class="small text-muted">Verantwortliche</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Fortschritt</div>
+                  <div class="small text-muted">Verzugswarnung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Meilensteine</div>
+                  <div class="small text-muted">Phasenlieferung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Abschluss</div>
+                  <div class="small opacity-75">Retrospektive</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Projektstart</td>
+                      <td class="py-3 text-muted">Projekt anlegen, mit Kunde (Dienstleistungsprojekt) oder Anlage (IT-Projekt) verknüpfen, Projektleitung benennen</td>
+                      <td class="py-3 text-muted">Projektstammdaten, Kundenverknüpfung, Verantwortliche</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Aufgabenaufteilung</td>
+                      <td class="py-3 text-muted">Aufgaben aufteilen, Verantwortliche, Start- und Endtermine sowie Abhängigkeiten festlegen</td>
+                      <td class="py-3 text-muted">Aufgabentabelle, Verantwortliche, Abhängigkeitsdiagramm</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Fortschritt</td>
+                      <td class="py-3 text-muted">Teammitglieder pflegen den Fortschritt; überfällige Aufgaben werden automatisch rot markiert</td>
+                      <td class="py-3 text-muted">Fortschritt in Prozent, Verzugsmarkierung</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Meilensteine</td>
+                      <td class="py-3 text-muted">Wichtige Punkte als Meilensteine definieren (Review / interne Tests / Go-Live); Phasenlieferungen erfassen</td>
+                      <td class="py-3 text-muted">Meilensteinliste, Lieferanlagen</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Abschluss</td>
+                      <td class="py-3 text-muted">Projekt abschließen und archivieren, Aufwand und Kosten festhalten</td>
+                      <td class="py-3 text-muted">Abschlussbericht, Aufwandsübersicht</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Schlanke Projektverfolgung vom Projektstart bis zum Abschluss</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/de/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/de/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Zwei Ebenen: Projekt + Aufgabe</h5>
+              <p class="text-muted mt-2">Ein Projekt wird in mehrere Aufgaben aufgeteilt; Verantwortliche, Termine und Fortschritt jeder Aufgabe werden eigenständig gepflegt; das Projekt-Board zeigt den Status aller Aufgaben.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/de/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/de/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Meilensteinmanagement</h5>
+              <p class="text-muted mt-2">Wichtige Punkte werden als Meilensteine definiert (Prototyp-Review, interner Test, Go-Live); der Projektfortschritt orientiert sich am Meilensteinrhythmus.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Verzugswarnung</h5>
+              <p class="text-muted mt-2">Überfällige Aufgaben werden automatisch rot markiert; die Liste verzögerter Projekte aktualisiert sich in Echtzeit, Risiken sind sofort sichtbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Verantwortliche und Auslastung</h5>
+              <p class="text-muted mt-2">Aufgabenanzahl und Arbeitslast werden je Verantwortlichem aggregiert; wer voll ausgelastet ist, wer freie Kapazität hat und wer häufig Verzögerungen hat, ist auf einen Blick erkennbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Projektstatus-Board</h5>
+              <p class="text-muted mt-2">KPI-Aggregation nach Projekttyp, Status und Verantwortlichem; laufende, abgeschlossene und verzögerte Projekte werden getrennt dargestellt.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Verknüpfung mit Kunde und Anlagen</h5>
+              <p class="text-muted mt-2">Projekte lassen sich mit Kunden (Dienstleistungsprojekte) und Anlagen (IT-Projekte) verknüpfen; auf der Kundendetailseite ist der Verlauf zugehöriger Projekte sichtbar.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Weitere Funktionen in Entwicklung</h5>
+              <p class="text-muted small mt-2 mb-0">Geplant: Aufgabenabhängigkeitsdiagramm, Zeiterfassung & Kostenberechnung, Liefergegenstandsarchiv, Gantt-Diagramm</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/de/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Vertriebsmanagement, Helpdesk, Anlagenverwaltung und HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseDE>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/de/solutions/project-management.astro
+++ b/src/pages/de/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Meilensteine</div>
                   <div class="small text-muted">Phasenlieferung</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Meilensteinmanagement</h5>
               <p class="text-muted mt-2">Wichtige Punkte werden als Meilensteine definiert (Prototyp-Review, interner Test, Go-Live); der Projektfortschritt orientiert sich am Meilensteinrhythmus.</p>

--- a/src/pages/de/solutions/sales-management.astro
+++ b/src/pages/de/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Forderungs-KPI</h5>
-              <p class="text-muted mt-2">Liste überfälliger Forderungen, Altersstrukturanalyse (Eimer 30 / 60 / 90 Tage); Aggregation nach Kunde und Vertriebler, Mahnwesen auf einen Blick.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Mehrwährung und Wechselkurse</h5>
-              <p class="text-muted mt-2">Angebote und Aufträge in USD, EUR, CNY und weiteren Währungen; Wechselkurspflege manuell oder per Import; die Heimwährungsumrechnung erfolgt automatisch.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Versand und Logistik</h5>
-              <p class="text-muted mt-2">Lieferscheine sind mit Auftrag und Sendungsnummer verknüpft; Mehrfach- und Teilversand werden unterstützt; der Status wird automatisch in den Auftrag übernommen.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Vertriebs-Dashboard</h5>

--- a/src/pages/de/solutions/sales-management.astro
+++ b/src/pages/de/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseDE from "../../../layouts/BaseDE.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseDE
+  title="Vertriebsmanagement – Open-Source Auftrags- und Forderungsmanagement | NocoBase"
+  description="Open-Source Vertriebsmanagementsystem auf Basis der No-Code-Plattform NocoBase: vollständige Kette aus Angebot, Vertriebsauftrag, Rechnung und Zahlungseingang; mit integriertem Genehmigungsprozess, Mehrwährungsunterstützung, Forderungs-KPIs und Verzugsanalyse."
+  keywords="Vertriebsmanagement, Auftragsverwaltung, Angebotsverwaltung, Rechnungsverwaltung, Forderungsmanagement, Zahlungseingang, Vertriebsprozess, Vertriebsgenehmigung, Open-Source Vertriebsmanagement, Mehrwährungs-Angebote, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Vertriebsmanagement-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Vertriebsmanagement</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Vollständige Kette aus <strong>Angebot → Auftrag → Rechnung → Zahlungseingang</strong>, mit integriertem Genehmigungs-Workflow, Mehrwährungs-Angeboten, Forderungs-KPIs und Verzugsanalyse.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mehrwährungs-Angebote</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Auftrags-Genehmigung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Forderungs-KPI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-Vertrieb</span>
+                  <span class="badge bg-soft-primary me-2">Exportgeschäft</span>
+                  <span class="badge bg-soft-primary me-2">Anlagenvertrieb</span>
+                  <span class="badge bg-soft-primary">Forderungsmanagement</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Oberfläche des Vertriebsmanagementsystems" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Vertriebsprozess</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Geschlossener Kreislauf vom Angebot bis zum Zahlungseingang – Genehmigung und Forderungs-KPI vollständig verbunden</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Angebot</div>
+                  <div class="small text-muted">Mehrwährung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Auftrag</div>
+                  <div class="small text-muted">Genehmigung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Versand</div>
+                  <div class="small text-muted">Sendungsverfolgung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Rechnung</div>
+                  <div class="small text-muted">Kundendaten vorausgefüllt</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Zahlungseingang</div>
+                  <div class="small opacity-75">Forderungs-KPI</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Angebot</td>
+                      <td class="py-3 text-muted">Kunde/Produkt wählen, Mehrwährungs-Angebot erstellen, mit Rabatt, Steuersatz und Gültigkeit</td>
+                      <td class="py-3 text-muted">Angebot, Positionen, PDF-Export</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Auftrag</td>
+                      <td class="py-3 text-muted">Angebot in Auftrag überführen; Sonderrabatte oder Großaufträge lösen Genehmigung aus</td>
+                      <td class="py-3 text-muted">Vertriebsauftrag, Genehmigungsprozess, Auftragspositionen</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Versand</td>
+                      <td class="py-3 text-muted">Nach Auftragsbestätigung Lieferschein erfassen, mit Sendungsnummer verknüpft</td>
+                      <td class="py-3 text-muted">Lieferschein, Sendungsnummer, Statusverlauf</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Rechnung</td>
+                      <td class="py-3 text-muted">Rechnungslegung nach Auftrag oder Versand; Steuernummer und Adresse aus Kundenstammdaten werden vorausgefüllt</td>
+                      <td class="py-3 text-muted">Rechnungsdatensatz, Rechnungsstatus</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Zahlungseingang</td>
+                      <td class="py-3 text-muted">Zahlungseingänge können in Teilbeträgen gebucht werden; Forderungs-KPI nach Altersstufen aggregiert</td>
+                      <td class="py-3 text-muted">Zahlungsbuchung, offene Forderung, Altersstufen</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständige Kette aus Angebot, Auftrag, Rechnung und Zahlungseingang – mit Genehmigung und Forderungsanalyse</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Angebotsverwaltung</h5>
+              <p class="text-muted mt-2">Mehrwährungs-Angebote mit Rabatten, Steuersätzen und Gültigkeit; PDF-Export per Klick zum Versand an den Kunden; direkte Umwandlung in einen Vertriebsauftrag.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vertriebsaufträge</h5>
+              <p class="text-muted mt-2">Auftragsstatus (Entwurf / in Prüfung / bestätigt / versandt / abgeschlossen), Kunden- und Produktverknüpfung, Positionen je Zeile editierbar.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Auftrags-Genehmigung</h5>
+              <p class="text-muted mt-2">Sonderrabatte, Großaufträge oder besondere Konditionen lösen den Genehmigungsprozess aus; Genehmiger lassen sich flexibel nach Abteilung, Position und Betragsschwelle konfigurieren.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Rechnungsverwaltung</h5>
+              <p class="text-muted mt-2">Aus dem Auftrag entsteht die Rechnung, Rechnungsstatus wird verfolgt; Steuernummer, Adresse und Anmerkungen aus den Kundenstammdaten werden vorausgefüllt – weniger Tippfehler.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Zahlungserfassung</h5>
+              <p class="text-muted mt-2">Teilzahlungen und Anzahlungen erfassen; offene Forderung wird automatisch berechnet; Zahlungsstatus je Kunde und je Auftrag aggregiert.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Forderungs-KPI</h5>
+              <p class="text-muted mt-2">Liste überfälliger Forderungen, Altersstrukturanalyse (Eimer 30 / 60 / 90 Tage); Aggregation nach Kunde und Vertriebler, Mahnwesen auf einen Blick.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mehrwährung und Wechselkurse</h5>
+              <p class="text-muted mt-2">Angebote und Aufträge in USD, EUR, CNY und weiteren Währungen; Wechselkurspflege manuell oder per Import; die Heimwährungsumrechnung erfolgt automatisch.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Versand und Logistik</h5>
+              <p class="text-muted mt-2">Lieferscheine sind mit Auftrag und Sendungsnummer verknüpft; Mehrfach- und Teilversand werden unterstützt; der Status wird automatisch in den Auftrag übernommen.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vertriebs-Dashboard</h5>
+              <p class="text-muted mt-2">Umsatz, Auftragszahl und Zahlungsquote werden je Vertriebler, Region und Produkt aggregiert; Monats- und Quartalstrends auf einen Blick.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Helpdesk, Projektmanagement, Anlagenverwaltung und HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseDE>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/de/solutions/ticketing-v2.astro
+++ b/src/pages/de/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseDE from "../../../layouts/BaseDE.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI-Powered Intelligent Ticketing System - NocoBase"
-  description="NocoBase AI-powered intelligent ticketing system with T-shaped data architecture supporting multiple business scenarios. AI employee team for auto-classification, smart replies, and knowledge recommendations. Full SLA monitoring for complete ticket lifecycle management."
-  keywords="NocoBase ticketing system, AI ticketing, intelligent customer service, SLA management, knowledge base, ticket classification"
+<BaseDE
+  title="Helpdesk (Tickets) – Open-Source Ticketsystem für den Kundenservice | NocoBase"
+  description="Open-Source Helpdesk-Software auf Basis der No-Code-Plattform NocoBase: Störungsmeldung, intelligente Zuweisung, SLA-Zeitmessung, Prioritätsstufen, AI-Klassifizierung, Zufriedenheitsbewertung, Service-Arbeitsplatz. Sofort einsatzbereit, geeignet für Customer-Service- und After-Sales-Teams in KMU."
+  keywords="Helpdesk-Software, Ticketsystem, Open-Source Helpdesk, Help Desk, Ticketing, Ticketverwaltung, SLA-Management, After-Sales-System, Kundenservice-System, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,336 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI-Powered<br/>Intelligent Ticketing</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Helpdesk-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Helpdesk (Tickets)</h1>
             <p class="para-desc text-muted">
-              Let support teams focus on solving problems, not navigating complex workflows. Built on NocoBase no-code platform with T-shaped data architecture for unified multi-business management. AI employee team powers the entire ticket lifecycle from creation to closure.
+              Auf der No-Code-Plattform NocoBase aufgebaut. Vollständige Kette von <strong>Störungsmeldung → intelligente Zuweisung → Bearbeitung → Zufriedenheitsbewertung</strong>, mit integrierter SLA-Zeitmessung, Prioritätsverwaltung, AI-Klassifizierung und Service-Arbeitsplatz.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Multi-source Intake</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI Smart Routing</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Full SLA Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Auto Knowledge Capture</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Automatische SLA-Zeitmessung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 Prioritätsstufen</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI-Klassifizierung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Equipment Repair</span>
-                  <span class="badge bg-soft-primary me-2">IT Support</span>
-                  <span class="badge bg-soft-primary me-2">Customer Complaints</span>
-                  <span class="badge bg-soft-primary">Inquiries</span>
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">Customer Service / After-Sales</span>
+                  <span class="badge bg-soft-primary me-2">IT-Servicedesk</span>
+                  <span class="badge bg-soft-primary me-2">Anlagenwartung</span>
+                  <span class="badge bg-soft-primary">SaaS-Support</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha version is now live. Try it out - we're actively improving.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Oberfläche des Helpdesk-Ticketsystems" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Enterprises face diverse service requests with scattered sources, varying workflows, and lack of unified management</p>
+            <h4 class="title mb-4">Ticket-Bearbeitungsprozess</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Geschlossener Kreislauf von der Störungsmeldung bis zur Schlussbewertung – durchgehend mit SLA-Zeitmessung</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High Cost, Slow Customization</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Fragmented Systems, Data Silos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Slow Response, No Transparency</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Quality Hard to Ensure</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Knowledge Can't Accumulate</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Missing AI Capabilities</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Universal ticketing platform built on NocoBase no-code: unified intake, smart distribution, multi-business support, closed-loop feedback</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-source Intake</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI Smart Routing</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Full SLA Monitoring</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">T-Shaped Data Architecture</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Equipment Repair</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT Support</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">AI Employee Team</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Erstellung</div>
+                  <div class="small text-muted">Mehrkanal</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Klassifizierung</div>
+                  <div class="small text-muted">AI-Erkennung</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Zuweisung</div>
+                  <div class="small text-muted">Regelbasiert</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Bearbeitung</div>
+                  <div class="small text-muted">SLA-Messung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Bewertung</div>
+                  <div class="small opacity-75">Abschluss und Ablage</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Erstellung</td>
+                      <td class="py-3 text-muted">Eingang per E-Mail, Formular oder Messenger; verknüpft mit Kunde und Produkt</td>
+                      <td class="py-3 text-muted">Ticketnummer, Quelle, Kundenstammdaten</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Klassifizierung</td>
+                      <td class="py-3 text-muted">AI erkennt die Problemkategorie (Konto / Funktion / Bug) und setzt die Priorität</td>
+                      <td class="py-3 text-muted">Kategorie-Tag, Priorität, Konfidenz</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Zuweisung</td>
+                      <td class="py-3 text-muted">Regelbasierte Weiterleitung an Team oder Mitarbeitenden; dringende Tickets benachrichtigen den Bereitschaftsdienst</td>
+                      <td class="py-3 text-muted">Verantwortliche Person, Zuweisungsprotokoll, Team-Queue</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bearbeitung</td>
+                      <td class="py-3 text-muted">Mitarbeitende bearbeiten das Ticket und kommunizieren mit dem Kunden; SLA-Zähler läuft, Warnung vor Überschreitung</td>
+                      <td class="py-3 text-muted">Bearbeitungsprotokoll, SLA-Status, Wartegrund</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bewertung</td>
+                      <td class="py-3 text-muted">Beim Abschluss Bewertung anfordern (1-5 Sterne + Kommentar); Aggregation nach Mitarbeiter / Produkt</td>
+                      <td class="py-3 text-muted">Zufriedenheitsdaten, archivierte Tickets, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständige Ticketverwaltung von der Annahme bis zum Abschluss</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA-Zeitmessung und Warnungen</h5>
+              <p class="text-muted mt-2">Reaktions- und Lösungsfristen werden je Priorität automatisch berechnet; Warnung vor Überschreitung, überfällige Tickets erscheinen rot; SLA-Erfüllungsquote wird im Dashboard angezeigt.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 Prioritätsstufen</h5>
+              <p class="text-muted mt-2">Dringend, hoch, mittel und niedrig – jeweils mit unterschiedlichen Reaktionszeiten; dringende Tickets werden automatisch oben angepinnt und der Bereitschaftsdienst informiert.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI-Klassifizierung</h5>
+              <p class="text-muted mt-2">Neue Tickets werden per AI automatisch der Problemkategorie zugeordnet (Konto, Funktion, Bug-Report u. a.) und regelbasiert dem zuständigen Team zugewiesen.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Differenzierte Wartegründe</h5>
+              <p class="text-muted mt-2">"Wartet auf Kundenantwort", "Wartet auf Drittpartei", "Anforderung in Prüfung" – wartende Tickets werden nicht zur SLA-Überschreitung gezählt.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Service-Arbeitsplatz</h5>
+              <p class="text-muted mt-2">Nach dem Login sehen Mitarbeitende ihre Tickets direkt; sortiert nach Fälligkeit – offen, in Bearbeitung und kurz vor Überschreitung auf einen Blick.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ticket-Dashboard</h5>
+              <p class="text-muted mt-2">Verteilung von heute neuen, abgeschlossenen, offenen und überfälligen Tickets; Aggregation nach Mitarbeitendem, Kunde und Produktlinie für den Gesamtüberblick.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Weitere Funktionen in Entwicklung</h5>
+              <p class="text-muted small mt-2 mb-0">Geplant: Zufriedenheitsbewertung, Weiterleitungs- und Eskalationsprozess, Antwortvorlagen, Wissensdatenbank-Integration</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Vertriebsmanagement, Projektmanagement, Anlagenverwaltung und HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/de/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseDE>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/de/solutions/ticketing.astro
+++ b/src/pages/de/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseDE from "../../../layouts/BaseDE.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BaseDE
+  title="Helpdesk (Tickets) – Open-Source Ticketsystem für den Kundenservice | NocoBase"
+  description="Open-Source Helpdesk-Software auf Basis der No-Code-Plattform NocoBase: Störungsmeldung, intelligente Zuweisung, SLA-Zeitmessung, Prioritätsstufen, AI-Klassifizierung, Zufriedenheitsbewertung, Service-Arbeitsplatz. Sofort einsatzbereit, geeignet für Customer-Service- und After-Sales-Teams in KMU."
+  keywords="Helpdesk-Software, Ticketsystem, Open-Source Helpdesk, Help Desk, Ticketing, Ticketverwaltung, SLA-Management, After-Sales-System, Kundenservice-System, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,336 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/de/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One-Business-System</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Helpdesk-Modul</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Helpdesk (Tickets)</h1>
+            <p class="para-desc text-muted">
+              Auf der No-Code-Plattform NocoBase aufgebaut. Vollständige Kette von <strong>Störungsmeldung → intelligente Zuweisung → Bearbeitung → Zufriedenheitsbewertung</strong>, mit integrierter SLA-Zeitmessung, Prioritätsverwaltung, AI-Klassifizierung und Service-Arbeitsplatz.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Automatische SLA-Zeitmessung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 Prioritätsstufen</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI-Klassifizierung</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open Source und kostenlos</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Einsatzszenarien:</span>
+                  <span class="badge bg-soft-primary me-2">Customer Service / After-Sales</span>
+                  <span class="badge bg-soft-primary me-2">IT-Servicedesk</span>
+                  <span class="badge bg-soft-primary me-2">Anlagenwartung</span>
+                  <span class="badge bg-soft-primary">SaaS-Support</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+              <a href="/de/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Gesamtlösung ansehen</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Oberfläche des Helpdesk-Ticketsystems" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Ticket-Bearbeitungsprozess</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Geschlossener Kreislauf von der Störungsmeldung bis zur Schlussbewertung – durchgehend mit SLA-Zeitmessung</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/de/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/de/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Erstellung</div>
+                  <div class="small text-muted">Mehrkanal</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Klassifizierung</div>
+                  <div class="small text-muted">AI-Erkennung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Zuweisung</div>
+                  <div class="small text-muted">Regelbasiert</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Bearbeitung</div>
+                  <div class="small text-muted">SLA-Messung</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Bewertung</div>
+                  <div class="small opacity-75">Abschluss und Ablage</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Phase</th>
+                      <th class="border-0 py-3">Wichtige Aktionen</th>
+                      <th class="border-0 py-3">Systemeinträge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Erstellung</td>
+                      <td class="py-3 text-muted">Eingang per E-Mail, Formular oder Messenger; verknüpft mit Kunde und Produkt</td>
+                      <td class="py-3 text-muted">Ticketnummer, Quelle, Kundenstammdaten</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Klassifizierung</td>
+                      <td class="py-3 text-muted">AI erkennt die Problemkategorie (Konto / Funktion / Bug) und setzt die Priorität</td>
+                      <td class="py-3 text-muted">Kategorie-Tag, Priorität, Konfidenz</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Zuweisung</td>
+                      <td class="py-3 text-muted">Regelbasierte Weiterleitung an Team oder Mitarbeitenden; dringende Tickets benachrichtigen den Bereitschaftsdienst</td>
+                      <td class="py-3 text-muted">Verantwortliche Person, Zuweisungsprotokoll, Team-Queue</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bearbeitung</td>
+                      <td class="py-3 text-muted">Mitarbeitende bearbeiten das Ticket und kommunizieren mit dem Kunden; SLA-Zähler läuft, Warnung vor Überschreitung</td>
+                      <td class="py-3 text-muted">Bearbeitungsprotokoll, SLA-Status, Wartegrund</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bewertung</td>
+                      <td class="py-3 text-muted">Beim Abschluss Bewertung anfordern (1-5 Sterne + Kommentar); Aggregation nach Mitarbeiter / Produkt</td>
+                      <td class="py-3 text-muted">Zufriedenheitsdaten, archivierte Tickets, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/de/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/de/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/de/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Kernfunktionen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vollständige Ticketverwaltung von der Annahme bis zum Abschluss</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA-Zeitmessung und Warnungen</h5>
+              <p class="text-muted mt-2">Reaktions- und Lösungsfristen werden je Priorität automatisch berechnet; Warnung vor Überschreitung, überfällige Tickets erscheinen rot; SLA-Erfüllungsquote wird im Dashboard angezeigt.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 Prioritätsstufen</h5>
+              <p class="text-muted mt-2">Dringend, hoch, mittel und niedrig – jeweils mit unterschiedlichen Reaktionszeiten; dringende Tickets werden automatisch oben angepinnt und der Bereitschaftsdienst informiert.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI-Klassifizierung</h5>
+              <p class="text-muted mt-2">Neue Tickets werden per AI automatisch der Problemkategorie zugeordnet (Konto, Funktion, Bug-Report u. a.) und regelbasiert dem zuständigen Team zugewiesen.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Differenzierte Wartegründe</h5>
+              <p class="text-muted mt-2">"Wartet auf Kundenantwort", "Wartet auf Drittpartei", "Anforderung in Prüfung" – wartende Tickets werden nicht zur SLA-Überschreitung gezählt.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Service-Arbeitsplatz</h5>
+              <p class="text-muted mt-2">Nach dem Login sehen Mitarbeitende ihre Tickets direkt; sortiert nach Fälligkeit – offen, in Bearbeitung und kurz vor Überschreitung auf einen Blick.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ticket-Dashboard</h5>
+              <p class="text-muted mt-2">Verteilung von heute neuen, abgeschlossenen, offenen und überfälligen Tickets; Aggregation nach Mitarbeitendem, Kunde und Produktlinie für den Gesamtüberblick.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Weitere Funktionen in Entwicklung</h5>
+              <p class="text-muted small mt-2 mb-0">Geplant: Zufriedenheitsbewertung, Weiterleitungs- und Eskalationsprozess, Antwortvorlagen, Wissensdatenbank-Integration</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Herunterladen und einsetzen</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dieses Modul ist Bestandteil der Backup-Vorlage des All-in-One-Business-Systems und wird gemeinsam ausgerollt</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Backup-Vorlage herunterladen</h5>
+                <p class="text-muted mt-2">Backup der Gesamtlösung; nach dem Restore stehen die Beispieldaten dieses Moduls und der weiteren fünf Module zur Verfügung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata-Backup herunterladen</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Alternativ: SQL-Paket herunterladen</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installationsanleitung</h5>
+                <p class="text-muted mt-2">Detaillierte Restore-Schritte, häufige Fragen und Hinweise – in Vorbereitung</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Demnächst verfügbar</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Jetzt starten</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Dieses Modul ist auch im <a href="/de/solutions/all-in-one">All-in-One-Business-System</a> enthalten – einzeln nutzbar oder im Zusammenspiel mit CRM, Vertriebsmanagement, Projektmanagement, Anlagenverwaltung und HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo ausprobieren</a>
+            <a href="/de/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Kontakt aufnehmen</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseDE>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/en/solutions/all-in-one.astro
+++ b/src/pages/en/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseEN from "../../../layouts/BaseEN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseEN
+  title="All-in-One Business Suite - CRM / Help Desk / Project Management / IT Assets / HR | NocoBase"
+  description="Open-source all-in-one business suite: CRM, sales management, help desk ticketing, project management, IT asset management, and HR — six modules in one platform. Built on NocoBase no-code, ready out of the box for small and mid-sized teams."
+  keywords="all-in-one business suite, open source CRM, CRM software, help desk software, ticketing system, project management software, IT asset management, fixed asset management, HRMS, HR management software, sales management, no-code ERP, integrated business platform, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">All-in-One<br/>Business Suite</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. Covers six modules: <strong>CRM, sales management, help desk, project management, IT asset management, and HR</strong>.
+              Ready out of the box — no procurement decisions, no integration project between multiple systems.
+            </p>
+
+            <!-- Core value -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Multiple systems integrated</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">20+ languages built in</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI employees + workflow</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open source, free</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Use case tags -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">Startups</span>
+                  <span class="badge bg-soft-primary me-2">Multi-line stores</span>
+                  <span class="badge bg-soft-primary me-2">Business exploration</span>
+                  <span class="badge bg-soft-primary">Training & education</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Try the demo
+              </a>
+              <a href="/en/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Contact us
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="All-in-One Business Suite" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Six modules, one system</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, sales management, help desk, project management, IT asset management, and HR — the full business loop lives in a single system</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- CRM -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Customer Management)</h5>
+              <p class="text-muted mt-2">Open-source CRM: full pipeline from lead to follow-up, conversion, merge and dedupe; customer 360 view aggregates orders, tickets, projects, and assets.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Lead stage management and conversion</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Customer 360 detail view</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Merge / dedupe tools</li>
+              </ul>
+              <a href="/en/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sales -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sales Management</h5>
+              <p class="text-muted mt-2">Sales orders end to end: quotes, orders, invoices, payments. Built-in approval workflow and accounts receivable analysis.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Multi-currency quotes</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Order approval workflow</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Overdue receivables KPI</li>
+              </ul>
+              <a href="/en/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Help Desk -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Ticketing)</h5>
+              <p class="text-muted mt-2">Customer issue reporting, dispatch, handling, and satisfaction review. SLA timing, priority management, and granular wait reasons.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>SLA auto-timing with overdue alerts</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Ticket dashboard + team workbench</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4-tier priority + AI classification</li>
+              </ul>
+              <a href="/en/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project Management -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Project Management</h5>
+              <p class="text-muted mt-2">Lightweight project tracking with project + task two-level management. Owners, progress, milestones, and overdue alerts.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Project status board</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Task owner workload</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Overdue project alerts</li>
+              </ul>
+              <a href="/en/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Asset Management -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">IT Asset Management</h5>
+              <p class="text-muted mt-2">Full lifecycle management of IT and office assets — procurement, assignment, maintenance, disposal — backed by a vendor ledger.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Asset assignment / return</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Maintenance tickets</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Procurement and vendor analysis</li>
+              </ul>
+              <a href="/en/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR Management</h5>
+              <p class="text-muted mt-2">Employee records, onboarding, offboarding, leave, and probation tracking, aligned with position and department structure.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Onboarding / offboarding checklists</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Leave approval</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Probation employee board</li>
+              </ul>
+              <a href="/en/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Learn more <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Platform foundation</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Built on NocoBase 2.x with AI, workflow, multi-language, and multi-workspace capabilities</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI employees</h5>
+            <p class="text-muted small">Built-in AI roles such as Lina (localization), Lexi (translation), and Atlas (collaboration), invoked per business scenario.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Multi-language support</h5>
+            <p class="text-muted small">20+ languages built in — Chinese, English, Japanese, Korean, German, French, and more — with full UI translation.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Workflow engine</h5>
+            <p class="text-muted small">Approval, notification, SLA timing, and scheduled triggers. Visual orchestration — no code needed to configure rules.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Multi-workspace isolation</h5>
+            <p class="text-muted small">One system serves multiple teams or stores with isolated data and independently managed permissions.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI collaboration</span>
+            <h4 class="title mb-4">Built-in AI employees</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Nine preset AI employees covering typical business roles, with MCP-based extensibility for external agents</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Team lead — task dispatch and collaboration orchestration</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Front-end engineer — UI and JS block code generation</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Visual design — charts and dashboard layout</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Insight analysis — trend detection and KPI interpretation</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Research analysis — information gathering and summarization</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Data tidying — cleansing, merging, and batch processing</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Translation — multilingual customer conversations and email</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Localization engineer — UI copy and i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Email assistant — intent analysis and reply drafting</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Custom AI employees</h6>
+              <p class="text-muted small mb-0">Create your own roles, prompts, and skill sets to fit your business</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">External agent integration</h6>
+              <p class="text-muted small mb-0">Connect your own agents and toolchains via the MCP protocol</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Use cases</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Where the integrated suite fits especially well</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Cross-functional, single-system view</h5>
+                  <p class="text-muted mb-0">Business spans sales, service, and projects. Teams want one system to see the whole picture instead of switching between separate tools.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Multi-line stores</h5>
+                  <p class="text-muted mb-0">Stores handle sales, after-sales, and project delivery. Many business lines, limited headcount — standalone tools come with high coordination cost.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Business exploration stage</h5>
+                  <p class="text-muted mb-0">The business model is not yet locked in. Avoid committing too early to a single tool — the integrated platform can be used immediately and iterated as needs evolve.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Training / education / POC</h5>
+                  <p class="text-muted mb-0">A complete reference for NocoBase platform capabilities. Suitable for internal training, solution walkthroughs, and proof of concept across typical business processes.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">How to deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy and start using the all-in-one suite</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Install NocoBase</h5>
+                <p class="text-muted mt-2">Follow the official guide to deploy NocoBase locally or on a server</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/en/get-started/quickstart" target="_blank" class="btn btn-primary">Installation guide</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download the backup template</h5>
+                <p class="text-muted mt-2">After restore, all six modules are populated with preset data</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Start using the all-in-one suite</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            An integrated business system built on NocoBase 2.x. The template can be used and extended as is; contact us if you need a deeper, business-specific customization.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Try the demo
+            </a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Contact us
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseEN>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/en/solutions/asset-management.astro
+++ b/src/pages/en/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseEN from "../../../layouts/BaseEN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseEN
+  title="IT Asset Management — Open Source IT and Office Asset Management | NocoBase"
+  description="Open-source asset management built on the NocoBase no-code platform: procurement, assignment, maintenance, and disposal — full lifecycle management for IT and office assets, with vendor ledger, maintenance tickets, and procurement analytics."
+  keywords="IT asset management, fixed asset management, asset management software, open source asset management, office asset tracking, asset lifecycle management, equipment management, asset inventory, vendor management, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">IT Asset Management module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">IT Asset Management</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. Full lifecycle: <strong>procurement → assignment → maintenance → disposal</strong>. Covers IT and office assets, backed by a vendor ledger and maintenance ticketing.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Full lifecycle</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Maintenance tickets</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Vendor ledger</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">IT assets</span>
+                  <span class="badge bg-soft-primary me-2">Office assets</span>
+                  <span class="badge bg-soft-primary me-2">Equipment leasing</span>
+                  <span class="badge bg-soft-primary">Asset inventory</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="IT asset management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Asset lifecycle</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From procurement to disposal — every asset is traceable end to end</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Procurement</div>
+                  <div class="small text-muted">Linked vendor</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Receipt</div>
+                  <div class="small text-muted">Asset record</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Assignment</div>
+                  <div class="small text-muted">Signed handover</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Maintenance</div>
+                  <div class="small text-muted">Linked tickets</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Disposal</div>
+                  <div class="small opacity-75">Residual value</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Procurement</td>
+                      <td class="py-3 text-muted">Purchase order linked to vendor and price; supports multiple categories and quantities</td>
+                      <td class="py-3 text-muted">PO record, vendor, purchase amount</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Receipt</td>
+                      <td class="py-3 text-muted">On receipt, an asset record is generated automatically (asset ID, serial number, warranty captured in one step)</td>
+                      <td class="py-3 text-muted">Asset record, unique ID, warranty</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Assignment</td>
+                      <td class="py-3 text-muted">Assign assets to employees / customers / departments with signed confirmation</td>
+                      <td class="py-3 text-muted">Assignment record, holder, start / end dates</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Maintenance</td>
+                      <td class="py-3 text-muted">Issue maintenance tickets for failures or scheduled servicing, linked to the asset record</td>
+                      <td class="py-3 text-muted">Maintenance ticket, cumulative cost</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Disposal</td>
+                      <td class="py-3 text-muted">Record disposal reason (damaged / retired / sold), depreciation, and residual value</td>
+                      <td class="py-3 text-muted">Disposal record, residual value, disposition</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Complete fixed asset management from procurement to disposal</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Asset procurement</h5>
+              <p class="text-muted mt-2">PO linked to vendor and price. On receipt, an asset record is generated automatically — asset ID, serial number, and warranty captured in one step.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Assignment / return</h5>
+              <p class="text-muted mt-2">Assign assets to employees or customers with signed handover. Returns release the assignment automatically; each asset has a full traceable history.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Maintenance tickets</h5>
+              <p class="text-muted mt-2">Failures or scheduled servicing open maintenance tickets, linked to the asset record. Cumulative cost informs disposal decisions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Disposal / sale</h5>
+              <p class="text-muted mt-2">Record disposal reason (damaged / retired / sold). Depreciation and residual value are kept on file, consistent with finance reconciliation.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vendor ledger</h5>
+              <p class="text-muted mt-2">Vendor profiles with full procurement history. Purchase amount, categories, and payment terms are visible at a glance, supporting sourcing decisions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Asset dashboard</h5>
+              <p class="text-muted mt-2">Total, in-use, under maintenance, and disposed asset distribution. Aggregate by type, department, or holder; export inventory data in one click.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">More features in development</h5>
+              <p class="text-muted small mt-2 mb-0">Planned: inventory check tasks, depreciation calculation, QR code scanning, asset request approval flow</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, sales management, help desk, project management, and HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseEN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/en/solutions/crm-v2.astro
+++ b/src/pages/en/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseEN from "../../../layouts/BaseEN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 Sales Management System - NocoBase"
-  description="CRM 2.0 sales management system built on NocoBase no-code platform. Modular design with complete sales cycle. Supports AI-assisted lead scoring, opportunity win-rate prediction, and more."
-  keywords="NocoBase CRM, AI CRM, sales management, opportunity management, customer relationship management, lead management, no-code CRM"
+<BaseEN
+  title="CRM Customer Management — Open Source, Self-Hosted | NocoBase"
+  description="Open-source CRM built on the NocoBase no-code platform: lead management, follow-up, conversion, merge/dedupe, and customer 360 view. Ready out of the box, self-hostable."
+  keywords="CRM software, open source CRM, customer management system, customer relationship management, lead management, customer follow-up, customer 360, no-code CRM, self-hosted CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sales Management System</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Customer Management</h1>
             <p class="para-desc text-muted">
-              Built on NocoBase no-code platform. Modular design with complete sales cycle. Workflow automation handles routine tasks, AI assists with lead scoring, opportunity analysis, and more.
+              Built on the NocoBase no-code platform. Covers the full pipeline — lead, follow-up, conversion, merge/dedupe — with a customer 360 view that aggregates orders, tickets, projects, and asset history.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Smart Lead Scoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Win-Rate Prediction</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Customer Health Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Modular Design</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Lead stage management</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Customer 360 view</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Merge / dedupe</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">B2B Sales</span>
-                  <span class="badge bg-soft-primary me-2">Project Sales</span>
-                  <span class="badge bg-soft-primary me-2">Foreign Trade</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">B2B sales</span>
+                  <span class="badge bg-soft-primary me-2">Project-based sales</span>
+                  <span class="badge bg-soft-primary me-2">Export trade</span>
+                  <span class="badge bg-soft-primary">Small and mid teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Sales teams face multiple challenges in daily operations</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM customer management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inconsistent Lead Quality</h5>
-              </div>
-              <p class="text-muted mb-0">Large volumes of leads with varying quality. Sales waste time on low-quality leads while high-value ones get overlooked.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Delayed Opportunity Follow-up</h5>
-              </div>
-              <p class="text-muted mb-0">Opportunities stall without progress. Sales managers struggle to track team pipeline health, missing optimal closing windows.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Scattered Customer Data</h5>
-              </div>
-              <p class="text-muted mb-0">Customer data scattered across emails, chats, and documents. No complete customer profile for targeted marketing.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inaccurate Sales Forecasts</h5>
-              </div>
-              <p class="text-muted mb-0">Forecasting based on gut feeling without data support. Large prediction gaps affect resource allocation and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High SaaS Costs</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot and other SaaS CRMs charge per seat. Custom development takes long with unpredictable costs.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Data Security Concerns</h5>
-              </div>
-              <p class="text-muted mb-0">Customer and opportunity data stored on third-party clouds, not meeting data localization and privacy compliance requirements.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 system built on NocoBase no-code platform. Workflow automation + AI assistance</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Smart Lead Scoring</h5>
-              <p class="text-muted mt-2">Auto-evaluate lead quality, prioritize high-value leads, recommend optimal contact times</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Win-Rate Prediction</h5>
-              <p class="text-muted mt-2">Predict close probability based on historical data, identify at-risk deals, provide stage progression suggestions</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Customer Health Monitoring</h5>
-              <p class="text-muted mt-2">360-degree customer profile, health scoring, churn risk alerts, proactive relationship maintenance</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Modular Design</h5>
-              <p class="text-muted mt-2">Independent module design, minimal setup requires only Customers + Opportunities, scale as needed</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">Complete Sales Cycle</h4>
-            <p class="para-desc mx-auto text-muted mb-0">From lead acquisition to customer success, unified data flow with AI assistance at every stage</p>
+            <h4 class="title mb-4">Customer management pipeline</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From lead intake to customer 360 view — data flows end to end</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Multi-channel</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Follow-up</div>
+                  <div class="small text-muted">Logged history</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversion</div>
+                  <div class="small text-muted">Customer record</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Customer 360</div>
+                  <div class="small text-muted">Full view</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Insights</div>
+                  <div class="small opacity-75">Sales dashboard</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Stage Conversion</th>
-                      <th class="border-0 py-3">Trigger</th>
-                      <th class="border-0 py-3">AI Assistance</th>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Customer</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Form, import, or manual entry; tag source and owner</td>
+                      <td class="py-3 text-muted">Lead pool, source tags, stage transitions</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Customer → Opportunity</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">AI analyzes intent, recommends creating opportunity</td>
+                      <td class="py-3">Follow-up</td>
+                      <td class="py-3 text-muted">Log calls, emails, and visits; set next follow-up time</td>
+                      <td class="py-3 text-muted">Follow-up timeline, next-action reminders</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Opportunity → Quote</td>
-                      <td class="py-3 text-muted">Enters proposal stage</td>
-                      <td class="py-3 text-primary">AI pricing suggestions, competitor comparison, tiered pricing</td>
+                      <td class="py-3">Conversion</td>
+                      <td class="py-3 text-muted">Convert lead to customer; fill customer record (industry / size / contacts)</td>
+                      <td class="py-3 text-muted">Customer table, contact table, linked lead</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Quote → Order</td>
-                      <td class="py-3 text-muted">Customer accepts quote</td>
-                      <td class="py-3 text-primary">Auto-generate order with product details and pricing</td>
+                      <td class="py-3">Customer 360</td>
+                      <td class="py-3 text-muted">See the full picture: orders, tickets, projects, assets</td>
+                      <td class="py-3 text-muted">Embedded blocks, cross-module relationships</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Insights</td>
+                      <td class="py-3 text-muted">Sales dashboard aggregates KPIs by rep, region, type</td>
+                      <td class="py-3 text-muted">Charts, drill-down details, export</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Assistance</span>
-            <h4 class="title mb-4">AI Assistance Capabilities</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Through workflow AI nodes, assist with scoring, analysis, writing, and other repetitive tasks</p>
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, customers, follow-ups, dashboards — the full daily workflow for customer relationship management</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Workflow Node</span></h5>
-              <span class="badge bg-soft-primary mb-2">Sales Scout</span>
-              <p class="text-muted mt-2 small">Deep opportunity analysis, win-rate prediction, competitive intelligence, deal strategy suggestions</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lead import</h5>
+              <p class="text-muted mt-2">Three intake paths: Excel batch import, form collection, and API. Visual field mapping and automatic dedupe on conflict.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Insights Analyst</span>
-              <p class="text-muted mt-2 small">Smart lead scoring, customer health assessment, sales data analysis, pipeline forecasting</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Stage transitions</h5>
+              <p class="text-muted mt-2">Visually configure lead stages (new / contacted / converted / lost). Stage changes are logged automatically and conversion rates are computed in real time.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Editor Assistant</span>
-              <p class="text-muted mt-2 small">Email sentiment/intent analysis, reply drafting, communication summary</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Follow-up records</h5>
+              <p class="text-muted mt-2">Log every visit, call, and email. The timeline view shows the full conversation history, making handoffs effortless.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Daily Planning</span>
-              <p class="text-muted mt-2 small">Daily priorities, next action suggestions, follow-up planning</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Follow-up reminders</h5>
+              <p class="text-muted mt-2">Automatic notification before the next follow-up date. Long-inactive customers move to a "needs re-engagement" board so nothing gets forgotten.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language customer communication, content translation, foreign trade email handling</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Customer 360 view</h5>
+              <p class="text-muted mt-2">The customer detail page aggregates orders, tickets, projects, and assets — the full picture on one screen, no system switching required.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">More AI Employees</h5>
-              <span class="badge bg-soft-secondary mb-2">Expanding</span>
-              <p class="text-muted mt-2 small">More specialized AI employees can be added based on business needs</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Categories and tags</h5>
+              <p class="text-muted mt-2">Tag customers across multiple dimensions: type, industry, size, source. Filter and aggregate by any tag combination.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Flexible Architecture</span>
-            <h4 class="title mb-4">Modular Design</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Each module designed independently, can be toggled on/off. Scale your solution to fit your needs</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Module</th>
-                  <th class="border-0 py-3">Required</th>
-                  <th class="border-0 py-3">Description</th>
-                  <th class="border-0 py-3">AI Capabilities</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Customer Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Opportunity Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Lead Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Quote Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Order Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Product Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Email Integration</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Full Suite</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Standard</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Lite</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Trade</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Merge and dedupe</h5>
+              <p class="text-muted mt-2">Duplicate entries for the same customer are detected automatically. Merge in one click — follow-up history and related records are preserved.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sales dashboard</h5>
+              <p class="text-muted mt-2">KPIs aggregated by rep, region, and customer type: new customers, conversion rate, active customer distribution.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Field and row-level permissions</h5>
+              <p class="text-muted mt-2">Configure visible fields by role. Sales reps see only their own customers; managers see all.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value from Automation</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Workflow automation + AI assistance reduces repetitive work, letting sales focus on customer relationships</p>
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS CRM and custom development</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimension</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">Custom Dev</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of box</td>
-                  <td class="py-3 text-muted">Months of development</td>
-                  <td class="py-3 text-primary">Configure and go, quick launch</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexible customization</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Assistance</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">Workflow AI nodes, use as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Module Flexibility</td>
-                  <td class="py-3 text-muted">Bundled features</td>
-                  <td class="py-3 text-muted">Code changes needed</td>
-                  <td class="py-3 text-primary">Modular, scale as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">Per-seat subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">One-time purchase, long-term use</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy CRM 2.0 system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/" target="_blank" class="btn btn-outline-primary">Solution Docs</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Restore Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with sales management, help desk, project management, IT asset management, and HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/en/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseEN>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/en/solutions/crm.astro
+++ b/src/pages/en/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseEN from "../../../layouts/BaseEN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="No-code, Flexible & Powerful CRM Platform"
-  description="Ready to use out of the box. Provides ultimate customization capabilities while ensuring complete data sovereignty. You can extend fields, blocks, functions, and pages on this foundation to make it fully meet your business needs."
-  keywords="NocoBase CRM, Customer Relationship Management, No-code CRM, Open Source CRM, Custom CRM"
+<BaseEN
+  title="CRM Customer Management — Open Source, Self-Hosted | NocoBase"
+  description="Open-source CRM built on the NocoBase no-code platform: lead management, follow-up, conversion, merge/dedupe, and customer 360 view. Ready out of the box, self-hostable."
+  keywords="CRM software, open source CRM, customer management system, customer relationship management, lead management, customer follow-up, customer 360, no-code CRM, self-hosted CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">No-code, Flexible & Powerful<br/>CRM Platform</h1>
-            <p class="para-desc text-muted">Ready to use out of the box, with powerful customization to fit your unique needs. Extend fields, blocks, and pages to build the perfect solution for your business—all while keeping full control of your data.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Customer Management</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. Covers the full pipeline — lead, follow-up, conversion, merge/dedupe — with a customer 360 view that aggregates orders, tickets, projects, and asset history.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Lead stage management</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Customer 360 view</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Merge / dedupe</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">B2B sales</span>
+                  <span class="badge bg-soft-primary me-2">Project-based sales</span>
+                  <span class="badge bg-soft-primary me-2">Export trade</span>
+                  <span class="badge bg-soft-primary">Small and mid teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM customer management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase CRM Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Unlike SaaS and other CRM systems, NocoBase CRM is flexible and fully controlled</p>
+            <h4 class="title mb-4">Customer management pipeline</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From lead intake to customer 360 view — data flows end to end</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Completely No-Code</h5>
-              <p class="text-muted mt-2">No programming skills required for CRM customization</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Covers Common CRM Features</h5>
-              <p class="text-muted mt-2">Customer management, sales pipeline, opportunity tracking, contact management, email communication, approval processes and more</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easily Modifiable & Extensible</h5>
-              <p class="text-muted mt-2">Supports custom fields, processes and business logic, flexible architecture makes "secondary development" simple</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Full Data Control</h5>
-              <p class="text-muted mt-2">Complete control over system code and data, ensuring enterprise data security</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Try NocoBase CRM Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Quick experience with just a few clicks</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Dashboard Data Visualization</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Interactive Demo
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Multi-channel</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Follow-up</div>
+                  <div class="small text-muted">Logged history</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversion</div>
+                  <div class="small text-muted">Customer record</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Customer 360</div>
+                  <div class="small text-muted">Full view</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Insights</div>
+                  <div class="small opacity-75">Sales dashboard</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Lead Conversion Process</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Form, import, or manual entry; tag source and owner</td>
+                      <td class="py-3 text-muted">Lead pool, source tags, stage transitions</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Follow-up</td>
+                      <td class="py-3 text-muted">Log calls, emails, and visits; set next follow-up time</td>
+                      <td class="py-3 text-muted">Follow-up timeline, next-action reminders</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Conversion</td>
+                      <td class="py-3 text-muted">Convert lead to customer; fill customer record (industry / size / contacts)</td>
+                      <td class="py-3 text-muted">Customer table, contact table, linked lead</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Customer 360</td>
+                      <td class="py-3 text-muted">See the full picture: orders, tickets, projects, assets</td>
+                      <td class="py-3 text-muted">Embedded blocks, cross-module relationships</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Insights</td>
+                      <td class="py-3 text-muted">Sales dashboard aggregates KPIs by rep, region, type</td>
+                      <td class="py-3 text-muted">Charts, drill-down details, export</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, customers, follow-ups, dashboards — the full daily workflow for customer relationship management</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lead import</h5>
+              <p class="text-muted mt-2">Three intake paths: Excel batch import, form collection, and API. Visual field mapping and automatic dedupe on conflict.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Stage transitions</h5>
+              <p class="text-muted mt-2">Visually configure lead stages (new / contacted / converted / lost). Stage changes are logged automatically and conversion rates are computed in real time.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Follow-up records</h5>
+              <p class="text-muted mt-2">Log every visit, call, and email. The timeline view shows the full conversation history, making handoffs effortless.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Follow-up reminders</h5>
+              <p class="text-muted mt-2">Automatic notification before the next follow-up date. Long-inactive customers move to a "needs re-engagement" board so nothing gets forgotten.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Customer 360 view</h5>
+              <p class="text-muted mt-2">The customer detail page aggregates orders, tickets, projects, and assets — the full picture on one screen, no system switching required.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Categories and tags</h5>
+              <p class="text-muted mt-2">Tag customers across multiple dimensions: type, industry, size, source. Filter and aggregate by any tag combination.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Merge and dedupe</h5>
+              <p class="text-muted mt-2">Duplicate entries for the same customer are detected automatically. Merge in one click — follow-up history and related records are preserved.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sales dashboard</h5>
+              <p class="text-muted mt-2">KPIs aggregated by rep, region, and customer type: new customers, conversion rate, active customer distribution.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Field and row-level permissions</h5>
+              <p class="text-muted mt-2">Configure visible fields by role. Sales reps see only their own customers; managers see all.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with sales management, help desk, project management, IT asset management, and HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseEN>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/en/solutions/hr-management.astro
+++ b/src/pages/en/solutions/hr-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseEN from "../../../layouts/BaseEN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseEN
+  title="HR Management — Open Source Human Resource Management | NocoBase"
+  description="Open-source HR management built on the NocoBase no-code platform: employee records, onboarding, offboarding, leave, probation tracking, and position / department structure. Lightweight and self-hostable for small and mid-sized HR teams."
+  keywords="HRMS, HR management software, human resource management system, open source HR, employee management software, onboarding software, offboarding, leave approval, probation tracking, organizational structure, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">HR module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR Management</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. Employee records with end-to-end tracking for <strong>onboarding, offboarding, leave, and probation</strong>, aligned with position and department structure.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Onboarding / offboarding checklists</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Leave approval</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Probation board</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">Small / mid businesses</span>
+                  <span class="badge bg-soft-primary me-2">Chain stores</span>
+                  <span class="badge bg-soft-primary me-2">Industry HR</span>
+                  <span class="badge bg-soft-primary">Cross-team coordination</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="HR management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Employee lifecycle</h4>
+            <p class="para-desc mx-auto text-muted mb-0">A full HR management loop from recruiting to offboarding</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Recruiting</div>
+                  <div class="small text-muted">Candidates</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Onboarding</div>
+                  <div class="small text-muted">Checklist tracking</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Active employee</div>
+                  <div class="small text-muted">Attendance & leave</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Evaluation</div>
+                  <div class="small text-muted">Confirm / transfer</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Offboarding</div>
+                  <div class="small opacity-75">Handover & archive</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Recruiting</td>
+                      <td class="py-3 text-muted">Capture candidate details and interview evaluations; convert to employee record on hire</td>
+                      <td class="py-3 text-muted">Candidate table, interview scores</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Onboarding</td>
+                      <td class="py-3 text-muted">Onboarding task checklist (sign contract, issue badge, hand out equipment, create accounts)</td>
+                      <td class="py-3 text-muted">Onboarding checklist, contract file</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Active employee</td>
+                      <td class="py-3 text-muted">Day-to-day attendance, leave, time off, and overtime approval</td>
+                      <td class="py-3 text-muted">Leave records, balance</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Evaluation</td>
+                      <td class="py-3 text-muted">Probation review, confirmation, transfer, promotion</td>
+                      <td class="py-3 text-muted">Evaluation form, position changes</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Offboarding</td>
+                      <td class="py-3 text-muted">Offboarding checklist: handover, return assets, disable accounts, complete paperwork</td>
+                      <td class="py-3 text-muted">Offboarding record, asset release</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Complete HR management from onboarding to offboarding</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Employee Roster</h5>
+              <p class="text-muted mt-2">Employee profiles with employee number, hire date, position, department — unified records, searchable by multiple dimensions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Employee Lifecycle</h5>
+              <p class="text-muted mt-2">Pending onboarding → probation → active → offboarding → inactive: 5 statuses across the employee record; filter by status at a glance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Department Structure</h5>
+              <p class="text-muted mt-2">Tree-shaped org chart: department → sub-department, based on NocoBase's built-in departments plugin, linked with permissions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Position Records</h5>
+              <p class="text-muted mt-2">Position definitions with job level (junior / mid / senior / expert); employees linked to positions for career path and permission management.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Leave Approval</h5>
+              <p class="text-muted mt-2">8 leave types (annual / sick / personal / compensatory / marriage / parental / bereavement / other); approval flow configurable by department / direct manager.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Field-Level Permissions</h5>
+              <p class="text-muted mt-2">HR sees salary fields; managers see basic info of their team — flexible config via NocoBase role permissions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">More features in development</h5>
+              <p class="text-muted small mt-2 mb-0">Planned: onboarding / offboarding checklists, probation evaluation, contract & social insurance management, recruitment & candidates, transfer / promotion records</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, sales management, help desk, project management, and IT asset management.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseEN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/en/solutions/project-management.astro
+++ b/src/pages/en/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseEN from "../../../layouts/BaseEN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BaseEN
+  title="Project Management — Open Source Lightweight Project Collaboration | NocoBase"
+  description="Open-source project management built on the NocoBase no-code platform: two-level project + task model, owners, progress, milestones, overdue alerts, and workload distribution. Lightweight and self-hostable for small-to-mid teams and cross-functional projects."
+  keywords="project management software, project management system, task management software, open source project management, lightweight project management, task tracking, project collaboration, milestone tracking, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,337 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Project Management module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Project Management</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. A two-level <strong>project + task</strong> model covering owners, progress, milestones, overdue alerts, and workload distribution. Lightweight and self-hostable.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Project + task two-level</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Overdue alerts</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Milestone tracking</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">Delivery projects</span>
+                  <span class="badge bg-soft-primary me-2">Internal IT</span>
+                  <span class="badge bg-soft-primary me-2">Cross-functional work</span>
+                  <span class="badge bg-soft-primary">Small and mid teams</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Project management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Project lifecycle</h4>
+            <p class="para-desc mx-auto text-muted mb-0">A full tracking loop from kickoff to closure, with milestones and overdue alerts running in the background</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Kickoff</div>
+                  <div class="small text-muted">Link customer</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Task breakdown</div>
+                  <div class="small text-muted">Owners</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Progress</div>
+                  <div class="small text-muted">Overdue alerts</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Milestone</div>
+                  <div class="small text-muted">Stage delivery</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Closure</div>
+                  <div class="small opacity-75">Review and archive</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Kickoff</td>
+                      <td class="py-3 text-muted">Create project, link to customer (delivery projects) or asset (IT projects), assign project manager</td>
+                      <td class="py-3 text-muted">Project record, customer link, owner</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Task breakdown</td>
+                      <td class="py-3 text-muted">Decompose into tasks with owners, start/end dates, and dependencies</td>
+                      <td class="py-3 text-muted">Task table, owners, dependency graph</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Progress</td>
+                      <td class="py-3 text-muted">Members update task progress; overdue tasks are flagged automatically</td>
+                      <td class="py-3 text-muted">Progress percentage, overdue flag</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Milestone</td>
+                      <td class="py-3 text-muted">Mark key checkpoints as milestones (review / beta / launch); register deliverables for each stage</td>
+                      <td class="py-3 text-muted">Milestone list, deliverable attachments</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Closure</td>
+                      <td class="py-3 text-muted">Close and archive on completion; record hours and cost</td>
+                      <td class="py-3 text-muted">Closure report, hours summary</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Lightweight project tracking from kickoff to closure</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Project + task two-level</h5>
+              <p class="text-muted mt-2">One project breaks down into multiple tasks. Each task tracks its own owner, dates, and progress. The project board shows the full task status view.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Milestone management</h5>
+              <p class="text-muted mt-2">Mark key checkpoints as milestones (prototype review, beta, launch). Project progress is presented by milestone cadence.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Overdue alerts</h5>
+              <p class="text-muted mt-2">Tasks past their due date are flagged in red. The overdue project list refreshes in real time so managers can see risk at a glance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Owners and workload</h5>
+              <p class="text-muted mt-2">Aggregate task counts and workload by owner. Who is overloaded, who has bandwidth, who is repeatedly late — visible to managers at a glance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Project status board</h5>
+              <p class="text-muted mt-2">KPIs aggregated by project type, status, and owner. Active, closed, and overdue projects are grouped for quick scanning.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Linked customers and assets</h5>
+              <p class="text-muted mt-2">Projects can link to customers (delivery projects) and assets (IT projects). The customer detail page shows the related project history.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">More features in development</h5>
+              <p class="text-muted small mt-2 mb-0">Planned: task dependency graph, time logging & cost, deliverable archive, Gantt chart view</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, sales management, help desk, IT asset management, and HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseEN>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/en/solutions/project-management.astro
+++ b/src/pages/en/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Milestone</div>
                   <div class="small text-muted">Stage delivery</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Milestone management</h5>
               <p class="text-muted mt-2">Mark key checkpoints as milestones (prototype review, beta, launch). Project progress is presented by milestone cadence.</p>

--- a/src/pages/en/solutions/sales-management.astro
+++ b/src/pages/en/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseEN from "../../../layouts/BaseEN.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseEN
+  title="Sales Management — Open Source Sales Order and Receivables | NocoBase"
+  description="Open-source sales management built on the NocoBase no-code platform: quotes, sales orders, invoices, and payments end to end. Built-in approval workflow, multi-currency, accounts receivable KPIs, and overdue analysis."
+  keywords="sales management software, sales order management, quote management, invoice management, accounts receivable, payment tracking, sales workflow, sales approval, open source sales, multi-currency quotes, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Sales Management module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sales Management</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. End-to-end flow: <strong>quote → order → invoice → payment</strong>. Built-in sales approval workflow, multi-currency quotes, accounts receivable KPIs, and overdue analysis.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Multi-currency quotes</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Order approval workflow</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Receivables KPIs</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">B2B sales</span>
+                  <span class="badge bg-soft-primary me-2">Export orders</span>
+                  <span class="badge bg-soft-primary me-2">Equipment sales</span>
+                  <span class="badge bg-soft-primary">Receivables management</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Sales management interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Sales pipeline</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From quote to payment — approval and receivables KPIs run end to end</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Quote</div>
+                  <div class="small text-muted">Multi-currency</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Order</div>
+                  <div class="small text-muted">Approval flow</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Shipment</div>
+                  <div class="small text-muted">Logistics tracking</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Invoice</div>
+                  <div class="small text-muted">Auto-fill</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Payment</div>
+                  <div class="small opacity-75">Receivables KPI</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Quote</td>
+                      <td class="py-3 text-muted">Pick customer / products, generate multi-currency quote with discount, tax, and validity</td>
+                      <td class="py-3 text-muted">Quote record, line items, PDF export</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Order</td>
+                      <td class="py-3 text-muted">Convert quote to order; large discounts or large orders trigger approval</td>
+                      <td class="py-3 text-muted">Sales order, approval flow, line items</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Shipment</td>
+                      <td class="py-3 text-muted">After order confirmation, log shipments with carrier tracking numbers</td>
+                      <td class="py-3 text-muted">Shipment record, tracking number, status</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Invoice</td>
+                      <td class="py-3 text-muted">Issue invoice from order or shipment; customer tax ID and address auto-fill from profile</td>
+                      <td class="py-3 text-muted">Invoice record, billing status</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Payment</td>
+                      <td class="py-3 text-muted">Log payments by installment; aggregate receivables KPIs by aging</td>
+                      <td class="py-3 text-muted">Payment record, AR balance, aging buckets</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Quote, order, invoice, payment end to end — with approval workflow and receivables analytics</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quote management</h5>
+              <p class="text-muted mt-2">Multi-currency quotes with discount, tax, and validity. Export to PDF in one click and convert to sales orders when accepted.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sales orders</h5>
+              <p class="text-muted mt-2">Order status transitions (draft / under review / confirmed / shipped / closed). Customer and product linkage; line items are editable row by row.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Order approval workflow</h5>
+              <p class="text-muted mt-2">Large discounts, large orders, and special terms trigger approval. Configure approver nodes flexibly by department, role, and amount threshold.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Invoice management</h5>
+              <p class="text-muted mt-2">Issue invoices from orders and track billing status. Tax ID, address, and notes auto-fill from the customer profile to reduce manual error.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Payment records</h5>
+              <p class="text-muted mt-2">Log partial and installment payments. AR balance recalculates automatically; payment status aggregates by customer and by order.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Accounts receivable KPIs</h5>
+              <p class="text-muted mt-2">Overdue receivables list and aging analysis (30 / 60 / 90 day buckets). Aggregate by customer or rep — collection priorities are immediately clear.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Multi-currency and FX</h5>
+              <p class="text-muted mt-2">USD / EUR / CNY quotes and orders. An FX rate table supports manual updates or imports; base-currency totals are converted automatically.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Shipment and logistics</h5>
+              <p class="text-muted mt-2">Shipments link to orders and carrier tracking numbers. Supports multiple and partial shipments; order status syncs automatically.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sales dashboard</h5>
+              <p class="text-muted mt-2">Aggregate revenue, order count, and collection rate by rep, region, and product. Monthly and quarterly trends at a glance.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, help desk, project management, IT asset management, and HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseEN>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/en/solutions/sales-management.astro
+++ b/src/pages/en/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Accounts receivable KPIs</h5>
-              <p class="text-muted mt-2">Overdue receivables list and aging analysis (30 / 60 / 90 day buckets). Aggregate by customer or rep — collection priorities are immediately clear.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-currency and FX</h5>
-              <p class="text-muted mt-2">USD / EUR / CNY quotes and orders. An FX rate table supports manual updates or imports; base-currency totals are converted automatically.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Shipment and logistics</h5>
-              <p class="text-muted mt-2">Shipments link to orders and carrier tracking numbers. Supports multiple and partial shipments; order status syncs automatically.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Sales dashboard</h5>

--- a/src/pages/en/solutions/ticketing-v2.astro
+++ b/src/pages/en/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseEN from "../../../layouts/BaseEN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI-Powered Intelligent Ticketing System - NocoBase"
-  description="NocoBase AI-powered intelligent ticketing system with T-shaped data architecture supporting multiple business scenarios. AI employee team for auto-classification, smart replies, and knowledge recommendations. Full SLA monitoring for complete ticket lifecycle management."
-  keywords="NocoBase ticketing system, AI ticketing, intelligent customer service, SLA management, knowledge base, ticket classification"
+<BaseEN
+  title="Help Desk — Open Source Ticketing System | NocoBase"
+  description="Open-source help desk built on the NocoBase no-code platform: customer issue reporting, smart dispatch, SLA timing, priority, AI classification, satisfaction reviews, and a service workbench. Ready out of the box for small support and after-sales teams."
+  keywords="help desk software, ticketing system, open source help desk, customer service software, IT service desk, SLA management, after-sales system, customer support software, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,337 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI-Powered<br/>Intelligent Ticketing</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Help Desk module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Ticketing)</h1>
             <p class="para-desc text-muted">
-              Let support teams focus on solving problems, not navigating complex workflows. Built on NocoBase no-code platform with T-shaped data architecture for unified multi-business management. AI employee team powers the entire ticket lifecycle from creation to closure.
+              Built on the NocoBase no-code platform. End-to-end flow: <strong>customer issue → smart dispatch → handling → satisfaction review</strong>. Built-in SLA timing, priority management, AI classification, and a service workbench.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Multi-source Intake</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI Smart Routing</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Full SLA Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Auto Knowledge Capture</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA auto-timing</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4-tier priority</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI classification</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Equipment Repair</span>
-                  <span class="badge bg-soft-primary me-2">IT Support</span>
-                  <span class="badge bg-soft-primary me-2">Customer Complaints</span>
-                  <span class="badge bg-soft-primary">Inquiries</span>
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">Customer support</span>
+                  <span class="badge bg-soft-primary me-2">IT service desk</span>
+                  <span class="badge bg-soft-primary me-2">Equipment maintenance</span>
+                  <span class="badge bg-soft-primary">SaaS support</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha version is now live. Try it out - we're actively improving.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Help desk ticketing interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Enterprises face diverse service requests with scattered sources, varying workflows, and lack of unified management</p>
+            <h4 class="title mb-4">Ticket lifecycle</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From customer issue to closure and review — SLA timing across the entire flow</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High Cost, Slow Customization</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Fragmented Systems, Data Silos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Slow Response, No Transparency</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Quality Hard to Ensure</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Knowledge Can't Accumulate</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Missing AI Capabilities</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Universal ticketing platform built on NocoBase no-code: unified intake, smart distribution, multi-business support, closed-loop feedback</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-source Intake</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI Smart Routing</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Full SLA Monitoring</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">T-Shaped Data Architecture</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Equipment Repair</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT Support</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">AI Employee Team</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Create</div>
+                  <div class="small text-muted">Multi-channel</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classify</div>
+                  <div class="small text-muted">AI detection</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Dispatch</div>
+                  <div class="small text-muted">Group rules</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Handle</div>
+                  <div class="small text-muted">SLA timing</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Review</div>
+                  <div class="small opacity-75">Close and archive</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Create</td>
+                      <td class="py-3 text-muted">Submit via email, form, or IM; link to customer and product</td>
+                      <td class="py-3 text-muted">Ticket ID, source, customer profile</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classify</td>
+                      <td class="py-3 text-muted">AI detects issue category (account / feature / bug) and sets priority</td>
+                      <td class="py-3 text-muted">Category tag, priority, confidence score</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Dispatch</td>
+                      <td class="py-3 text-muted">Route to the right group / agent; urgent tickets notify on-call staff</td>
+                      <td class="py-3 text-muted">Assignee, dispatch log, group queue</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Handle</td>
+                      <td class="py-3 text-muted">Agent works the ticket and communicates with the customer; SLA timing with pre-breach alerts</td>
+                      <td class="py-3 text-muted">Handling log, SLA status, wait reasons</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Review</td>
+                      <td class="py-3 text-muted">On close, request customer rating (1–5 stars + text); aggregate by agent / product</td>
+                      <td class="py-3 text-muted">Satisfaction records, archived ticket, KPIs</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">The full daily help desk workflow, from intake to closure</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA timing and alerts</h5>
+              <p class="text-muted mt-2">Response and resolution deadlines are calculated by priority. Alerts fire before breach; overdue tickets turn red. SLA attainment surfaces on the dashboard.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Four-tier priority</h5>
+              <p class="text-muted mt-2">Urgent, high, medium, and low, each with its own response window. Urgent tickets are pinned to the top and notify on-call staff.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI classification</h5>
+              <p class="text-muted mt-2">New tickets are categorized automatically (account issue, feature question, bug report, etc.) and dispatched to the right group by rule.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Wait-reason granularity</h5>
+              <p class="text-muted mt-2">"Waiting on customer," "waiting on third party," "needs review" — time spent in wait states does not count toward SLA breach.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Service workbench</h5>
+              <p class="text-muted mt-2">Agents land directly on their assigned tickets, sorted by due time. One screen shows pending, in-progress, and near-breach work.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ticket dashboard</h5>
+              <p class="text-muted mt-2">Today's new / closed / pending / overdue distribution. Aggregate by agent, customer, or product line for a full management view.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">More features in development</h5>
+              <p class="text-muted small mt-2 mb-0">Planned: satisfaction rating, transfer & escalation flow, reply templates & macros, knowledge base integration</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, sales management, project management, IT asset management, and HR.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/en/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseEN>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/en/solutions/ticketing.astro
+++ b/src/pages/en/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseEN from "../../../layouts/BaseEN.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BaseEN
+  title="Help Desk — Open Source Ticketing System | NocoBase"
+  description="Open-source help desk built on the NocoBase no-code platform: customer issue reporting, smart dispatch, SLA timing, priority, AI classification, satisfaction reviews, and a service workbench. Ready out of the box for small support and after-sales teams."
+  keywords="help desk software, ticketing system, open source help desk, customer service software, IT service desk, SLA management, after-sales system, customer support software, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,337 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/en/solutions/all-in-one" class="text-muted small text-decoration-none">All-in-One Business Suite</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">Help Desk module</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Ticketing)</h1>
+            <p class="para-desc text-muted">
+              Built on the NocoBase no-code platform. End-to-end flow: <strong>customer issue → smart dispatch → handling → satisfaction review</strong>. Built-in SLA timing, priority management, AI classification, and a service workbench.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA auto-timing</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4-tier priority</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI classification</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, free</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Use cases:</span>
+                  <span class="badge bg-soft-primary me-2">Customer support</span>
+                  <span class="badge bg-soft-primary me-2">IT service desk</span>
+                  <span class="badge bg-soft-primary me-2">Equipment maintenance</span>
+                  <span class="badge bg-soft-primary">SaaS support</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+              <a href="/en/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>See full solution</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Help desk ticketing interface" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Ticket lifecycle</h4>
+            <p class="para-desc mx-auto text-muted mb-0">From customer issue to closure and review — SLA timing across the entire flow</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Create</div>
+                  <div class="small text-muted">Multi-channel</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classify</div>
+                  <div class="small text-muted">AI detection</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Dispatch</div>
+                  <div class="small text-muted">Group rules</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Handle</div>
+                  <div class="small text-muted">SLA timing</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Review</div>
+                  <div class="small opacity-75">Close and archive</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Stage</th>
+                      <th class="border-0 py-3">Key actions</th>
+                      <th class="border-0 py-3">System records</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Create</td>
+                      <td class="py-3 text-muted">Submit via email, form, or IM; link to customer and product</td>
+                      <td class="py-3 text-muted">Ticket ID, source, customer profile</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classify</td>
+                      <td class="py-3 text-muted">AI detects issue category (account / feature / bug) and sets priority</td>
+                      <td class="py-3 text-muted">Category tag, priority, confidence score</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Dispatch</td>
+                      <td class="py-3 text-muted">Route to the right group / agent; urgent tickets notify on-call staff</td>
+                      <td class="py-3 text-muted">Assignee, dispatch log, group queue</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Handle</td>
+                      <td class="py-3 text-muted">Agent works the ticket and communicates with the customer; SLA timing with pre-breach alerts</td>
+                      <td class="py-3 text-muted">Handling log, SLA status, wait reasons</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Review</td>
+                      <td class="py-3 text-muted">On close, request customer rating (1–5 stars + text); aggregate by agent / product</td>
+                      <td class="py-3 text-muted">Satisfaction records, archived ticket, KPIs</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Core features</h4>
+            <p class="para-desc mx-auto text-muted mb-0">The full daily help desk workflow, from intake to closure</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA timing and alerts</h5>
+              <p class="text-muted mt-2">Response and resolution deadlines are calculated by priority. Alerts fire before breach; overdue tickets turn red. SLA attainment surfaces on the dashboard.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Four-tier priority</h5>
+              <p class="text-muted mt-2">Urgent, high, medium, and low, each with its own response window. Urgent tickets are pinned to the top and notify on-call staff.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI classification</h5>
+              <p class="text-muted mt-2">New tickets are categorized automatically (account issue, feature question, bug report, etc.) and dispatched to the right group by rule.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Wait-reason granularity</h5>
+              <p class="text-muted mt-2">"Waiting on customer," "waiting on third party," "needs review" — time spent in wait states does not count toward SLA breach.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Service workbench</h5>
+              <p class="text-muted mt-2">Agents land directly on their assigned tickets, sorted by due time. One screen shows pending, in-progress, and near-breach work.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ticket dashboard</h5>
+              <p class="text-muted mt-2">Today's new / closed / pending / overdue distribution. Aggregate by agent, customer, or product line for a full management view.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">More features in development</h5>
+              <p class="text-muted small mt-2 mb-0">Planned: satisfaction rating, transfer & escalation flow, reply templates & macros, knowledge base integration</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download and deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">This module is included in the all-in-one suite backup template and is deployed together</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Download backup template</h5>
+                <p class="text-muted mt-2">All-in-one backup. After restore, all six modules — including this one — are populated with preset data.</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Download .nbdata backup</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Or download the SQL archive</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installation docs</h5>
+                <p class="text-muted mt-2">Detailed restore steps, FAQs, and notes — currently in preparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Coming soon</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Get started</h3>
+          <p class="text-muted para-desc mx-auto mb-0">This module is also part of the <a href="/en/solutions/all-in-one">All-in-One Business Suite</a>. Use it standalone, or together with CRM, sales management, project management, IT asset management, and HR.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Try the demo</a>
+            <a href="/en/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contact us</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseEN>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/es/solutions/all-in-one.astro
+++ b/src/pages/es/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseES from "../../../layouts/BaseES.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseES
+  title="Sistema de Gestión Empresarial Integral - CRM / Tickets / Proyectos / Activos / RRHH | NocoBase"
+  description="Sistema de gestión empresarial integral de código abierto: CRM, gestión de ventas, help desk, gestión de proyectos, gestión de activos y recursos humanos integrados en 6 módulos. Construido sobre la plataforma no-code de NocoBase, listo para usar y adecuado para equipos pequeños y medianos."
+  keywords="sistema de gestión empresarial integral, sistema CRM, CRM open source, sistema de tickets, software help desk, sistema de gestión de proyectos, gestión de activos TI, sistema RRHH, software RRHH, gestión de ventas, ERP no-code, sistema todo en uno, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Sistema<br/>de Gestión Integral</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Cubre seis módulos: <strong>CRM (Gestión de Clientes), Gestión de Ventas, Help Desk (Tickets), Gestión de Proyectos, Gestión de Activos y Recursos Humanos</strong>.
+              Listo para usar, sin necesidad de seleccionar e integrar varios sistemas independientes.
+            </p>
+
+            <!-- Valores principales -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Integración multisistema</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Más de 20 idiomas incluidos</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Empleados de AI + workflows</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Código abierto y gratuito</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Etiquetas de casos de uso -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Empresas emergentes</span>
+                  <span class="badge bg-soft-primary me-2">Locales con varias líneas de negocio</span>
+                  <span class="badge bg-soft-primary me-2">Fase exploratoria del negocio</span>
+                  <span class="badge bg-soft-primary">Docencia y formación</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Probar la Demo
+              </a>
+              <a href="/es/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Contactar
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Sistema de Gestión Integral" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 módulos integrados</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, Gestión de Ventas, Help Desk, Gestión de Proyectos, Gestión de Activos y Recursos Humanos — todos los procesos de negocio se cierran dentro del mismo sistema</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- Gestión de clientes -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Gestión de Clientes)</h5>
+              <p class="text-muted mt-2">Sistema CRM open source: flujo completo de lead, seguimiento, conversión y deduplicación; vista 360 del cliente que agrega pedidos, tickets, proyectos y activos del histórico.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Gestión de etapas y conversión de leads</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Vista de detalle 360 del cliente</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Herramientas de fusión / deduplicación</li>
+              </ul>
+              <a href="/es/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestión de ventas -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de Ventas</h5>
+              <p class="text-muted mt-2">Gestión de pedidos de venta: ciclo completo de presupuesto, pedido, factura y cobro; incluye workflows de aprobación y análisis de cuentas por cobrar.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Presupuestos multidivisa</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Workflow de aprobación de pedidos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI de cuentas vencidas</li>
+              </ul>
+              <a href="/es/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Help Desk -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Tickets)</h5>
+              <p class="text-muted mt-2">Sistema de tickets de atención al cliente: incidencias del cliente, asignación, tratamiento y valoración de satisfacción; soporta cronometraje SLA, gestión de prioridades y motivos de espera detallados.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Cronometraje SLA automático y avisos de vencimiento</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Dashboard de tickets + escritorio del equipo</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 niveles de prioridad + clasificación con AI</li>
+              </ul>
+              <a href="/es/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestión de proyectos -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de Proyectos</h5>
+              <p class="text-muted mt-2">Gestión de proyectos ligera: gestión a dos niveles de proyectos y tareas; incluye responsables, progreso, hitos y avisos de retraso.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Panel de estado de proyectos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Carga de trabajo por responsable</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Avisos de proyectos retrasados</li>
+              </ul>
+              <a href="/es/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestión de activos -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de Activos</h5>
+              <p class="text-muted mt-2">Gestión integral del ciclo de vida de activos TI y de oficina: compra, asignación, mantenimiento y baja, con registro de proveedores asociado.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Asignación / devolución de activos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tickets de mantenimiento</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Análisis de compras y proveedores</li>
+              </ul>
+              <a href="/es/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Recursos Humanos -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Recursos Humanos</h5>
+              <p class="text-muted mt-2">Sistema de gestión de recursos humanos: ficha del empleado, incorporación, baja, vacaciones y seguimiento del periodo de prueba, combinado con la estructura de puestos y departamentos.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Listas de incorporación / baja</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Aprobación de vacaciones</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Panel de empleados en periodo de prueba</li>
+              </ul>
+              <a href="/es/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Más información <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Capacidades de la plataforma base</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Basado en NocoBase 2.x, con AI, workflows, multilenguaje y multiespacio incorporados</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>Empleados de AI</h5>
+            <p class="text-muted small">Lina (localización), Lexi (traducción), Atlas (coordinación) y otros roles de AI integrados, invocables por escenario de negocio.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Soporte multilenguaje</h5>
+            <p class="text-muted small">Más de 20 idiomas incluidos (español, chino, inglés, japonés, coreano, alemán, francés, etc.); toda la UI está traducida.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Motor de workflows</h5>
+            <p class="text-muted small">Aprobaciones, notificaciones, cronometraje SLA, disparadores programados; configuración visual sin necesidad de programar.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Aislamiento multiespacio</h5>
+            <p class="text-muted small">Un mismo sistema sirve a varios equipos o locales, con datos aislados y permisos gestionados de forma independiente.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">Colaboración con AI</span>
+            <h4 class="title mb-4">Empleados de AI incluidos</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 empleados de AI preconfigurados cubren los roles de negocio habituales y permiten conectar agentes externos mediante el protocolo MCP</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Responsable del equipo — asignación de tareas y coordinación</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Frontend — generación de interfaces y bloques JS</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Diseño visual — gráficos y paneles</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Insights — detección de tendencias y lectura de KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Investigación — recopilación y resumen de información</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Tratamiento de datos — limpieza, fusión y normalización</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Traducción — conversaciones y correos multilingüe con clientes</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Localización — textos de interfaz e i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Asistente de correo — análisis de intención y borradores de respuesta</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Empleado de AI personalizado</h6>
+              <p class="text-muted small mb-0">Crea roles, prompts y combinaciones de habilidades según tu negocio</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Conexión de agentes externos</h6>
+              <p class="text-muted small mb-0">Protocolo MCP para conectar tus propios agentes y herramientas</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Casos de uso</h4>
+            <p class="para-desc mx-auto text-muted mb-0">La solución integral resulta especialmente útil en los siguientes escenarios</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Gestión global multilínea de negocio</h5>
+                  <p class="text-muted mb-0">El negocio abarca ventas, atención al cliente y proyectos. Se necesita una visión global en un único sistema, sin cambiar entre herramientas independientes.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Locales con varias líneas de negocio</h5>
+                  <p class="text-muted mb-0">El local cubre ventas, postventa y entrega de proyectos. Muchas líneas de negocio pero tamaño reducido: el coste de coordinar soluciones independientes es alto.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Fase exploratoria del negocio</h5>
+                  <p class="text-muted mb-0">El negocio todavía no está definido. Evita atarse a una solución concreta demasiado pronto: la plataforma integral puede usarse desde el principio e iterar según evolucionen las necesidades.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Docencia / formación / POC</h5>
+                  <p class="text-muted mb-0">Como ejemplo completo de las capacidades de NocoBase, sirve para formación interna, demos de soluciones o pruebas de concepto que cubran procesos de negocio habituales.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">¿Cómo se usa?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Tres pasos para desplegar el Sistema de Gestión Integral</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Instalar NocoBase</h5>
+                <p class="text-muted mt-2">Sigue la documentación oficial para desplegar NocoBase en local o en un servidor</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Guía de instalación</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Tras la restauración dispondrás de todos los datos preconfigurados de los 6 módulos</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Empieza a usar el Sistema de Gestión Integral</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Sistema integrado de gestión empresarial construido sobre NocoBase 2.x. La plantilla se puede reutilizar y ampliar directamente; si necesitas una personalización profunda para un negocio concreto, contáctanos.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Probar la Demo
+            </a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Contactar
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseES>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/es/solutions/asset-management.astro
+++ b/src/pages/es/solutions/asset-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseES from "../../../layouts/BaseES.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseES
+  title="Sistema de Gestión de Activos — open source para activos TI y de oficina | NocoBase"
+  description="Sistema de gestión de activos open source basado en la plataforma no-code de NocoBase: gestión del ciclo de vida completo (compra, asignación, mantenimiento y baja) para activos TI y de oficina, con registro de proveedores, tickets de mantenimiento y análisis de compras."
+  keywords="gestión de activos TI, sistema de gestión de activos, gestión de activos de oficina, gestión de activos open source, ciclo de vida de activos, sistema de gestión de equipos, inventario de activos, gestión de proveedores, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestión de Activos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistema de Gestión de Activos</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Gestión integral del ciclo de vida <strong>compra → asignación → mantenimiento → baja</strong>, cubriendo activos TI y de oficina, con registro de proveedores y tickets de mantenimiento.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Ciclo de vida completo</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tickets de mantenimiento</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Registro de proveedores</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Activos TI</span>
+                  <span class="badge bg-soft-primary me-2">Activos de oficina</span>
+                  <span class="badge bg-soft-primary me-2">Alquiler de equipos</span>
+                  <span class="badge bg-soft-primary">Inventario de activos</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Interfaz del sistema de gestión de activos" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ciclo de vida del activo</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo cerrado desde la compra y entrada en almacén hasta la baja, con cada activo trazable</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Compra</div>
+                  <div class="small text-muted">Proveedor</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Entrada</div>
+                  <div class="small text-muted">Ficha de activo</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Asignación</div>
+                  <div class="small text-muted">Firma del receptor</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Mantenimiento</div>
+                  <div class="small text-muted">Tickets</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Baja</div>
+                  <div class="small opacity-75">Valor residual</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Compra</td>
+                      <td class="py-3 text-muted">Orden de compra vinculada al proveedor y al precio, con varias categorías y cantidades</td>
+                      <td class="py-3 text-muted">Orden de compra, proveedor, importe</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Entrada</td>
+                      <td class="py-3 text-muted">La entrada genera automáticamente la ficha del activo (código, número de serie, garantía registrados en un paso)</td>
+                      <td class="py-3 text-muted">Ficha de activo, código único, periodo de garantía</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Asignación</td>
+                      <td class="py-3 text-muted">Préstamo del activo a empleado / cliente / departamento, con firma de aceptación</td>
+                      <td class="py-3 text-muted">Registro de asignación, usuario, fechas de inicio y fin</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Mantenimiento</td>
+                      <td class="py-3 text-muted">Las averías o mantenimientos abren un ticket vinculado a la ficha del activo</td>
+                      <td class="py-3 text-muted">Ticket de mantenimiento, coste acumulado</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Baja</td>
+                      <td class="py-3 text-muted">Registro del motivo de baja (avería / obsolescencia / venta) y de la amortización o valor residual</td>
+                      <td class="py-3 text-muted">Registro de baja, valor residual, modo de disposición</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestión completa de activos, desde la compra hasta la baja</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Compras de activos</h5>
+              <p class="text-muted mt-2">Orden de compra vinculada al proveedor y al precio; la entrada genera la ficha del activo con código, número de serie y garantía en un único paso.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Asignación / devolución</h5>
+              <p class="text-muted mt-2">Préstamo del activo a empleados o clientes con firma de aceptación; la devolución libera el activo y el "historial de uso" es totalmente trazable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tickets de mantenimiento</h5>
+              <p class="text-muted mt-2">Las averías o mantenimientos abren un ticket vinculado a la ficha del activo; el coste acumulado del mantenimiento ayuda a decidir la baja.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Baja / venta</h5>
+              <p class="text-muted mt-2">Registro del motivo de baja (avería / obsolescencia / venta) y de la amortización o valor residual, alineado con contabilidad.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de proveedores</h5>
+              <p class="text-muted mt-2">Ficha del proveedor con histórico de compras; importes, categorías y condiciones de pago a la vista para apoyar las decisiones de compra.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Panel de activos</h5>
+              <p class="text-muted mt-2">Total de activos, en uso, en mantenimiento y dados de baja; agregación por tipo, departamento y usuario, con exportación de los datos de inventario.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Más funciones en desarrollo</h5>
+              <p class="text-muted small mt-2 mb-0">Planificado: tareas de inventario, cálculo automático de depreciación, escaneo de código QR, flujo de solicitud de activos</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Gestión de Ventas, Help Desk, Gestión de Proyectos y Recursos Humanos.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseES>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/es/solutions/crm-v2.astro
+++ b/src/pages/es/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseES from "../../../layouts/BaseES.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 - Sistema de gestión comercial"
-  description="Sistema CRM 2.0 construido sobre la plataforma no-code de NocoBase. Diseño modular con ciclo comercial completo y funciones como puntuación de leads asistida por IA y predicción de cierre de oportunidades."
-  keywords="NocoBase CRM, CRM con IA, gestión comercial, oportunidades, clientes, leads, CRM no-code"
+<BaseES
+  title="Sistema CRM — open source y autoalojable | NocoBase"
+  description="Sistema CRM open source basado en la plataforma no-code de NocoBase: gestión de leads, seguimiento de clientes, conversión, fusión / deduplicación y vista 360 del cliente. Listo para usar y autoalojable."
+  keywords="sistema CRM, CRM open source, sistema de gestión de clientes, CRM, gestión de leads, seguimiento de clientes, cliente 360, CRM no-code, CRM autoalojable, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,40 +14,23 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sistema de gestión comercial</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestión de Clientes</h1>
             <p class="para-desc text-muted">
-              Construido sobre la plataforma no-code de NocoBase. Diseño modular con un ciclo comercial completo. La automatización gestiona tareas rutinarias y la IA ayuda con la puntuación de leads, el análisis de oportunidades y mucho más.
+              Construido sobre la plataforma no-code de NocoBase. Cubre el flujo completo de leads, seguimiento, conversión y deduplicación; la vista 360 del cliente agrega el histórico de pedidos, tickets, proyectos y activos.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Puntuación inteligente de leads</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Predicción de tasa de cierre</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Seguimiento de salud del cliente</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Diseño modular</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestión por etapas de leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Vista 360 del cliente</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Fusión / deduplicación</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
@@ -56,751 +38,329 @@ import AIAvatar from "../../../components/AIAvatar.astro";
                   <span class="badge bg-soft-primary me-2">Ventas B2B</span>
                   <span class="badge bg-soft-primary me-2">Ventas por proyecto</span>
                   <span class="badge bg-soft-primary me-2">Comercio exterior</span>
-                  <span class="badge bg-soft-primary">Todos los sectores</span>
+                  <span class="badge bg-soft-primary">Equipos pequeños y medianos</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo en vivo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>Cómo usarlo
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Te enfrentas a estos retos?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Los equipos comerciales se enfrentan a varios retos en su trabajo diario</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interfaz del sistema CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Calidad irregular de los leads</h5>
-              </div>
-              <p class="text-muted mb-0">Grandes volúmenes de leads con calidad desigual. El equipo comercial pierde tiempo con leads poco valiosos mientras algunos de alto potencial pasan desapercibidos.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Seguimiento tardío de oportunidades</h5>
-              </div>
-              <p class="text-muted mb-0">Las oportunidades se estancan sin avanzar. A los responsables comerciales les cuesta seguir la salud del pipeline y se pierden ventanas óptimas de cierre.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Datos de clientes dispersos</h5>
-              </div>
-              <p class="text-muted mb-0">Los datos de cliente están dispersos entre correos, chats y documentos. No existe una visión completa del cliente para actuar con precisión.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Previsiones comerciales imprecisas</h5>
-              </div>
-              <p class="text-muted mb-0">Las previsiones se hacen por intuición y sin apoyo de datos. Las desviaciones afectan a la asignación de recursos y a la toma de decisiones.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Costes elevados del SaaS</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot y otros CRM SaaS cobran por usuario. El desarrollo a medida tarda más y tiene costes difíciles de prever.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Preocupaciones de seguridad de datos</h5>
-              </div>
-              <p class="text-muted mb-0">Los datos de clientes y oportunidades quedan en nubes de terceros, algo que no siempre cumple con los requisitos de localización y privacidad.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Nuestra solución</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 construido sobre la plataforma no-code de NocoBase. Automatización de workflows + asistencia de IA</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Módulos -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Puntuación inteligente de leads</h5>
-              <p class="text-muted mt-2">Evalúa automáticamente la calidad del lead, prioriza los más valiosos y recomienda el mejor momento de contacto</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Predicción de tasa de cierre</h5>
-              <p class="text-muted mt-2">Predice la probabilidad de cierre a partir de datos históricos, detecta operaciones en riesgo y sugiere cómo avanzar de etapa</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Seguimiento de salud del cliente</h5>
-              <p class="text-muted mt-2">Perfil 360 del cliente, puntuación de salud, alertas de fuga y mantenimiento proactivo de la relación</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Diseño modular</h5>
-              <p class="text-muted mt-2">Diseño modular independiente: la configuración mínima solo requiere Clientes + Oportunidades y puede ampliarse según se necesite</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Diseño base</span>
-            <h4 class="title mb-4">Ciclo comercial completo</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Desde la captación de leads hasta el éxito del cliente, con flujo de datos unificado y ayuda de IA en cada etapa</p>
+            <h4 class="title mb-4">Flujo de gestión del cliente</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Desde la entrada del lead hasta la vista 360 del cliente, con datos conectados de extremo a extremo</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Multicanal</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Seguimiento</div>
+                  <div class="small text-muted">Trazabilidad</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversión</div>
+                  <div class="small text-muted">Ficha de cliente</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Cliente 360</div>
+                  <div class="small text-muted">Vista agregada</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Consolidación</div>
+                  <div class="small opacity-75">Panel comercial</div>
                 </div>
               </div>
 
-              <!-- Stage Descripción -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Cambio de etapa</th>
-                      <th class="border-0 py-3">Disparador</th>
-                      <th class="border-0 py-3">Asistencia de IA</th>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Cliente</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulario / importación / entrada manual, con origen y comercial asignado</td>
+                      <td class="py-3 text-muted">Pool de leads, etiquetas de origen, paso de etapa</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Cliente → Oportunidad</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">La IA analiza la intención y recomienda crear una oportunidad</td>
+                      <td class="py-3">Seguimiento</td>
+                      <td class="py-3 text-muted">Registro de llamadas, correos y visitas; siguiente fecha de seguimiento</td>
+                      <td class="py-3 text-muted">Línea temporal de seguimiento, recordatorio</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Oportunidad → Presupuesto</td>
-                      <td class="py-3 text-muted">Entra en fase de propuesta</td>
-                      <td class="py-3 text-primary">Sugerencias de precio por IA, comparación con la competencia y precios por tramos</td>
+                      <td class="py-3">Conversión</td>
+                      <td class="py-3 text-muted">Convertir lead a cliente, rellenar ficha (sector / tamaño / contacto)</td>
+                      <td class="py-3 text-muted">Tabla de clientes, tabla de contactos, vínculo con leads</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Presupuesto → Pedido</td>
-                      <td class="py-3 text-muted">El cliente acepta el presupuesto</td>
-                      <td class="py-3 text-primary">Generación automática del pedido con detalle de productos y precios</td>
+                      <td class="py-3">Cliente 360</td>
+                      <td class="py-3 text-muted">Visión integral del cliente: pedidos, tickets, proyectos, activos</td>
+                      <td class="py-3 text-muted">Bloques embebidos, relaciones entre módulos</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Consolidación</td>
+                      <td class="py-3 text-muted">Panel comercial agrega KPI por comercial, región y tipo</td>
+                      <td class="py-3 text-muted">Gráficos, detalle navegable y exportación</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">Asistencia de IA</span>
-            <h4 class="title mb-4">Capacidades de asistencia con IA</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Mediante nodos de IA en workflows, ayuda con puntuación, análisis, redacción y otras tareas repetitivas</p>
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clientes, seguimiento y paneles: cubre el día a día de la gestión de la relación con el cliente</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Nodo de workflow</span></h5>
-              <span class="badge bg-soft-primary mb-2">Explorador comercial</span>
-              <p class="text-muted mt-2 small">Análisis profundo de oportunidades, predicción de cierre, inteligencia competitiva y sugerencias de estrategia comercial</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Importación de leads</h5>
+              <p class="text-muted mt-2">Importación masiva por Excel, recogida por formulario o conexión por API; mapeo de campos visual y deduplicación automática en conflictos.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Analista de insights</span>
-              <p class="text-muted mt-2 small">Puntuación inteligente de leads, evaluación de salud del cliente, análisis comercial y previsión del pipeline</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Paso de etapas</h5>
+              <p class="text-muted mt-2">Etapas del lead (nuevo / contactado / convertido / descartado) configurables visualmente; cada cambio queda registrado y la tasa de conversión se calcula automáticamente.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Asistente de redacción</span>
-              <p class="text-muted mt-2 small">Análisis de intención y tono en correos, borradores de respuesta y resúmenes de comunicación</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registros de seguimiento</h5>
+              <p class="text-muted mt-2">Cada visita, llamada o correo deja registro; la línea temporal muestra el histórico de comunicaciones para que los relevos sean sin fricción.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Planificación diaria</span>
-              <p class="text-muted mt-2 small">Prioridades del día, siguientes acciones sugeridas y planificación del seguimiento</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Recordatorios de seguimiento</h5>
+              <p class="text-muted mt-2">Aviso automático antes del próximo seguimiento; los clientes sin contacto en mucho tiempo entran al panel "por reactivar" para no olvidarlos.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Traductor</span>
-              <p class="text-muted mt-2 small">Comunicación multilingüe con clientes, traducción de contenidos y gestión de correos de comercio exterior</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vista 360 del cliente</h5>
+              <p class="text-muted mt-2">El detalle del cliente agrega pedidos, tickets, proyectos y activos: un único panel para ver todo el contexto sin cambiar de sistema.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">Más empleados de IA</h5>
-              <span class="badge bg-soft-secondary mb-2">En expansión</span>
-              <p class="text-muted mt-2 small">Pueden añadirse más empleados de IA especializados según las necesidades del negocio</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Clasificación y etiquetas</h5>
+              <p class="text-muted mt-2">Etiquetas multidimensionales por tipo de cliente, sector, tamaño y origen; filtrado y análisis agregado por etiqueta.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Módulo Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Arquitectura flexible</span>
-            <h4 class="title mb-4">Diseño modular</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Cada módulo se diseña de forma independiente y puede activarse o desactivarse. Escala la solución según tus necesidades</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Módulo</th>
-                  <th class="border-0 py-3">Obligatorio</th>
-                  <th class="border-0 py-3">Descripción</th>
-                  <th class="border-0 py-3">Capacidades de IA</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de clientes</td>
-                  <td class="py-3"><span class="badge bg-success">Obligatorio</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de oportunidades</td>
-                  <td class="py-3"><span class="badge bg-success">Obligatorio</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de leads</td>
-                  <td class="py-3"><span class="badge bg-secondary">Opcional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de presupuestos</td>
-                  <td class="py-3"><span class="badge bg-secondary">Opcional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de pedidos</td>
-                  <td class="py-3"><span class="badge bg-secondary">Opcional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Gestión de productos</td>
-                  <td class="py-3"><span class="badge bg-secondary">Opcional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Integración de correo</td>
-                  <td class="py-3"><span class="badge bg-secondary">Opcional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Suite completa</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Estándar</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Ligero</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Comercio</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fusión y deduplicación</h5>
+              <p class="text-muted mt-2">Detecta entradas duplicadas del mismo cliente; fusión con un clic conservando los seguimientos y registros relacionados.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Módulo Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Panel comercial</h5>
+              <p class="text-muted mt-2">KPI agregados por comercial, región y tipo de cliente: nuevos clientes, tasa de conversión y distribución de clientes activos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permisos por campo y por fila</h5>
+              <p class="text-muted mt-2">Campos visibles configurables según el rol; el comercial ve solo los clientes que gestiona y los responsables ven todo.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Valor de la automatización</h4>
-            <p class="para-desc mx-auto text-muted mb-0">La automatización de workflows y la asistencia de IA reducen el trabajo repetitivo y permiten al equipo comercial centrarse en la relación con el cliente</p>
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Por qué elegirnos?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparativa frente a CRM SaaS tradicional y desarrollo a medida</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimensión</th>
-                  <th class="border-0 py-3">CRM SaaS</th>
-                  <th class="border-0 py-3">Desarrollo a medida</th>
-                  <th class="border-0 py-3 text-primary">Solución NocoBase</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Tiempo de puesta en marcha</td>
-                  <td class="py-3 text-muted">Listo para usar</td>
-                  <td class="py-3 text-muted">Meses de desarrollo</td>
-                  <td class="py-3 text-primary">Configura y arranca, despliegue rápido</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Personalización</td>
-                  <td class="py-3 text-muted">Limitada</td>
-                  <td class="py-3 text-muted">Control total</td>
-                  <td class="py-3 text-primary">Personalización flexible sin código</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Seguridad de datos</td>
-                  <td class="py-3 text-muted">Alojado en la nube</td>
-                  <td class="py-3 text-muted">Autohospedado</td>
-                  <td class="py-3 text-primary">Autohospedado, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Asistencia de IA</td>
-                  <td class="py-3 text-muted">Limitada/extra cost</td>
-                  <td class="py-3 text-muted">Desarrollarlo por tu cuenta</td>
-                  <td class="py-3 text-primary">Nodos de IA en workflows, úsalo según convenga</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Módulo Flexibility</td>
-                  <td class="py-3 text-muted">Funciones empaquetadas</td>
-                  <td class="py-3 text-muted">Requiere cambios de código</td>
-                  <td class="py-3 text-primary">Modular, crece según necesites</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Coste total</td>
-                  <td class="py-3 text-muted">Suscripción por usuario</td>
-                  <td class="py-3 text-muted">Alto coste de desarrollo</td>
-                  <td class="py-3 text-primary">Compra única, uso a largo plazo</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- Cómo usarlo Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Cómo usarlo?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Tres pasos para desplegar CRM 2.0 en tu entorno</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Instala NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Guía de instalación</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Conoce la solución</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/" target="_blank" class="btn btn-outline-primary">Documentación de la solución</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restaurar en el sistema</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Guía de restauración</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Cómo usarlo End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con Gestión de Ventas, Help Desk, Gestión de Proyectos, Gestión de Activos y Recursos Humanos.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Demo en vivo
-            </a>
-            <a href="/en/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseES>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/es/solutions/crm.astro
+++ b/src/pages/es/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseES from "../../../layouts/BaseES.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="CRM no-code, flexible y potente"
-  description="Listo para usar desde el primer momento. Ofrece una personalización profunda manteniendo la soberanía total sobre tus datos. Amplía campos, bloques, funciones y páginas para adaptarlo por completo a tu negocio."
-  keywords="NocoBase CRM, gestión de clientes, CRM no-code, CRM open source, CRM personalizable"
+<BaseES
+  title="Sistema CRM — open source y autoalojable | NocoBase"
+  description="Sistema CRM open source basado en la plataforma no-code de NocoBase: gestión de leads, seguimiento de clientes, conversión, fusión / deduplicación y vista 360 del cliente. Listo para usar y autoalojable."
+  keywords="sistema CRM, CRM open source, sistema de gestión de clientes, CRM, gestión de leads, seguimiento de clientes, cliente 360, CRM no-code, CRM autoalojable, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM no-code,<br/>flexible y potente</h1>
-            <p class="para-desc text-muted">Listo para usar desde el primer momento y con la flexibilidad necesaria para adaptarse a tus necesidades. Amplía campos, bloques y páginas para construir la solución ideal para tu negocio, manteniendo siempre el control total de tus datos.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Construido con NocoBase 1.x (2.0 en desarrollo)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestión de Clientes</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Cubre el flujo completo de leads, seguimiento, conversión y deduplicación; la vista 360 del cliente agrega el histórico de pedidos, tickets, proyectos y activos.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestión por etapas de leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Vista 360 del cliente</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Fusión / deduplicación</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Sectores:</span>
-                  <span class="badge bg-soft-primary">Todos los sectores</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Ventas B2B</span>
+                  <span class="badge bg-soft-primary me-2">Ventas por proyecto</span>
+                  <span class="badge bg-soft-primary me-2">Comercio exterior</span>
+                  <span class="badge bg-soft-primary">Equipos pequeños y medianos</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Desarrollado por:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo en vivo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interfaz del sistema CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Qué hace único al CRM de NocoBase</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A diferencia del SaaS y de otros CRM, NocoBase CRM es flexible y está completamente bajo tu control</p>
+            <h4 class="title mb-4">Flujo de gestión del cliente</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Desde la entrada del lead hasta la vista 360 del cliente, con datos conectados de extremo a extremo</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Totalmente no-code</h5>
-              <p class="text-muted mt-2">No necesitas programar para personalizar el CRM</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Cubre las funciones habituales de un CRM</h5>
-              <p class="text-muted mt-2">Gestión de clientes, pipeline comercial, seguimiento de oportunidades, contactos, correo, aprobaciones y mucho más</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Fácil de modificar y ampliar</h5>
-              <p class="text-muted mt-2">Admite campos personalizados, procesos y lógica de negocio; su arquitectura flexible simplifica la ampliación posterior</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Código abierto y control total de datos</h5>
-              <p class="text-muted mt-2">Control completo sobre el código y los datos del sistema, con seguridad empresarial</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Demo interactiva Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Prueba las funciones del CRM de NocoBase</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Hazte una idea en solo unos clics</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Visualización de datos en paneles</h5>
-              <!-- Demo interactiva Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Demo interactiva
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Multicanal</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Seguimiento</div>
+                  <div class="small text-muted">Trazabilidad</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversión</div>
+                  <div class="small text-muted">Ficha de cliente</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Cliente 360</div>
+                  <div class="small text-muted">Vista agregada</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Consolidación</div>
+                  <div class="small opacity-75">Panel comercial</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Proceso de conversión de leads</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Demo interactiva
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">De oportunidad a pedido</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Demo interactiva
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Demo interactiva End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Demo interactiva -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Pruébalo ahora
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Llévalo a tu entorno
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Guía de desarrollo y ampliación del CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Aprende a construir y ampliar un CRM profesional con NocoBase</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Configuración básica y personalización</h5>
-                <p class="text-muted text-center">Aprende a crear modelos de datos, configurar relaciones entre campos, permisos y diseños de interfaz</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Análisis y visualización de datos</h5>
-                <p class="text-muted text-center">Crea paneles de análisis comercial para supervisar resultados y visualizar datos</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Automatización de procesos</h5>
-                <p class="text-muted text-center">Configura workflows para automatizar procesos comerciales, aprobaciones y reglas de negocio</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Integración y ampliación del sistema</h5>
-                <p class="text-muted text-center">Integra sistemas de terceros, adapta la experiencia móvil y amplía funciones avanzadas</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Plugins comerciales para CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">El núcleo del CRM es open source y los plugins comerciales amplían sus capacidades</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">Por <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Detalles</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso vitalicio, 1 año de actualizaciones</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso y actualizaciones de por vida</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">Más plugins próximamente</h6>
-                  <p class="text-muted small">Estamos preparando más plugins comerciales útiles; muy pronto habrá más</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulario / importación / entrada manual, con origen y comercial asignado</td>
+                      <td class="py-3 text-muted">Pool de leads, etiquetas de origen, paso de etapa</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Seguimiento</td>
+                      <td class="py-3 text-muted">Registro de llamadas, correos y visitas; siguiente fecha de seguimiento</td>
+                      <td class="py-3 text-muted">Línea temporal de seguimiento, recordatorio</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Conversión</td>
+                      <td class="py-3 text-muted">Convertir lead a cliente, rellenar ficha (sector / tamaño / contacto)</td>
+                      <td class="py-3 text-muted">Tabla de clientes, tabla de contactos, vínculo con leads</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Cliente 360</td>
+                      <td class="py-3 text-muted">Visión integral del cliente: pedidos, tickets, proyectos, activos</td>
+                      <td class="py-3 text-muted">Bloques embebidos, relaciones entre módulos</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Consolidación</td>
+                      <td class="py-3 text-muted">Panel comercial agrega KPI por comercial, región y tipo</td>
+                      <td class="py-3 text-muted">Gráficos, detalle navegable y exportación</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">Ver todos los plugins comerciales</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Consultar precios</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Cómo usarlo?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Tres pasos para desplegar rápidamente NocoBase CRM en tu entorno</p>
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clientes, seguimiento y paneles: cubre el día a día de la gestión de la relación con el cliente</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Instala NocoBase</h5>
-                                  <p class="text-muted mt-2">Sigue nuestra documentación de instalación para desplegar NocoBase en tu servidor</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Ver guía de instalación</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Importación de leads</h5>
+              <p class="text-muted mt-2">Importación masiva por Excel, recogida por formulario o conexión por API; mapeo de campos visual y deduplicación automática en conflictos.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Descargar plantilla del CRM</h5>
-                <p class="text-muted mt-2">Obtén la plantilla completa del sistema CRM de NocoBase, disponible en dos formatos</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Descargar archivo SQL</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Descargar copia (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Paso de etapas</h5>
+              <p class="text-muted mt-2">Etapas del lead (nuevo / contactado / convertido / descartado) configurables visualmente; cada cambio queda registrado y la tasa de conversión se calcula automáticamente.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restaurar en el sistema</h5>
-                <p class="text-muted mt-2">Importa la plantilla en tu sistema NocoBase para completar el despliegue</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/es/solution/crm/v1" class="btn btn-outline-primary">Guía de restauración</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registros de seguimiento</h5>
+              <p class="text-muted mt-2">Cada visita, llamada o correo deja registro; la línea temporal muestra el histórico de comunicaciones para que los relevos sean sin fricción.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Recordatorios de seguimiento</h5>
+              <p class="text-muted mt-2">Aviso automático antes del próximo seguimiento; los clientes sin contacto en mucho tiempo entran al panel "por reactivar" para no olvidarlos.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vista 360 del cliente</h5>
+              <p class="text-muted mt-2">El detalle del cliente agrega pedidos, tickets, proyectos y activos: un único panel para ver todo el contexto sin cambiar de sistema.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Clasificación y etiquetas</h5>
+              <p class="text-muted mt-2">Etiquetas multidimensionales por tipo de cliente, sector, tamaño y origen; filtrado y análisis agregado por etiqueta.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fusión y deduplicación</h5>
+              <p class="text-muted mt-2">Detecta entradas duplicadas del mismo cliente; fusión con un clic conservando los seguimientos y registros relacionados.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Panel comercial</h5>
+              <p class="text-muted mt-2">KPI agregados por comercial, región y tipo de cliente: nuevos clientes, tasa de conversión y distribución de clientes activos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permisos por campo y por fila</h5>
+              <p class="text-muted mt-2">Campos visibles configurables según el rol; el comercial ve solo los clientes que gestiona y los responsables ven todo.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">¿Listo para usar NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Despliega una demo dedicada de CRM en un minuto. Desde la estructura de datos hasta la interfaz y la lógica de procesos, todo se configura visualmente en NocoBase sin escribir una sola línea de código.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con Gestión de Ventas, Help Desk, Gestión de Proyectos, Gestión de Activos y Recursos Humanos.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Demo en vivo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseES>
 
 <style>
-/* Demo interactiva Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/es/solutions/hr-management.astro
+++ b/src/pages/es/solutions/hr-management.astro
@@ -1,0 +1,348 @@
+---
+import BaseES from "../../../layouts/BaseES.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseES
+  title="Sistema de Recursos Humanos — gestión de RRHH open source | NocoBase"
+  description="Sistema RRHH open source basado en la plataforma no-code de NocoBase: ficha del empleado, incorporación, baja, vacaciones, seguimiento del periodo de prueba, puestos y estructura departamental. Ligero, autoalojable, adecuado para equipos de RRHH en pymes."
+  keywords="sistema RRHH, software RRHH, sistema de recursos humanos, sistema RRHH open source, gestión de empleados, gestión de incorporaciones, gestión de bajas, aprobación de vacaciones, gestión del periodo de prueba, organigrama, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Recursos Humanos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistema de Recursos Humanos</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Ficha del empleado y seguimiento integral de <strong>incorporación, baja, vacaciones y periodo de prueba</strong>, junto con la estructura de puestos y departamentos.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Listas de incorporación / baja</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Aprobación de vacaciones</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Panel de periodo de prueba</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Pymes</span>
+                  <span class="badge bg-soft-primary me-2">Cadenas de locales</span>
+                  <span class="badge bg-soft-primary me-2">RRHH sectorial</span>
+                  <span class="badge bg-soft-primary">Colaboración entre áreas</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Interfaz del sistema de recursos humanos" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ciclo del empleado</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo cerrado de gestión de recursos humanos, desde el reclutamiento hasta la baja</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Reclutamiento</div>
+                  <div class="small text-muted">Candidatos</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Incorporación</div>
+                  <div class="small text-muted">Lista de tareas</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Empleado activo</div>
+                  <div class="small text-muted">Vacaciones</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Evaluación</div>
+                  <div class="small text-muted">Confirmación / cambio</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Baja</div>
+                  <div class="small opacity-75">Traspaso y archivo</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Reclutamiento</td>
+                      <td class="py-3 text-muted">Registro y valoración de candidatos; los aceptados pasan a ficha de empleado</td>
+                      <td class="py-3 text-muted">Tabla de candidatos, valoración de entrevistas</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Incorporación</td>
+                      <td class="py-3 text-muted">Lista de tareas (firmar contrato, hacer la tarjeta, entregar equipos, dar de alta cuentas)</td>
+                      <td class="py-3 text-muted">Lista de incorporación, ficha del contrato</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Empleado activo</td>
+                      <td class="py-3 text-muted">Asistencia, vacaciones, compensaciones y horas extra del día a día</td>
+                      <td class="py-3 text-muted">Registros de ausencias, saldo de vacaciones</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Evaluación</td>
+                      <td class="py-3 text-muted">Evaluación del periodo de prueba, confirmación, cambios de puesto y promociones</td>
+                      <td class="py-3 text-muted">Formularios de evaluación, cambios de puesto</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Baja</td>
+                      <td class="py-3 text-muted">Lista de baja: traspaso, devolución de activos, cierre de cuentas y trámites</td>
+                      <td class="py-3 text-muted">Registro de baja, liberación de activos</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestión completa de recursos humanos, desde la incorporación hasta la baja</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de empleados</h5>
+              <p class="text-muted mt-2">Perfil de empleados con número de empleado, fecha de contratación, puesto, departamento — registros unificados, búsqueda multidimensional.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ciclo de vida del empleado</h5>
+              <p class="text-muted mt-2">Pendiente onboarding → período de prueba → activo → offboarding → inactivo: 5 estados a través del registro del empleado; filtrar por estado de un vistazo.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Estructura departamental</h5>
+              <p class="text-muted mt-2">Organigrama en árbol: departamento → subdepartamento, basado en el plugin nativo departments de NocoBase, vinculado con permisos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catálogo de puestos</h5>
+              <p class="text-muted mt-2">Definiciones de puestos con nivel laboral (junior / medio / senior / experto); empleados vinculados a puestos para gestión de carrera y permisos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aprobación de permisos</h5>
+              <p class="text-muted mt-2">8 tipos de permiso (anual / por enfermedad / personal / compensatorio / matrimonio / paternal / luto / otros); flujo de aprobación configurable por departamento / supervisor directo.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permisos a nivel de campo</h5>
+              <p class="text-muted mt-2">RRHH ve campos salariales; los gerentes ven información básica de su equipo — configuración flexible mediante permisos de rol de NocoBase.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Más funciones en desarrollo</h5>
+              <p class="text-muted small mt-2 mb-0">Planificado: listas de onboarding/offboarding, evaluación de período de prueba, gestión de contratos y seguridad social, candidatos de reclutamiento, registros de transferencias/promociones</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Gestión de Ventas, Help Desk, Gestión de Proyectos y Gestión de Activos.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseES>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/es/solutions/project-management.astro
+++ b/src/pages/es/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseES from "../../../layouts/BaseES.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Solución integral de gestión de proyectos de I+D"
-  description="El sistema de gestión de proyectos de I+D de NocoBase cubre todo el ciclo de desarrollo: planificación, asignación de tareas, seguimiento del progreso, calidad y colaboración del equipo."
-  keywords="NocoBase gestión de proyectos I+D, tareas, colaboración, agile, calidad"
+<BaseES
+  title="Sistema de Gestión de Proyectos — colaboración ligera open source | NocoBase"
+  description="Sistema de gestión de proyectos open source basado en la plataforma no-code de NocoBase: gestión a dos niveles de proyecto + tarea, responsables, progreso, hitos, avisos de retraso y distribución de carga de trabajo. Ligero, autoalojable, adecuado para equipos pequeños y medianos y colaboración entre áreas."
+  keywords="sistema de gestión de proyectos, software de gestión de proyectos, sistema de tareas, gestión de proyectos open source, gestión ligera de proyectos, gestión de tareas, colaboración en proyectos, seguimiento de proyectos, gestión de hitos, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,335 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Solución integral de<br/>gestión de proyectos de I+D</h1>
-            <p class="para-desc text-muted">Una plataforma potente y flexible de gestión de proyectos de I+D construida con NocoBase. Soporta metodologías Agile, Waterfall y enfoques híbridos para gestionar requisitos, tareas, equipos, iteraciones y calidad desde un único lugar.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Construido con NocoBase 1.x (2.0 en desarrollo)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestión de Proyectos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistema de Gestión de Proyectos</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Gestión a dos niveles <strong>proyecto + tarea</strong>, con responsables, progreso, hitos, avisos de retraso y distribución de carga de trabajo. Ligero y autoalojable.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Dos niveles proyecto + tarea</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Avisos de retraso</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Seguimiento de hitos</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Sectores:</span>
-                  <span class="badge bg-soft-primary">I+D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Proyectos de entrega</span>
+                  <span class="badge bg-soft-primary me-2">TI interna</span>
+                  <span class="badge bg-soft-primary me-2">Colaboración entre áreas</span>
+                  <span class="badge bg-soft-primary">Equipos pequeños y medianos</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Desarrollado por:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Interfaz del sistema de gestión de proyectos" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Flujo de proyecto</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo completo desde la apertura hasta el cierre, con hitos y avisos de retraso automáticos</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Apertura</div>
+                  <div class="small text-muted">Cliente vinculado</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tareas</div>
+                  <div class="small text-muted">Responsable</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Seguimiento</div>
+                  <div class="small text-muted">Aviso de retraso</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Hitos</div>
+                  <div class="small text-muted">Entregables</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Cierre</div>
+                  <div class="small opacity-75">Retrospectiva y archivo</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo en vivo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase I+D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Qué hace única a la gestión de proyectos de NocoBase</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Una solución completa que se adapta a tu forma de gestionar proyectos</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Ciclo de vida completo del proyecto</h5>
-              <p class="text-muted mt-2">Desde la definición y la planificación hasta la ejecución, el seguimiento y el cierre: gestiona cada fase de tus proyectos</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Métodos ágiles y tradicionales</h5>
-              <p class="text-muted mt-2">Soporta sprints Scrum, tableros Kanban, diagramas de Gantt, gráficos de burn-down y enfoques tradicionales en cascada</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Colaboración de equipo y gestión de calidad</h5>
-              <p class="text-muted mt-2">Gestiona con eficacia los equipos de desarrollo, sigue la calidad del código y controla incidencias y defectos para asegurar la calidad del producto</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Fácil de modificar y ampliar</h5>
-              <p class="text-muted mt-2">Aprovecha las capacidades no-code de NocoBase para personalizar campos, procesos y lógica de negocio con control total</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Pruébalo ahora
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Llévalo a tu entorno
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Guía de desarrollo para gestión de proyectos</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Aprende a construir desde cero un sistema profesional de gestión de proyectos con NocoBase</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Diseño del modelo de datos</h5>
-                <p class="text-muted text-center">Aprende a crear las estructuras de datos básicas para proyectos, tareas, equipos y sus relaciones</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Apertura</td>
+                      <td class="py-3 text-muted">Crear proyecto, vincularlo a cliente (entrega) o a activo (TI), asignar jefe de proyecto</td>
+                      <td class="py-3 text-muted">Ficha de proyecto, vínculo con cliente, responsable</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tareas</td>
+                      <td class="py-3 text-muted">Descomponer en tareas con responsable, fechas y dependencias</td>
+                      <td class="py-3 text-muted">Tabla de tareas, responsables, grafo de dependencias</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Seguimiento</td>
+                      <td class="py-3 text-muted">Los miembros actualizan el progreso; las tareas vencidas se marcan en rojo automáticamente</td>
+                      <td class="py-3 text-muted">Porcentaje de avance, marca de retraso</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Hitos</td>
+                      <td class="py-3 text-muted">Los puntos clave (revisión, beta, lanzamiento) se marcan como hitos; entregables registrados</td>
+                      <td class="py-3 text-muted">Lista de hitos, adjuntos de entregables</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Cierre</td>
+                      <td class="py-3 text-muted">El proyecto se cierra y se archiva con horas y coste consolidados</td>
+                      <td class="py-3 text-muted">Informe de cierre, resumen de horas</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Configuración de workflows</h5>
-                <p class="text-muted text-center">Configura asignación de tareas, cambios de estado y workflows automatizados del proyecto</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprints y seguimiento</h5>
-                <p class="text-muted text-center">Configura sprints, gráficos de burn-down y funciones de seguimiento del avance</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Amplía con plugins comerciales</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Amplía tus capacidades de gestión de proyectos con plugins comerciales</p>
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Seguimiento ligero de proyectos desde la apertura hasta el cierre</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">Por <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Detalles</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso vitalicio, 1 año de actualizaciones</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso y actualizaciones de por vida</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dos niveles proyecto + tarea</h5>
+              <p class="text-muted mt-2">Cada proyecto se descompone en varias tareas, con responsable, fechas y progreso propios; el tablero del proyecto muestra el estado global de las tareas.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">Ver todos los plugins comerciales</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Consultar precios</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de hitos</h5>
+              <p class="text-muted mt-2">Los puntos clave (revisión de prototipo, beta, lanzamiento) se marcan como hitos; el avance del proyecto se muestra por hitos.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Avisos de retraso</h5>
+              <p class="text-muted mt-2">Las tareas vencidas se marcan en rojo automáticamente; la lista de proyectos retrasados se actualiza en tiempo real para visualizar los riesgos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Responsables y carga de trabajo</h5>
+              <p class="text-muted mt-2">Agregación por responsable de número de tareas y carga; quién tiene mucho, quién está libre y quién acumula retrasos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Panel de estado de proyectos</h5>
+              <p class="text-muted mt-2">KPI agregados por tipo, estado y responsable: en curso, cerrados y retrasados se muestran clasificados.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vínculo con cliente y activos</h5>
+              <p class="text-muted mt-2">Los proyectos pueden vincularse a clientes (proyectos de entrega) o a activos (proyectos TI); en la ficha del cliente se ve el histórico de proyectos.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Más funciones en desarrollo</h5>
+              <p class="text-muted small mt-2 mb-0">Planificado: gráfico de dependencias de tareas, registro de tiempo y costos, archivo de entregables, vista de diagrama de Gantt</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Cómo usarlo?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Tres pasos para desplegar rápidamente el sistema CRM de NocoBase con funciones de gestión de proyectos en tu entorno</p>
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Instala el sistema NocoBase</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Ver guía de instalación</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Descargar plantilla del sistema CRM</h5>
-                <p class="text-muted mt-2">Descarga la plantilla CRM completa para obtener también la capacidad de gestión de proyectos</p>
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Descargar archivo SQL</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Descargar copia (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restaurar en el sistema</h5>
-                <p class="text-muted mt-2">Importa la plantilla CRM en tu sistema NocoBase para obtener tanto CRM como gestión de proyectos</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Guía de restauración</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Consejo</h6>
-                <p class="mb-0 text-muted">El sistema de gestión de proyectos está completamente integrado en la plantilla de CRM como un módulo completo. Tras el despliegue, podrás usar directamente todas sus funciones dentro del sistema CRM para gestionar proyectos y equipos de principio a fin.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">¿Listo para transformar tu gestión de I+D?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive I+D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Gestión de Ventas, Help Desk, Gestión de Activos y Recursos Humanos.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Demo en vivo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Despliega ahora
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseES>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/es/solutions/project-management.astro
+++ b/src/pages/es/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Hitos</div>
                   <div class="small text-muted">Entregables</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Gestión de hitos</h5>
               <p class="text-muted mt-2">Los puntos clave (revisión de prototipo, beta, lanzamiento) se marcan como hitos; el avance del proyecto se muestra por hitos.</p>

--- a/src/pages/es/solutions/sales-management.astro
+++ b/src/pages/es/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI de cuentas por cobrar</h5>
-              <p class="text-muted mt-2">Listado de cuentas vencidas, análisis de antigüedad (tramos de 30 / 60 / 90 días), agregado por cliente y por comercial para una recobranza clara.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multidivisa y tipo de cambio</h5>
-              <p class="text-muted mt-2">Presupuestos y pedidos en USD/EUR/CNY/MXN; tabla de tipo de cambio gestionada manualmente o por importación, con conversión automática a moneda local.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Envíos y logística</h5>
-              <p class="text-muted mt-2">Las órdenes de envío se vinculan al pedido y al número de logística; admite envíos múltiples o parciales con el estado sincronizado al pedido.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Panel comercial</h5>

--- a/src/pages/es/solutions/sales-management.astro
+++ b/src/pages/es/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseES from "../../../layouts/BaseES.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseES
+  title="Sistema de Gestión de Ventas — open source para pedidos y cuentas por cobrar | NocoBase"
+  description="Sistema de gestión de ventas open source basado en la plataforma no-code de NocoBase: ciclo completo de presupuesto, pedido de venta, factura y cobro, con workflow de aprobación, multidivisa, KPI de cuentas por cobrar y análisis de vencimientos."
+  keywords="sistema de gestión de ventas, gestión de pedidos de venta, presupuestos, gestión de facturas, gestión de cuentas por cobrar, gestión de cobros, proceso de ventas, aprobación de ventas, gestión de ventas open source, presupuestos multidivisa, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestión de Ventas</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistema de Gestión de Ventas</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Ciclo completo <strong>presupuesto → pedido → factura → cobro</strong>, con workflow de aprobación de ventas, presupuestos multidivisa, KPI de cuentas por cobrar y análisis de vencimientos.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Presupuestos multidivisa</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Workflow de aprobación</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI de cobros</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Casos de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Ventas B2B</span>
+                  <span class="badge bg-soft-primary me-2">Pedidos de comercio exterior</span>
+                  <span class="badge bg-soft-primary me-2">Venta de equipamiento</span>
+                  <span class="badge bg-soft-primary">Gestión de cobros</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Interfaz del sistema de gestión de ventas" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Proceso de ventas</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo cerrado desde el presupuesto hasta el cobro, con aprobación y KPI de cobros conectados</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Presupuesto</div>
+                  <div class="small text-muted">Multidivisa</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pedido</div>
+                  <div class="small text-muted">Aprobación</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Envío</div>
+                  <div class="small text-muted">Seguimiento</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Factura</div>
+                  <div class="small text-muted">Autocompletado</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Cobro</div>
+                  <div class="small opacity-75">KPI de cobros</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Presupuesto</td>
+                      <td class="py-3 text-muted">Elegir cliente y producto, generar presupuesto multidivisa con descuento, IVA y vigencia</td>
+                      <td class="py-3 text-muted">Presupuesto, detalle de productos, exportación a PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pedido</td>
+                      <td class="py-3 text-muted">El presupuesto se convierte en pedido; los descuentos extra o pedidos grandes lanzan aprobación</td>
+                      <td class="py-3 text-muted">Pedido de venta, workflow, líneas del pedido</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Envío</td>
+                      <td class="py-3 text-muted">Tras confirmar el pedido se crea la orden de envío con el número de logística asociado</td>
+                      <td class="py-3 text-muted">Orden de envío, número de logística, estado</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Factura</td>
+                      <td class="py-3 text-muted">Facturación tras pedido o envío; NIF y dirección se rellenan desde la ficha del cliente</td>
+                      <td class="py-3 text-muted">Registro de factura, estado de facturación</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Cobro</td>
+                      <td class="py-3 text-muted">Registro de cobros por tramos, KPI de cuentas por cobrar agregados por antigüedad</td>
+                      <td class="py-3 text-muted">Registros de cobro, saldo pendiente, antigüedad</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo completo de presupuesto, pedido, factura y cobro, más aprobación y análisis de cuentas por cobrar</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de presupuestos</h5>
+              <p class="text-muted mt-2">Presupuestos multidivisa con descuento, IVA y vigencia; exportación a PDF con un clic para enviar al cliente y conversión a pedido de venta.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pedidos de venta</h5>
+              <p class="text-muted mt-2">Flujo de estados del pedido (borrador / en revisión / confirmado / enviado / cerrado), con cliente y producto vinculados y líneas editables.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workflow de aprobación de pedidos</h5>
+              <p class="text-muted mt-2">Los descuentos extra, los pedidos grandes y las condiciones especiales lanzan una aprobación; nodos de aprobación configurables por área, cargo y umbral de importe.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestión de facturas</h5>
+              <p class="text-muted mt-2">Generación de la factura desde el pedido y seguimiento de su estado; NIF, dirección y notas se completan desde la ficha del cliente para evitar errores manuales.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de cobros</h5>
+              <p class="text-muted mt-2">Cobros parciales y por tramos; cálculo automático del saldo pendiente; estado de pago agregado por cliente y por pedido.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI de cuentas por cobrar</h5>
+              <p class="text-muted mt-2">Listado de cuentas vencidas, análisis de antigüedad (tramos de 30 / 60 / 90 días), agregado por cliente y por comercial para una recobranza clara.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Multidivisa y tipo de cambio</h5>
+              <p class="text-muted mt-2">Presupuestos y pedidos en USD/EUR/CNY/MXN; tabla de tipo de cambio gestionada manualmente o por importación, con conversión automática a moneda local.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Envíos y logística</h5>
+              <p class="text-muted mt-2">Las órdenes de envío se vinculan al pedido y al número de logística; admite envíos múltiples o parciales con el estado sincronizado al pedido.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Panel comercial</h5>
+              <p class="text-muted mt-2">Importes, número de pedidos y tasa de cobro agregados por comercial, región y producto; tendencias mensuales y trimestrales a la vista.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Help Desk, Gestión de Proyectos, Gestión de Activos y Recursos Humanos.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseES>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/es/solutions/ticketing-v2.astro
+++ b/src/pages/es/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseES from "../../../layouts/BaseES.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="Sistema inteligente de tickets impulsado por IA"
-  description="Sistema inteligente de tickets de NocoBase con arquitectura de datos en T para distintos escenarios de negocio. Equipo de empleados de IA para clasificación automática, respuestas inteligentes y recomendaciones de conocimiento, con seguimiento SLA completo."
-  keywords="NocoBase ticketing, tickets con IA, atención inteligente, SLA, base de conocimiento, clasificación"
+<BaseES
+  title="Help Desk — sistema de tickets open source | NocoBase"
+  description="Sistema de tickets de soporte open source basado en la plataforma no-code de NocoBase: incidencias del cliente, asignación inteligente, cronometraje SLA, prioridades, clasificación con AI, valoración de satisfacción y escritorio de atención. Listo para usar, adecuado para equipos pequeños y medianos de atención y postventa."
+  keywords="sistema de tickets, software help desk, help desk open source, ticketing, gestión de tickets, gestión SLA, sistema de postventa, sistema de atención al cliente, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,335 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Sistema inteligente de tickets<br/>impulsado por IA</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
             <p class="para-desc text-muted">
-              Permite que los equipos de soporte se centren en resolver problemas, no en lidiar con procesos complejos. Construido sobre la plataforma no-code de NocoBase y con una arquitectura de datos en T para gestionar múltiples líneas de negocio de forma unificada. El equipo de empleados de IA acompaña todo el ciclo del ticket, desde la creación hasta el cierre.
+              Construido sobre la plataforma no-code de NocoBase. Flujo completo <strong>incidencia del cliente → asignación inteligente → tratamiento → valoración de satisfacción</strong>, con cronometraje SLA, gestión de prioridades, clasificación con AI y escritorio de atención al cliente integrados.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Entrada multifuente</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Enrutamiento inteligente con IA</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Seguimiento SLA completo</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Captura automática de conocimiento</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cronometraje SLA automático</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 niveles de prioridad</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Clasificación con AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
                   <span class="text-muted me-2">Casos de uso:</span>
-                  <span class="badge bg-soft-primary me-2">Reparación de equipos</span>
-                  <span class="badge bg-soft-primary me-2">Soporte IT</span>
-                  <span class="badge bg-soft-primary me-2">Reclamaciones de clientes</span>
-                  <span class="badge bg-soft-primary">Consultas</span>
+                  <span class="badge bg-soft-primary me-2">Atención y postventa</span>
+                  <span class="badge bg-soft-primary me-2">Service desk TI</span>
+                  <span class="badge bg-soft-primary me-2">Mantenimiento de equipos</span>
+                  <span class="badge bg-soft-primary">Soporte SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo en vivo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>Cómo usarlo
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>La versión alpha ya está disponible. Pruébala: la estamos mejorando activamente.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interfaz del sistema de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Te enfrentas a estos retos?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Las empresas reciben solicitudes de servicio desde múltiples fuentes, con procesos distintos y sin una gestión unificada</p>
+            <h4 class="title mb-4">Flujo de tratamiento del ticket</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo cerrado de extremo a extremo, desde la incidencia del cliente hasta el cierre y la valoración, con SLA cronometrado en todo el proceso</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Coste alto y personalización lenta</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Sistemas fragmentados y silos de datos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Respuesta lenta y falta de transparencia</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Difícil garantizar la calidad</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">El conocimiento no se acumula</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Faltan capacidades de IA</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Nuestra solución</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Plataforma universal de tickets construida con NocoBase no-code: entrada unificada, distribución inteligente, soporte para varios negocios y feedback en circuito cerrado</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Entrada multifuente</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Enrutamiento inteligente con IA</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Seguimiento SLA completo</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Diseño base</span>
-            <h4 class="title mb-4">Arquitectura de datos en T</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Reparación de equipos</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">Soporte IT</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">Equipo de empleados de IA</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Creación</div>
+                  <div class="small text-muted">Multicanal</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Clasificación</div>
+                  <div class="small text-muted">AI</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Asignación</div>
+                  <div class="small text-muted">Por reglas</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tratamiento</div>
+                  <div class="small text-muted">Cronómetro SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Valoración</div>
+                  <div class="small opacity-75">Cierre y archivo</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Creación</td>
+                      <td class="py-3 text-muted">Recepción multicanal por correo, formulario o mensajería; relacionado con cliente y producto</td>
+                      <td class="py-3 text-muted">Número de ticket, origen, ficha de cliente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Clasificación</td>
+                      <td class="py-3 text-muted">La AI identifica la categoría (cuenta / funcionalidad / bug) y fija la prioridad automáticamente</td>
+                      <td class="py-3 text-muted">Etiqueta de categoría, prioridad, nivel de confianza</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Asignación</td>
+                      <td class="py-3 text-muted">Asignación por reglas al equipo o agente correspondiente; los tickets urgentes notifican a la guardia</td>
+                      <td class="py-3 text-muted">Responsable, historial de asignación, cola del equipo</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tratamiento</td>
+                      <td class="py-3 text-muted">El agente resuelve y se comunica con el cliente; el SLA se cronometra y avisa antes del vencimiento</td>
+                      <td class="py-3 text-muted">Registro de tratamiento, estado SLA, motivo de espera</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Valoración</td>
+                      <td class="py-3 text-muted">Al cerrarse, se envía al cliente una valoración (1-5 estrellas + texto) agregada por agente y producto</td>
+                      <td class="py-3 text-muted">Registro de satisfacción, ticket archivado, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestión completa de tickets de atención, desde la recepción hasta el cierre</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cronometraje y alertas SLA</h5>
+              <p class="text-muted mt-2">Cálculo automático de tiempos de respuesta y resolución según prioridad; aviso previo y marcado rojo de los vencidos; tasa de cumplimiento SLA visible en el panel.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 niveles de prioridad</h5>
+              <p class="text-muted mt-2">Urgente, alta, media y baja, con tiempos de respuesta distintos; los urgentes se fijan arriba y notifican al personal de guardia.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Clasificación con AI</h5>
+              <p class="text-muted mt-2">La AI identifica automáticamente la categoría del ticket nuevo (problema de cuenta, consulta funcional, bug, etc.) y lo deriva al equipo correcto.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Motivos de espera detallados</h5>
+              <p class="text-muted mt-2">"Esperando al cliente", "Esperando a un tercero", "Pendiente de revisión": los tickets en espera no cuentan como vencimiento de SLA, de forma equitativa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Escritorio del agente</h5>
+              <p class="text-muted mt-2">Al iniciar sesión el agente ve los tickets asignados a él, ordenados por vencimiento: pendientes, en curso y próximos a vencer en un único panel.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard de tickets</h5>
+              <p class="text-muted mt-2">Distribución de nuevos, cerrados, pendientes y vencidos del día; agregados por agente, cliente y línea de producto para una visión global.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Más funciones en desarrollo</h5>
+              <p class="text-muted small mt-2 mb-0">Planificado: evaluación de satisfacción, flujo de transferencia y escalado, plantillas de respuesta, integración con base de conocimientos</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- Cómo usarlo Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Cómo usarlo?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Cómo usarlo End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Gestión de Ventas, Gestión de Proyectos, Gestión de Activos y Recursos Humanos.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Demo en vivo
-            </a>
-            <a href="/es/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseES>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/es/solutions/ticketing.astro
+++ b/src/pages/es/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseES from "../../../layouts/BaseES.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Sistema de gestión de tickets eficiente y práctico"
-  description="El sistema de gestión de tickets de NocoBase complementa al CRM y cubre todo el ciclo de vida del ticket, desde el contacto inicial hasta la asignación, resolución y seguimiento."
-  keywords="NocoBase ticketing, gestión de tickets, atención al cliente, postventa, asignación de tickets"
+<BaseES
+  title="Help Desk — sistema de tickets open source | NocoBase"
+  description="Sistema de tickets de soporte open source basado en la plataforma no-code de NocoBase: incidencias del cliente, asignación inteligente, cronometraje SLA, prioridades, clasificación con AI, valoración de satisfacción y escritorio de atención. Listo para usar, adecuado para equipos pequeños y medianos de atención y postventa."
+  keywords="sistema de tickets, software help desk, help desk open source, ticketing, gestión de tickets, gestión SLA, sistema de postventa, sistema de atención al cliente, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,335 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Sistema de gestión de tickets<br/>eficiente y práctico</h1>
-            <p class="para-desc text-muted">El sistema de tickets de NocoBase actúa como un complemento clave del CRM y proporciona una gestión completa del ciclo de vida del ticket. Desde la creación del contacto hasta el registro, la asignación, la resolución y el seguimiento, permite una gestión digital integral del servicio postventa.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Construido con NocoBase 1.x (2.0 en desarrollo)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/es/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestión Integral</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
+            <p class="para-desc text-muted">
+              Construido sobre la plataforma no-code de NocoBase. Flujo completo <strong>incidencia del cliente → asignación inteligente → tratamiento → valoración de satisfacción</strong>, con cronometraje SLA, gestión de prioridades, clasificación con AI y escritorio de atención al cliente integrados.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cronometraje SLA automático</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 niveles de prioridad</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Clasificación con AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Código abierto y gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
+                <div class="d-flex align-items-center flex-wrap">
                   <span class="text-muted me-2">Casos de uso:</span>
-                  <span class="badge bg-soft-primary me-2">Atención al cliente</span>
-                  <span class="badge bg-soft-primary">Soporte postventa</span>
+                  <span class="badge bg-soft-primary me-2">Atención y postventa</span>
+                  <span class="badge bg-soft-primary me-2">Service desk TI</span>
+                  <span class="badge bg-soft-primary me-2">Mantenimiento de equipos</span>
+                  <span class="badge bg-soft-primary">Soporte SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Desarrollado por:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo en vivo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+              <a href="/es/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solución completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interfaz del sistema de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Funciones del sistema de tickets de NocoBase</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Como complemento clave del CRM, aporta una gestión profesional de atención al cliente y soporte postventa</p>
+            <h4 class="title mb-4">Flujo de tratamiento del ticket</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ciclo cerrado de extremo a extremo, desde la incidencia del cliente hasta el cierre y la valoración, con SLA cronometrado en todo el proceso</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Ciclo de vida completo del ticket</h5>
-              <p class="text-muted mt-2">Desde la creación hasta el cierre, la gestión de extremo a extremo garantiza que cada ticket se atienda correctamente</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Asignación y seguimiento inteligentes</h5>
-              <p class="text-muted mt-2">Asigna tareas automáticamente según el tipo de ticket y las habilidades del equipo, con seguimiento en tiempo real del progreso y el estado</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Registro multicanal de comunicaciones</h5>
-              <p class="text-muted mt-2">Sincroniza correo, teléfono, chat online y otros canales mediante API para gestionar de forma unificada la comunicación con el cliente</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Código abierto y control total de datos</h5>
-              <p class="text-muted mt-2">Código abierto y despliegue privado de datos para garantizar seguridad y control empresarial</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Pruébalo ahora
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Guía de desarrollo del sistema de tickets</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Aprende a construir desde cero un sistema profesional de gestión de tickets con NocoBase</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Diseño del modelo de datos</h5>
-                <p class="text-muted text-center">Aprende a crear las estructuras y relaciones básicas para tickets, clientes, categorías y más</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Configuración de workflows</h5>
-                <p class="text-muted text-center">Configura asignación de tickets, cambios de estado y workflows automatizados de resolución</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notificaciones y recordatorios</h5>
-                <p class="text-muted text-center">Configura notificaciones por correo y del sistema para asegurar una atención a tiempo</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Próximamente</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Plugins comerciales utilizados en el sistema de tickets</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Descubre cómo incorporar funciones más potentes mediante plugins comerciales para elevar el nivel y la utilidad de tu sistema de tickets</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">Por <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Detalles</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso vitalicio, 1 año de actualizaciones</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Uso y actualizaciones de por vida</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Creación</div>
+                  <div class="small text-muted">Multicanal</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Clasificación</div>
+                  <div class="small text-muted">AI</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Asignación</div>
+                  <div class="small text-muted">Por reglas</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tratamiento</div>
+                  <div class="small text-muted">Cronómetro SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Valoración</div>
+                  <div class="small opacity-75">Cierre y archivo</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Próximamente</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Acciones clave</th>
+                      <th class="border-0 py-3">Registro en el sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Creación</td>
+                      <td class="py-3 text-muted">Recepción multicanal por correo, formulario o mensajería; relacionado con cliente y producto</td>
+                      <td class="py-3 text-muted">Número de ticket, origen, ficha de cliente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Clasificación</td>
+                      <td class="py-3 text-muted">La AI identifica la categoría (cuenta / funcionalidad / bug) y fija la prioridad automáticamente</td>
+                      <td class="py-3 text-muted">Etiqueta de categoría, prioridad, nivel de confianza</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Asignación</td>
+                      <td class="py-3 text-muted">Asignación por reglas al equipo o agente correspondiente; los tickets urgentes notifican a la guardia</td>
+                      <td class="py-3 text-muted">Responsable, historial de asignación, cola del equipo</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tratamiento</td>
+                      <td class="py-3 text-muted">El agente resuelve y se comunica con el cliente; el SLA se cronometra y avisa antes del vencimiento</td>
+                      <td class="py-3 text-muted">Registro de tratamiento, estado SLA, motivo de espera</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Valoración</td>
+                      <td class="py-3 text-muted">Al cerrarse, se envía al cliente una valoración (1-5 estrellas + texto) agregada por agente y producto</td>
+                      <td class="py-3 text-muted">Registro de satisfacción, ticket archivado, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">¿Cómo usarlo?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Funcionalidades principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestión completa de tickets de atención, desde la recepción hasta el cierre</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Próximamente</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cronometraje y alertas SLA</h5>
+              <p class="text-muted mt-2">Cálculo automático de tiempos de respuesta y resolución según prioridad; aviso previo y marcado rojo de los vencidos; tasa de cumplimiento SLA visible en el panel.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Próximamente</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 niveles de prioridad</h5>
+              <p class="text-muted mt-2">Urgente, alta, media y baja, con tiempos de respuesta distintos; los urgentes se fijan arriba y notifican al personal de guardia.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Próximamente</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Clasificación con AI</h5>
+              <p class="text-muted mt-2">La AI identifica automáticamente la categoría del ticket nuevo (problema de cuenta, consulta funcional, bug, etc.) y lo deriva al equipo correcto.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Próximamente</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Motivos de espera detallados</h5>
+              <p class="text-muted mt-2">"Esperando al cliente", "Esperando a un tercero", "Pendiente de revisión": los tickets en espera no cuentan como vencimiento de SLA, de forma equitativa.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Escritorio del agente</h5>
+              <p class="text-muted mt-2">Al iniciar sesión el agente ve los tickets asignados a él, ordenados por vencimiento: pendientes, en curso y próximos a vencer en un único panel.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard de tickets</h5>
+              <p class="text-muted mt-2">Distribución de nuevos, cerrados, pendientes y vencidos del día; agregados por agente, cliente y línea de producto para una visión global.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Más funciones en desarrollo</h5>
+              <p class="text-muted small mt-2 mb-0">Planificado: evaluación de satisfacción, flujo de transferencia y escalado, plantillas de respuesta, integración con base de conocimientos</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Demo en vivo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Despliega en tu entorno
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Descarga y despliegue</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluido en la plantilla de backup del Sistema de Gestión Integral; se despliega de forma unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Descargar la plantilla de backup</h5>
+                <p class="text-muted mt-2">Backup de la solución integral; tras la restauración tendrás todos los datos preconfigurados de los 6 módulos, este incluido</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Descargar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">o descargar paquete SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consultar la guía de instalación</h5>
+                <p class="text-muted mt-2">Pasos detallados de restauración, preguntas habituales y advertencias, en preparación</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Próximamente</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Empezar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo también está integrado en el <a href="/es/solutions/all-in-one">Sistema de Gestión Integral</a>; puede usarse de forma independiente o combinado con CRM, Gestión de Ventas, Gestión de Proyectos, Gestión de Activos y Recursos Humanos.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Probar la Demo</a>
+            <a href="/es/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Contactar</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseES>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/fr/solutions/all-in-one.astro
+++ b/src/pages/fr/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseFR
+  title="Système de gestion tout-en-un - CRM / Help Desk / Gestion de projet / Gestion d'actifs / RH | NocoBase"
+  description="Système de gestion tout-en-un open source : CRM, gestion commerciale, help desk (tickets), gestion de projet, gestion d'actifs, gestion RH — 6 modules intégrés. Basé sur la plateforme no-code NocoBase, prêt à l'emploi, adapté aux PME pour un déploiement rapide."
+  keywords="système de gestion tout-en-un, CRM open source, logiciel CRM, logiciel help desk, système de tickets, gestion de projet, gestion d'actifs, gestion parc informatique, logiciel RH, gestion commerciale, ERP no-code, plateforme intégrée, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Système de gestion<br/>tout-en-un</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase, couvrant six modules : <strong>CRM (gestion clients), gestion commerciale, help desk (tickets), gestion de projet, gestion d'actifs et RH</strong>.
+              Prêt à l'emploi, sans sélection complexe ni intégration de plusieurs systèmes.
+            </p>
+
+            <!-- Valeurs clés -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Plateforme intégrée</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">20+ langues intégrées</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Employés AI + workflows</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open source et gratuit</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Étiquettes des cas d'usage -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Start-ups</span>
+                  <span class="badge bg-soft-primary me-2">Boutiques multi-activités</span>
+                  <span class="badge bg-soft-primary me-2">Phase d'exploration</span>
+                  <span class="badge bg-soft-primary">Formation et enseignement</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Essayer la démo
+              </a>
+              <a href="/fr/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Nous contacter
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Système de gestion tout-en-un" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 modules coordonnés</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, gestion commerciale, help desk, gestion de projet, gestion d'actifs et RH — tous vos processus métier dans un même système</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- Gestion clients -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Gestion clients)</h5>
+              <p class="text-muted mt-2">CRM open source : processus complet de gestion des leads, du suivi, de la conversion et de la déduplication ; vue 360 du client agrégeant l'historique des commandes, tickets, projets et actifs.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Gestion des étapes et conversion des leads</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Vue 360 du client</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Fusion / déduplication</li>
+              </ul>
+              <a href="/fr/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestion commerciale -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion commerciale</h5>
+              <p class="text-muted mt-2">Gestion des commandes commerciales : chaîne complète devis, commandes, factures, encaissements ; workflows d'approbation et analyse des créances inclus.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Devis multidevises</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Workflow d'approbation des commandes</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI sur les créances en retard</li>
+              </ul>
+              <a href="/fr/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Help Desk -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Tickets)</h5>
+              <p class="text-muted mt-2">Système de tickets pour le service client : signalement client, attribution, traitement et évaluation de la satisfaction ; SLA chronométrés, gestion des priorités et causes d'attente détaillées.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>SLA chronométrés et alertes de dépassement</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tableau de bord et espace de travail des agents</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 niveaux de priorité + classification AI</li>
+              </ul>
+              <a href="/fr/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestion de projet -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion de projet</h5>
+              <p class="text-muted mt-2">Système de gestion de projet léger : gestion à deux niveaux projets et tâches ; couvre les responsables, l'avancement, les jalons et les alertes de retard.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Tableau de bord d'état des projets</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Charge de travail par responsable de tâche</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Alertes sur les projets en retard</li>
+              </ul>
+              <a href="/fr/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestion d'actifs -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion d'actifs</h5>
+              <p class="text-muted mt-2">Gestion du cycle de vie complet des actifs informatiques et de bureau, couvrant l'achat, l'attribution, la maintenance et la mise au rebut, avec registre des fournisseurs associé.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Attribution / restitution</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tickets de maintenance</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Analyse des achats et fournisseurs</li>
+              </ul>
+              <a href="/fr/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- RH -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">RH / Ressources Humaines</h5>
+              <p class="text-muted mt-2">Système RH : registre des collaborateurs, suivi des arrivées, départs, congés et périodes d'essai, avec gestion des postes et structure organisationnelle.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Checklists d'arrivée / départ</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Approbation des congés</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tableau de bord période d'essai</li>
+              </ul>
+              <a href="/fr/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">En savoir plus <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Capacités de la plateforme</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Basé sur NocoBase 2.x, avec AI, workflows, multilingue et multi-espaces intégrés</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>Employés AI</h5>
+            <p class="text-muted small">Lina (localisation), Lexi (traduction), Atlas (collaboration) et d'autres rôles AI intégrés, mobilisables selon le contexte métier.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Support multilingue</h5>
+            <p class="text-muted small">Chinois, anglais, japonais, coréen, allemand, français et plus de 20 langues prises en charge ; interface entièrement traduite.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Moteur de workflows</h5>
+            <p class="text-muted small">Approbations, notifications, chronométrage SLA, déclencheurs programmés ; orchestration visuelle, règles configurables sans code.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Isolation multi-espaces</h5>
+            <p class="text-muted small">Un même système pour plusieurs équipes ou boutiques, avec isolation des données et gestion indépendante des permissions.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">Collaboration AI</span>
+            <h4 class="title mb-4">Employés AI intégrés</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 employés AI préconfigurés couvrant les rôles métier typiques, avec connexion à des agents externes via le protocole MCP</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Chef d'équipe — attribution des tâches et coordination</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Ingénieur front-end — interfaces et génération de blocs JS</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Conception visuelle — graphiques et tableaux de bord</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Analyse — détection des tendances et lecture des KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Recherche — collecte d'informations et synthèse</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Préparation des données — nettoyage, fusion et traitement par lot</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Communication multilingue — échanges et e-mails clients</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Ingénieur de localisation — textes d'interface et i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Assistant e-mail — analyse d'intention et rédaction de réponses</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Employés AI personnalisés</h6>
+              <p class="text-muted small mb-0">Créer des rôles / prompts / combinaisons de compétences sur mesure</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Intégration d'agents externes</h6>
+              <p class="text-muted small mb-0">Protocole MCP pour connecter vos propres agents / chaînes d'outils</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cas d'usage</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Une solution intégrée particulièrement adaptée aux contextes suivants</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Gestion transversale multi-activités</h5>
+                  <p class="text-muted mb-0">Vos activités couvrent plusieurs lignes (commercial, service client, projets) et vous avez besoin d'une vue d'ensemble dans un système unifié, sans basculer entre plusieurs outils.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Boutiques multi-activités</h5>
+                  <p class="text-muted mb-0">La boutique assure à la fois la vente, le SAV et la livraison de projets : beaucoup de lignes mais des volumes limités, où des solutions indépendantes coûtent cher en coordination.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Phase d'exploration métier</h5>
+                  <p class="text-muted mb-0">Votre activité n'est pas encore stabilisée et vous voulez éviter de vous engager trop tôt sur une solution spécifique ; la plateforme intégrée permet de démarrer et d'itérer selon les besoins.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Formation / enseignement / POC</h5>
+                  <p class="text-muted mb-0">En tant qu'exemple complet des capacités de la plateforme NocoBase, utilisable pour la formation interne, la démonstration ou la preuve de concept, couvrant les processus métier types.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Comment l'utiliser ?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Trois étapes pour déployer et commencer à utiliser le système de gestion tout-en-un</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Installer NocoBase</h5>
+                <p class="text-muted mt-2">Déployez NocoBase en local ou sur votre serveur en suivant la documentation officielle</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Voir la documentation</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Après restauration, vous disposez de toutes les données préchargées sur les 6 modules</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Démarrer avec le système de gestion tout-en-un</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Système métier intégré basé sur NocoBase 2.x. Le modèle est directement réutilisable et extensible ; pour des personnalisations métier approfondies, contactez-nous.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Essayer la démo
+            </a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Nous contacter
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/fr/solutions/asset-management.astro
+++ b/src/pages/fr/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseFR
+  title="Gestion d'actifs — parc informatique et mobilier open source | NocoBase"
+  description="Système de gestion d'actifs open source basé sur la plateforme no-code NocoBase : cycle de vie complet achat, attribution, maintenance et mise au rebut, couvrant les actifs informatiques et mobiliers, avec registre des fournisseurs, tickets de maintenance et analyse des achats."
+  keywords="gestion d'actifs, gestion parc informatique, logiciel gestion d'actifs, gestion d'actifs open source, gestion d'actifs de bureau, cycle de vie d'actif, gestion d'équipement, inventaire d'actifs, gestion des fournisseurs, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module Gestion d'actifs</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestion d'actifs</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Cycle de vie complet <strong>achat → attribution → maintenance → mise au rebut</strong>, couvrant les actifs informatiques et mobiliers, avec registre des fournisseurs et tickets de maintenance.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cycle de vie complet</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tickets de maintenance</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Registre des fournisseurs</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Parc informatique</span>
+                  <span class="badge bg-soft-primary me-2">Mobilier de bureau</span>
+                  <span class="badge bg-soft-primary me-2">Location d'équipement</span>
+                  <span class="badge bg-soft-primary">Inventaire</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Interface de la gestion d'actifs" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cycle de vie des actifs</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De l'entrée en stock à la mise au rebut, une traçabilité complète pour chaque actif</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Achat</div>
+                  <div class="small text-muted">Lien fournisseur</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Entrée stock</div>
+                  <div class="small text-muted">Fiche d'actif</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Attribution</div>
+                  <div class="small text-muted">Signature</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Maintenance</div>
+                  <div class="small text-muted">Ticket associé</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Mise au rebut</div>
+                  <div class="small opacity-75">Valeur résiduelle</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Achat</td>
+                      <td class="py-3 text-muted">Bon de commande lié au fournisseur et au prix ; gestion multi-catégories et multi-quantités</td>
+                      <td class="py-3 text-muted">Bon de commande, fournisseur, montant d'achat</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Entrée en stock</td>
+                      <td class="py-3 text-muted">Génération automatique de la fiche d'actif à l'entrée (numéro, n° de série, durée de garantie saisis d'un coup)</td>
+                      <td class="py-3 text-muted">Fiche d'actif, identifiant unique, garantie</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Attribution</td>
+                      <td class="py-3 text-muted">Actif attribué à un collaborateur / client / service avec signature</td>
+                      <td class="py-3 text-muted">Historique d'attribution, utilisateur, dates</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Maintenance</td>
+                      <td class="py-3 text-muted">Ouverture d'un ticket de maintenance en cas de panne ou d'entretien, lié à la fiche d'actif</td>
+                      <td class="py-3 text-muted">Ticket de maintenance, coût cumulé</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Mise au rebut</td>
+                      <td class="py-3 text-muted">Enregistrement du motif de rebut (panne / obsolescence / revente), amortissement et valeur résiduelle</td>
+                      <td class="py-3 text-muted">Historique de rebut, valeur résiduelle, mode de cession</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestion complète des actifs, de l'achat à la mise au rebut</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Achat d'actifs</h5>
+              <p class="text-muted mt-2">Bon de commande lié au fournisseur et au prix ; entrée en stock générant automatiquement la fiche d'actif avec numéro, série et garantie en une seule saisie.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Attribution / restitution</h5>
+              <p class="text-muted mt-2">Actif prêté à un collaborateur ou un client avec signature ; restitution libère automatiquement l'actif ; historique d'utilisation entièrement traçable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tickets de maintenance</h5>
+              <p class="text-muted mt-2">Ouverture de ticket pour panne ou entretien, lié à la fiche d'actif ; les coûts d'entretien s'accumulent et alimentent la décision de mise au rebut.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mise au rebut / revente</h5>
+              <p class="text-muted mt-2">Enregistrement du motif (panne / obsolescence / revente) ; amortissement et valeur résiduelle conservés, cohérents avec la comptabilité.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registre des fournisseurs</h5>
+              <p class="text-muted mt-2">Fiche fournisseur + historique d'achats ; montants, catégories et conditions de paiement visibles d'un coup d'œil pour appuyer la décision d'achat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord des actifs</h5>
+              <p class="text-muted mt-2">Total, en usage, en maintenance, mis au rebut : répartition agrégée par type, service et utilisateur ; données d'inventaire exportables en un clic.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Autres fonctionnalités à venir</h5>
+              <p class="text-muted small mt-2 mb-0">Prévu : tâches d'inventaire, calcul automatique d'amortissement, scan QR code, flux d'approbation de demande d'actif</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, la gestion commerciale, le help desk, la gestion de projet et les RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/fr/solutions/crm-v2.astro
+++ b/src/pages/fr/solutions/crm-v2.astro
@@ -1,0 +1,366 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseFR
+  title="CRM (Gestion clients) — open source et auto-hébergeable | NocoBase"
+  description="CRM open source basé sur la plateforme no-code NocoBase : gestion des leads, suivi client, conversion, fusion / déduplication, vue 360 du client. Prêt à l'emploi, déployable en interne."
+  keywords="CRM, CRM open source, logiciel CRM, gestion de la relation client, gestion des leads, suivi client, vue 360 client, CRM no-code, CRM auto-hébergeable, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestion clients</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Couvre le processus complet leads, suivi, conversion et fusion / déduplication ; la vue 360 du client agrège l'historique des commandes, tickets, projets et actifs.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestion des étapes des leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Vue 360 client</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Fusion / déduplication</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Vente B2B</span>
+                  <span class="badge bg-soft-primary me-2">Vente projet</span>
+                  <span class="badge bg-soft-primary me-2">Commerce international</span>
+                  <span class="badge bg-soft-primary">PME</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interface du CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Processus de gestion clients</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De la captation des leads à la vue 360 du client, l'ensemble de la chaîne de données est connectée</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Leads</div>
+                  <div class="small text-muted">Multi-canaux</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Suivi</div>
+                  <div class="small text-muted">Historique</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversion</div>
+                  <div class="small text-muted">Création fiche</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Vue 360</div>
+                  <div class="small text-muted">Agrégation</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Capitalisation</div>
+                  <div class="small opacity-75">Tableau de bord</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Leads</td>
+                      <td class="py-3 text-muted">Formulaire / import / saisie manuelle, marquage de la source et du commercial attribué</td>
+                      <td class="py-3 text-muted">Pool de leads, étiquette de source, transitions d'étape</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Suivi</td>
+                      <td class="py-3 text-muted">Enregistrement des appels, e-mails et visites, planification du prochain suivi</td>
+                      <td class="py-3 text-muted">Chronologie de suivi, rappel suivant</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Conversion</td>
+                      <td class="py-3 text-muted">Lead converti en client, fiche client renseignée (secteur, taille, contacts)</td>
+                      <td class="py-3 text-muted">Table clients, table contacts, lien vers les leads</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Vue 360</td>
+                      <td class="py-3 text-muted">Vue complète du client : commandes, tickets, projets, actifs</td>
+                      <td class="py-3 text-muted">Blocs intégrés, relations transverses</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Capitalisation</td>
+                      <td class="py-3 text-muted">Tableau de bord commercial agrégeant les KPI par commercial / région / type</td>
+                      <td class="py-3 text-muted">Graphiques, drill-down, exports</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clients, suivis, tableaux de bord — couverture complète de la gestion de la relation client</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Import de leads</h5>
+              <p class="text-muted mt-2">Import Excel en masse, formulaires de captation, intégration via API : trois modes ; mappage de champs visuel et déduplication automatique des conflits.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Transitions d'étapes</h5>
+              <p class="text-muted mt-2">Étapes des leads (nouveau / contacté / converti / abandonné) configurables visuellement ; chaque changement est tracé et le taux de conversion est calculé automatiquement.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Historique de suivi</h5>
+              <p class="text-muted mt-2">Chaque visite, appel ou e-mail est enregistré ; la chronologie donne l'historique de communication complet, facilitant les passages de relais.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Rappels de suivi</h5>
+              <p class="text-muted mt-2">Notification automatique avant l'échéance du prochain suivi ; les clients sans contact prolongé apparaissent dans un tableau « à relancer » pour éviter les oublis.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vue 360 du client</h5>
+              <p class="text-muted mt-2">La fiche client agrège commandes, tickets, projets et actifs ; toute l'information sur un seul écran, sans changer de système.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catégories et étiquettes</h5>
+              <p class="text-muted mt-2">Étiquettes multidimensionnelles par type de client, secteur, taille et source ; filtrage et analyses agrégées par étiquette.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fusion / déduplication</h5>
+              <p class="text-muted mt-2">Détection automatique des doublons lors de saisies répétées ; fusion en un clic, sans perte d'historique de suivi ni de relations associées.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord commercial</h5>
+              <p class="text-muted mt-2">KPI agrégés par commercial, région et type de client ; nouveaux clients, taux de conversion, répartition des clients actifs.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissions par champ et par ligne</h5>
+              <p class="text-muted mt-2">Visibilité des champs configurable par rôle ; chaque commercial voit ses propres clients, le manager voit l'ensemble.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec la gestion commerciale, le help desk, la gestion de projet, la gestion d'actifs et les RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/fr/solutions/crm.astro
+++ b/src/pages/fr/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseFR from "../../../layouts/BaseFR.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="No-code, Flexible & Powerful CRM Platform"
-  description="Ready to use out of the box. Provides ultimate customization capabilities while ensuring complete data sovereignty. You can extend fields, blocks, functions, and pages on this foundation to make it fully meet your business needs."
-  keywords="NocoBase CRM, Customer Relationship Management, No-code CRM, Open Source CRM, Custom CRM"
+<BaseFR
+  title="CRM (Gestion clients) — open source et auto-hébergeable | NocoBase"
+  description="CRM open source basé sur la plateforme no-code NocoBase : gestion des leads, suivi client, conversion, fusion / déduplication, vue 360 du client. Prêt à l'emploi, déployable en interne."
+  keywords="CRM, CRM open source, logiciel CRM, gestion de la relation client, gestion des leads, suivi client, vue 360 client, CRM no-code, CRM auto-hébergeable, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">No-code, Flexible & Powerful<br/>CRM Platform</h1>
-            <p class="para-desc text-muted">Ready to use out of the box, with powerful customization to fit your unique needs. Extend fields, blocks, and pages to build the perfect solution for your business—all while keeping full control of your data.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestion clients</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Couvre le processus complet leads, suivi, conversion et fusion / déduplication ; la vue 360 du client agrège l'historique des commandes, tickets, projets et actifs.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestion des étapes des leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Vue 360 client</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Fusion / déduplication</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Vente B2B</span>
+                  <span class="badge bg-soft-primary me-2">Vente projet</span>
+                  <span class="badge bg-soft-primary me-2">Commerce international</span>
+                  <span class="badge bg-soft-primary">PME</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interface du CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase CRM Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Unlike SaaS and other CRM systems, NocoBase CRM is flexible and fully controlled</p>
+            <h4 class="title mb-4">Processus de gestion clients</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De la captation des leads à la vue 360 du client, l'ensemble de la chaîne de données est connectée</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Completely No-Code</h5>
-              <p class="text-muted mt-2">No programming skills required for CRM customization</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Covers Common CRM Features</h5>
-              <p class="text-muted mt-2">Customer management, sales pipeline, opportunity tracking, contact management, email communication, approval processes and more</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easily Modifiable & Extensible</h5>
-              <p class="text-muted mt-2">Supports custom fields, processes and business logic, flexible architecture makes "secondary development" simple</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Full Data Control</h5>
-              <p class="text-muted mt-2">Complete control over system code and data, ensuring enterprise data security</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Try NocoBase CRM Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Quick experience with just a few clicks</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Dashboard Data Visualization</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Interactive Demo
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Leads</div>
+                  <div class="small text-muted">Multi-canaux</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Suivi</div>
+                  <div class="small text-muted">Historique</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversion</div>
+                  <div class="small text-muted">Création fiche</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Vue 360</div>
+                  <div class="small text-muted">Agrégation</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Capitalisation</div>
+                  <div class="small opacity-75">Tableau de bord</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Lead Conversion Process</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Leads</td>
+                      <td class="py-3 text-muted">Formulaire / import / saisie manuelle, marquage de la source et du commercial attribué</td>
+                      <td class="py-3 text-muted">Pool de leads, étiquette de source, transitions d'étape</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Suivi</td>
+                      <td class="py-3 text-muted">Enregistrement des appels, e-mails et visites, planification du prochain suivi</td>
+                      <td class="py-3 text-muted">Chronologie de suivi, rappel suivant</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Conversion</td>
+                      <td class="py-3 text-muted">Lead converti en client, fiche client renseignée (secteur, taille, contacts)</td>
+                      <td class="py-3 text-muted">Table clients, table contacts, lien vers les leads</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Vue 360</td>
+                      <td class="py-3 text-muted">Vue complète du client : commandes, tickets, projets, actifs</td>
+                      <td class="py-3 text-muted">Blocs intégrés, relations transverses</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Capitalisation</td>
+                      <td class="py-3 text-muted">Tableau de bord commercial agrégeant les KPI par commercial / région / type</td>
+                      <td class="py-3 text-muted">Graphiques, drill-down, exports</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clients, suivis, tableaux de bord — couverture complète de la gestion de la relation client</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Import de leads</h5>
+              <p class="text-muted mt-2">Import Excel en masse, formulaires de captation, intégration via API : trois modes ; mappage de champs visuel et déduplication automatique des conflits.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Transitions d'étapes</h5>
+              <p class="text-muted mt-2">Étapes des leads (nouveau / contacté / converti / abandonné) configurables visuellement ; chaque changement est tracé et le taux de conversion est calculé automatiquement.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/fr/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Historique de suivi</h5>
+              <p class="text-muted mt-2">Chaque visite, appel ou e-mail est enregistré ; la chronologie donne l'historique de communication complet, facilitant les passages de relais.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Rappels de suivi</h5>
+              <p class="text-muted mt-2">Notification automatique avant l'échéance du prochain suivi ; les clients sans contact prolongé apparaissent dans un tableau « à relancer » pour éviter les oublis.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vue 360 du client</h5>
+              <p class="text-muted mt-2">La fiche client agrège commandes, tickets, projets et actifs ; toute l'information sur un seul écran, sans changer de système.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catégories et étiquettes</h5>
+              <p class="text-muted mt-2">Étiquettes multidimensionnelles par type de client, secteur, taille et source ; filtrage et analyses agrégées par étiquette.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fusion / déduplication</h5>
+              <p class="text-muted mt-2">Détection automatique des doublons lors de saisies répétées ; fusion en un clic, sans perte d'historique de suivi ni de relations associées.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord commercial</h5>
+              <p class="text-muted mt-2">KPI agrégés par commercial, région et type de client ; nouveaux clients, taux de conversion, répartition des clients actifs.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissions par champ et par ligne</h5>
+              <p class="text-muted mt-2">Visibilité des champs configurable par rôle ; chaque commercial voit ses propres clients, le manager voit l'ensemble.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec la gestion commerciale, le help desk, la gestion de projet, la gestion d'actifs et les RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseFR>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/fr/solutions/hr-management.astro
+++ b/src/pages/fr/solutions/hr-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseFR
+  title="RH / Ressources Humaines — logiciel RH open source | NocoBase"
+  description="Système RH open source basé sur la plateforme no-code NocoBase : registre des collaborateurs, suivi des arrivées, départs, congés et périodes d'essai, gestion des postes et de la structure organisationnelle. Léger et auto-hébergeable, adapté aux équipes RH des PME."
+  keywords="logiciel RH, ressources humaines, système RH, RH open source, gestion des collaborateurs, gestion des arrivées, gestion des départs, approbation des congés, gestion des périodes d'essai, organigramme, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module RH</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">RH / Ressources Humaines</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Registre des collaborateurs, suivi complet <strong>arrivées, départs, congés et périodes d'essai</strong>, avec gestion des postes et de la structure organisationnelle.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Checklists arrivée / départ</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Approbation des congés</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tableau période d'essai</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">PME</span>
+                  <span class="badge bg-soft-primary me-2">Réseaux de boutiques</span>
+                  <span class="badge bg-soft-primary me-2">RH spécialisé</span>
+                  <span class="badge bg-soft-primary">Collaboration interservices</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Interface du système RH" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cycle de vie du collaborateur</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Du recrutement au départ, une boucle complète de gestion des ressources humaines</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Recrutement</div>
+                  <div class="small text-muted">Candidats</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Arrivée</div>
+                  <div class="small text-muted">Checklist</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Gestion courante</div>
+                  <div class="small text-muted">Présence / congés</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Évaluation</div>
+                  <div class="small text-muted">Titularisation</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Départ</div>
+                  <div class="small opacity-75">Passation</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Recrutement</td>
+                      <td class="py-3 text-muted">Saisie des candidats, évaluation d'entretien ; conversion en dossier collaborateur après acceptation</td>
+                      <td class="py-3 text-muted">Table candidats, notes d'entretien</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Arrivée</td>
+                      <td class="py-3 text-muted">Checklist d'arrivée (contrat, badge, équipement, comptes)</td>
+                      <td class="py-3 text-muted">Checklist d'arrivée, dossier contrat</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Gestion courante</td>
+                      <td class="py-3 text-muted">Présence, congés, récupérations et heures supplémentaires</td>
+                      <td class="py-3 text-muted">Historique de congés, solde</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Évaluation</td>
+                      <td class="py-3 text-muted">Évaluation de période d'essai, titularisation, mobilité, promotion</td>
+                      <td class="py-3 text-muted">Grille d'évaluation, changement de poste</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Départ</td>
+                      <td class="py-3 text-muted">Checklist de départ : passation, restitution des actifs, fermeture des comptes, formalités</td>
+                      <td class="py-3 text-muted">Historique de départ, libération des actifs</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestion RH complète, de l'arrivée au départ</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registre des employés</h5>
+              <p class="text-muted mt-2">Profil des employés avec matricule, date d'embauche, poste, département — dossiers unifiés, recherche multidimensionnelle.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cycle de vie de l'employé</h5>
+              <p class="text-muted mt-2">En attente d'intégration → période d'essai → actif → en cours de départ → inactif : 5 statuts traversent le dossier employé ; filtrer par statut en un coup d'œil.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Structure départementale</h5>
+              <p class="text-muted mt-2">Organigramme en arbre : département → sous-département, basé sur le plugin departments natif de NocoBase, lié aux permissions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fiche de poste</h5>
+              <p class="text-muted mt-2">Définitions de postes avec niveau (junior / intermédiaire / senior / expert) ; employés liés aux postes pour la gestion de carrière et des permissions.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Approbation des congés</h5>
+              <p class="text-muted mt-2">8 types de congés (annuel / maladie / personnel / récupération / mariage / parental / décès / autre) ; flux d'approbation configurable par département / supérieur hiérarchique.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissions au niveau du champ</h5>
+              <p class="text-muted mt-2">RH voit les champs salaires ; les managers voient les infos de base de leur équipe — configuration flexible via les permissions de rôle NocoBase.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Autres fonctionnalités à venir</h5>
+              <p class="text-muted small mt-2 mb-0">Prévu : checklists d'intégration/départ, évaluation de période d'essai, gestion contrats & sécurité sociale, candidats au recrutement, historique mutation/promotion</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, la gestion commerciale, le help desk, la gestion de projet et la gestion d'actifs.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/fr/solutions/project-management.astro
+++ b/src/pages/fr/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseFR from "../../../layouts/BaseFR.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BaseFR
+  title="Gestion de projet — collaboration légère et open source | NocoBase"
+  description="Système de gestion de projet open source basé sur la plateforme no-code NocoBase : gestion à deux niveaux projets + tâches, responsables, avancement, jalons, alertes de retard, répartition de la charge de travail. Léger, auto-hébergeable, adapté aux PME et à la collaboration interservices."
+  keywords="gestion de projet, logiciel de gestion de projet, gestion des tâches, gestion de projet open source, projet léger, collaboration projet, suivi de projet, gestion des jalons, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,337 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module Gestion de projet</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestion de projet</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Gestion à deux niveaux <strong>projets + tâches</strong>, couvrant responsables, avancement, jalons, alertes de retard et répartition de la charge de travail ; léger et auto-hébergeable.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Projets + tâches</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Alertes de retard</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Suivi des jalons</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Projets de livraison</span>
+                  <span class="badge bg-soft-primary me-2">IT interne</span>
+                  <span class="badge bg-soft-primary me-2">Collaboration interservices</span>
+                  <span class="badge bg-soft-primary">PME</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Interface du système de gestion de projet" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cycle d'un projet</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De l'initialisation à la clôture, une boucle de suivi complète avec jalons et alertes de retard automatiques</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Initialisation</div>
+                  <div class="small text-muted">Lien client</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Découpage</div>
+                  <div class="small text-muted">Responsable</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Suivi</div>
+                  <div class="small text-muted">Alertes retard</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Jalons</div>
+                  <div class="small text-muted">Livrables d'étape</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Clôture</div>
+                  <div class="small opacity-75">Bilan / archive</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Initialisation</td>
+                      <td class="py-3 text-muted">Création du projet, rattachement au client (projets de livraison) ou aux actifs (projets IT), désignation du chef de projet</td>
+                      <td class="py-3 text-muted">Fiche projet, lien client, responsable</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Découpage</td>
+                      <td class="py-3 text-muted">Décomposition en tâches avec responsable, dates de début/fin et dépendances</td>
+                      <td class="py-3 text-muted">Table des tâches, responsables, graphe de dépendances</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Suivi</td>
+                      <td class="py-3 text-muted">Mise à jour de l'avancement par les membres ; les tâches en dépassement sont marquées en rouge automatiquement</td>
+                      <td class="py-3 text-muted">Pourcentage d'avancement, marqueur de retard</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Jalons</td>
+                      <td class="py-3 text-muted">Étapes clés définies comme jalons (revue / test / mise en production) ; livrables d'étape consignés</td>
+                      <td class="py-3 text-muted">Liste des jalons, pièces jointes des livrables</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Clôture</td>
+                      <td class="py-3 text-muted">Archivage du projet à la fin, enregistrement des heures et des coûts</td>
+                      <td class="py-3 text-muted">Rapport de clôture, synthèse des heures</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Suivi léger et complet, de l'initialisation à la clôture du projet</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Projets + tâches</h5>
+              <p class="text-muted mt-2">Un projet est décomposé en plusieurs tâches, chacune avec son responsable, ses dates et son avancement ; le tableau de bord projet récapitule l'état de toutes les tâches.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion des jalons</h5>
+              <p class="text-muted mt-2">Les étapes clés (revue de maquette, test interne, mise en production) sont définies comme jalons ; l'avancement du projet est rythmé par leurs échéances.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Alertes de retard</h5>
+              <p class="text-muted mt-2">Les tâches dépassant l'échéance sont marquées en rouge ; la liste des projets en retard se met à jour en temps réel, les risques sont visibles d'un coup d'œil.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Responsables et charge</h5>
+              <p class="text-muted mt-2">Agrégation du nombre de tâches et de la charge par responsable ; qui est en surcharge, qui est disponible, qui accumule les retards — visible immédiatement.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord d'état</h5>
+              <p class="text-muted mt-2">KPI agrégés par type de projet, statut et responsable ; projets en cours, clos et en retard sont présentés séparément.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lien client et actifs</h5>
+              <p class="text-muted mt-2">Le projet peut être rattaché à un client (projets de livraison) ou à un actif (projets IT) ; la fiche client affiche l'historique des projets associés.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Autres fonctionnalités à venir</h5>
+              <p class="text-muted small mt-2 mb-0">Prévu : graphe de dépendances de tâches, saisie des temps & coûts, archive des livrables, vue Gantt</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, la gestion commerciale, le help desk, la gestion d'actifs et les RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseFR>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/fr/solutions/project-management.astro
+++ b/src/pages/fr/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Jalons</div>
                   <div class="small text-muted">Livrables d'étape</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Gestion des jalons</h5>
               <p class="text-muted mt-2">Les étapes clés (revue de maquette, test interne, mise en production) sont définies comme jalons ; l'avancement du projet est rythmé par leurs échéances.</p>

--- a/src/pages/fr/solutions/sales-management.astro
+++ b/src/pages/fr/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI sur les créances</h5>
-              <p class="text-muted mt-2">Liste des créances en retard et analyse par âge (classes 30/60/90 jours) ; agrégation par client et par commercial pour des relances claires.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multidevises et taux de change</h5>
-              <p class="text-muted mt-2">Devis et commandes en USD/EUR/CNY et autres devises ; table des taux maintenable manuellement ou par import ; conversion automatique en devise de référence.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Expédition et logistique</h5>
-              <p class="text-muted mt-2">Bon d'expédition relié à la commande et au numéro de suivi ; expéditions multiples ou partielles possibles ; statut synchronisé automatiquement avec la commande.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Tableau de bord commercial</h5>

--- a/src/pages/fr/solutions/sales-management.astro
+++ b/src/pages/fr/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseFR
+  title="Gestion commerciale — commandes et créances open source | NocoBase"
+  description="Système de gestion commerciale open source basé sur la plateforme no-code NocoBase : chaîne complète devis, commandes, factures, encaissements, avec workflows d'approbation, multidevises, KPI sur les créances et analyse des retards."
+  keywords="gestion commerciale, gestion des commandes, devis, gestion des factures, gestion des créances, encaissement, workflow commercial, approbation commande, gestion commerciale open source, devis multidevises, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module Gestion commerciale</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestion commerciale</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Chaîne complète <strong>devis → commandes → factures → encaissements</strong>, avec workflow d'approbation, devis multidevises, KPI sur les créances et analyse des retards intégrés.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Devis multidevises</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Workflow d'approbation</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI sur les créances</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Vente B2B</span>
+                  <span class="badge bg-soft-primary me-2">Commerce international</span>
+                  <span class="badge bg-soft-primary me-2">Vente d'équipement</span>
+                  <span class="badge bg-soft-primary">Gestion des créances</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Interface de la gestion commerciale" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cycle commercial</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Du devis à l'encaissement, une boucle complète où approbations et KPI sur les créances sont connectés</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Devis</div>
+                  <div class="small text-muted">Multidevises</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Commande</div>
+                  <div class="small text-muted">Approbation</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Expédition</div>
+                  <div class="small text-muted">Suivi logistique</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Facture</div>
+                  <div class="small text-muted">Pré-remplissage</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Encaissement</div>
+                  <div class="small opacity-75">KPI créances</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Devis</td>
+                      <td class="py-3 text-muted">Sélection client/produit, génération de devis multidevises, gestion des remises, taxes et durée de validité</td>
+                      <td class="py-3 text-muted">Devis, détail des produits, export PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Commande</td>
+                      <td class="py-3 text-muted">Devis converti en commande ; remises hors barème ou montants élevés déclenchent l'approbation</td>
+                      <td class="py-3 text-muted">Commande, workflow d'approbation, détail commande</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Expédition</td>
+                      <td class="py-3 text-muted">Bon d'expédition après confirmation de commande, avec numéro de suivi logistique</td>
+                      <td class="py-3 text-muted">Bon d'expédition, numéro de tracking, transitions de statut</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Facture</td>
+                      <td class="py-3 text-muted">Facturation après commande ou expédition ; numéro de TVA et adresse client pré-remplis automatiquement</td>
+                      <td class="py-3 text-muted">Enregistrement factures, statut de facturation</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Encaissement</td>
+                      <td class="py-3 text-muted">Encaissements partiels enregistrés ; KPI créances agrégés par âge</td>
+                      <td class="py-3 text-muted">Historique d'encaissements, solde créances, classes d'âge</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Devis, commandes, factures, encaissements — chaîne complète, approbations et analyse des créances</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion des devis</h5>
+              <p class="text-muted mt-2">Devis multidevises, gestion des remises, taux de taxes et durée de validité ; export PDF en un clic pour envoi au client ; conversion en commande disponible.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Commandes commerciales</h5>
+              <p class="text-muted mt-2">Transitions de statut (brouillon / en revue / confirmée / expédiée / clôturée), liens client et produit, détails de commande éditables ligne par ligne.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workflow d'approbation</h5>
+              <p class="text-muted mt-2">Remises hors barème, montants élevés et conditions particulières déclenchent l'approbation ; étapes configurables par service, poste et seuil de montant.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestion des factures</h5>
+              <p class="text-muted mt-2">Facture générée à partir de la commande, statut de facturation suivi ; numéro de TVA, adresse et notes du client pré-remplis pour limiter les erreurs.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Suivi des encaissements</h5>
+              <p class="text-muted mt-2">Encaissements partiels enregistrés ; solde créances calculé automatiquement ; statut de paiement agrégé par client et par commande.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI sur les créances</h5>
+              <p class="text-muted mt-2">Liste des créances en retard et analyse par âge (classes 30/60/90 jours) ; agrégation par client et par commercial pour des relances claires.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Multidevises et taux de change</h5>
+              <p class="text-muted mt-2">Devis et commandes en USD/EUR/CNY et autres devises ; table des taux maintenable manuellement ou par import ; conversion automatique en devise de référence.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Expédition et logistique</h5>
+              <p class="text-muted mt-2">Bon d'expédition relié à la commande et au numéro de suivi ; expéditions multiples ou partielles possibles ; statut synchronisé automatiquement avec la commande.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord commercial</h5>
+              <p class="text-muted mt-2">Agrégation du chiffre d'affaires, du nombre de commandes et du taux de recouvrement par commercial, région et produit ; tendance mensuelle / trimestrielle évidente.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, le help desk, la gestion de projet, la gestion d'actifs et les RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/fr/solutions/ticketing-v2.astro
+++ b/src/pages/fr/solutions/ticketing-v2.astro
@@ -1,0 +1,350 @@
+---
+import BaseFR from "../../../layouts/BaseFR.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseFR
+  title="Help Desk (Tickets) — logiciel de support client open source | NocoBase"
+  description="Système de tickets open source basé sur la plateforme no-code NocoBase : signalement client, attribution intelligente, chronométrage SLA, priorités, classification AI, évaluation de satisfaction, espace de travail des agents. Prêt à l'emploi, adapté aux équipes support et SAV."
+  keywords="help desk, logiciel help desk, système de tickets, ticketing open source, support client, gestion SLA, logiciel SAV, service client, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Chaîne complète <strong>signalement client → attribution intelligente → traitement → évaluation de satisfaction</strong>, avec chronométrage SLA, gestion des priorités, classification AI et espace de travail des agents intégrés.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Chronométrage SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 niveaux de priorité</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Classification AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Support et SAV</span>
+                  <span class="badge bg-soft-primary me-2">Service IT</span>
+                  <span class="badge bg-soft-primary me-2">Maintenance d'équipement</span>
+                  <span class="badge bg-soft-primary">Support SaaS</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interface du système de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Processus de traitement des tickets</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Du signalement client à l'évaluation à la clôture, une boucle complète avec SLA chronométré de bout en bout</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Création</div>
+                  <div class="small text-muted">Multi-canaux</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classification</div>
+                  <div class="small text-muted">Détection AI</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Attribution</div>
+                  <div class="small text-muted">Règles par équipe</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Traitement</div>
+                  <div class="small text-muted">SLA chronométré</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Évaluation</div>
+                  <div class="small opacity-75">Clôture et archivage</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Création</td>
+                      <td class="py-3 text-muted">Soumission par e-mail, formulaire ou messagerie ; rattachement client et produit</td>
+                      <td class="py-3 text-muted">Numéro de ticket, source, fiche client</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classification</td>
+                      <td class="py-3 text-muted">L'AI identifie la catégorie (compte / fonctionnalité / bug) et définit la priorité automatiquement</td>
+                      <td class="py-3 text-muted">Étiquettes de classification, priorité, score de confiance</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Attribution</td>
+                      <td class="py-3 text-muted">Affectation par règles à l'équipe ou agent ; les tickets urgents notifient l'agent de garde</td>
+                      <td class="py-3 text-muted">Responsable, historique d'attribution, file d'équipe</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Traitement</td>
+                      <td class="py-3 text-muted">Échanges agent / client ; SLA chronométré avec alerte automatique avant dépassement</td>
+                      <td class="py-3 text-muted">Journal de traitement, statut SLA, cause d'attente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Évaluation</td>
+                      <td class="py-3 text-muted">À la clôture, demande d'évaluation client (1-5 étoiles + commentaire) agrégée par agent / produit</td>
+                      <td class="py-3 text-muted">Notes de satisfaction, ticket archivé, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De la prise en charge à la clôture : gestion complète des tickets de support client</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA et alertes</h5>
+              <p class="text-muted mt-2">Calcul automatique des délais de réponse et de résolution selon la priorité ; alerte avant dépassement, ticket en rouge si dépassé ; taux d'atteinte SLA visualisable.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 niveaux de priorité</h5>
+              <p class="text-muted mt-2">Urgente, haute, moyenne, basse, chaque niveau associé à un délai de réponse propre ; les tickets urgents sont épinglés et l'agent de garde est notifié.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Classification AI</h5>
+              <p class="text-muted mt-2">L'AI catégorise automatiquement les nouveaux tickets (problème de compte / question fonctionnelle / rapport de bug) et les attribue à l'équipe adéquate selon les règles.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Causes d'attente détaillées</h5>
+              <p class="text-muted mt-2">« En attente du client », « En attente d'un tiers », « À valider » : les tickets en attente ne comptent pas dans le dépassement SLA.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Espace de travail des agents</h5>
+              <p class="text-muted mt-2">L'agent voit immédiatement ses tickets affectés, triés par échéance ; un écran pour tout : à traiter, en cours, proches de l'échéance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord des tickets</h5>
+              <p class="text-muted mt-2">Nouveaux / clos / en attente / en dépassement du jour ; agrégations par agent, client, gamme de produits, vue d'ensemble pour les managers.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Autres fonctionnalités à venir</h5>
+              <p class="text-muted small mt-2 mb-0">Prévu : évaluation de satisfaction, flux de transfert & escalade, modèles de réponse, intégration base de connaissances</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, la gestion commerciale, la gestion de projet, la gestion d'actifs et les RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseFR>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/fr/solutions/ticketing.astro
+++ b/src/pages/fr/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseFR from "../../../layouts/BaseFR.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BaseFR
+  title="Help Desk (Tickets) — logiciel de support client open source | NocoBase"
+  description="Système de tickets open source basé sur la plateforme no-code NocoBase : signalement client, attribution intelligente, chronométrage SLA, priorités, classification AI, évaluation de satisfaction, espace de travail des agents. Prêt à l'emploi, adapté aux équipes support et SAV."
+  keywords="help desk, logiciel help desk, système de tickets, ticketing open source, support client, gestion SLA, logiciel SAV, service client, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,337 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/fr/solutions/all-in-one" class="text-muted small text-decoration-none">Système de gestion tout-en-un</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">module Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
+            <p class="para-desc text-muted">
+              Construit sur la plateforme no-code NocoBase. Chaîne complète <strong>signalement client → attribution intelligente → traitement → évaluation de satisfaction</strong>, avec chronométrage SLA, gestion des priorités, classification AI et espace de travail des agents intégrés.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Chronométrage SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 niveaux de priorité</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Classification AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source et gratuit</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cas d'usage :</span>
+                  <span class="badge bg-soft-primary me-2">Support et SAV</span>
+                  <span class="badge bg-soft-primary me-2">Service IT</span>
+                  <span class="badge bg-soft-primary me-2">Maintenance d'équipement</span>
+                  <span class="badge bg-soft-primary">Support SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+              <a href="/fr/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Voir la solution complète</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interface du système de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Processus de traitement des tickets</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Du signalement client à l'évaluation à la clôture, une boucle complète avec SLA chronométré de bout en bout</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/en/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/en/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Création</div>
+                  <div class="small text-muted">Multi-canaux</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classification</div>
+                  <div class="small text-muted">Détection AI</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Attribution</div>
+                  <div class="small text-muted">Règles par équipe</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Traitement</div>
+                  <div class="small text-muted">SLA chronométré</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Évaluation</div>
+                  <div class="small opacity-75">Clôture et archivage</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Étape</th>
+                      <th class="border-0 py-3">Actions clés</th>
+                      <th class="border-0 py-3">Données enregistrées</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Création</td>
+                      <td class="py-3 text-muted">Soumission par e-mail, formulaire ou messagerie ; rattachement client et produit</td>
+                      <td class="py-3 text-muted">Numéro de ticket, source, fiche client</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classification</td>
+                      <td class="py-3 text-muted">L'AI identifie la catégorie (compte / fonctionnalité / bug) et définit la priorité automatiquement</td>
+                      <td class="py-3 text-muted">Étiquettes de classification, priorité, score de confiance</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Attribution</td>
+                      <td class="py-3 text-muted">Affectation par règles à l'équipe ou agent ; les tickets urgents notifient l'agent de garde</td>
+                      <td class="py-3 text-muted">Responsable, historique d'attribution, file d'équipe</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Traitement</td>
+                      <td class="py-3 text-muted">Échanges agent / client ; SLA chronométré avec alerte automatique avant dépassement</td>
+                      <td class="py-3 text-muted">Journal de traitement, statut SLA, cause d'attente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Évaluation</td>
+                      <td class="py-3 text-muted">À la clôture, demande d'évaluation client (1-5 étoiles + commentaire) agrégée par agent / produit</td>
+                      <td class="py-3 text-muted">Notes de satisfaction, ticket archivé, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/en/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/en/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/en/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Fonctionnalités principales</h4>
+            <p class="para-desc mx-auto text-muted mb-0">De la prise en charge à la clôture : gestion complète des tickets de support client</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA et alertes</h5>
+              <p class="text-muted mt-2">Calcul automatique des délais de réponse et de résolution selon la priorité ; alerte avant dépassement, ticket en rouge si dépassé ; taux d'atteinte SLA visualisable.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 niveaux de priorité</h5>
+              <p class="text-muted mt-2">Urgente, haute, moyenne, basse, chaque niveau associé à un délai de réponse propre ; les tickets urgents sont épinglés et l'agent de garde est notifié.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Classification AI</h5>
+              <p class="text-muted mt-2">L'AI catégorise automatiquement les nouveaux tickets (problème de compte / question fonctionnelle / rapport de bug) et les attribue à l'équipe adéquate selon les règles.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Causes d'attente détaillées</h5>
+              <p class="text-muted mt-2">« En attente du client », « En attente d'un tiers », « À valider » : les tickets en attente ne comptent pas dans le dépassement SLA.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Espace de travail des agents</h5>
+              <p class="text-muted mt-2">L'agent voit immédiatement ses tickets affectés, triés par échéance ; un écran pour tout : à traiter, en cours, proches de l'échéance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tableau de bord des tickets</h5>
+              <p class="text-muted mt-2">Nouveaux / clos / en attente / en dépassement du jour ; agrégations par agent, client, gamme de produits, vue d'ensemble pour les managers.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Autres fonctionnalités à venir</h5>
+              <p class="text-muted small mt-2 mb-0">Prévu : évaluation de satisfaction, flux de transfert & escalade, modèles de réponse, intégration base de connaissances</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Téléchargement et déploiement</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ce module fait partie du modèle de sauvegarde du système de gestion tout-en-un, déployé en une seule fois</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Télécharger le modèle de sauvegarde</h5>
+                <p class="text-muted mt-2">Sauvegarde de la solution intégrée : après restauration, vous disposez des données préchargées des 6 modules dont celui-ci</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Télécharger la sauvegarde .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Ou télécharger l'archive SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulter la documentation d'installation</h5>
+                <p class="text-muted mt-2">Étapes de restauration détaillées, FAQ et points d'attention, en préparation</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Bientôt disponible</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Démarrer</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Ce module est également intégré au <a href="/fr/solutions/all-in-one">Système de gestion tout-en-un</a> ; utilisable seul, ou en synergie avec le CRM, la gestion commerciale, la gestion de projet, la gestion d'actifs et les RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Essayer la démo</a>
+            <a href="/fr/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Nous contacter</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseFR>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/id/solutions/all-in-one.astro
+++ b/src/pages/id/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseID from "../../../layouts/BaseID.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseID
+  title="Sistem Manajemen Bisnis Terintegrasi - CRM / Tiket / Manajemen Proyek / Aset Tetap / SDM | NocoBase"
+  description="Sistem manajemen bisnis terintegrasi open source: CRM (Manajemen Pelanggan), Manajemen Penjualan, Help Desk (Tiket), Manajemen Proyek, Manajemen Aset Tetap, dan Manajemen SDM — enam modul lengkap terpadu. Dibangun di atas platform tanpa kode NocoBase, siap pakai, cocok untuk tim kecil dan menengah yang ingin onboarding cepat."
+  keywords="sistem manajemen bisnis terintegrasi, sistem CRM, CRM open source, sistem tiket, sistem tiket customer service, sistem manajemen proyek, sistem manajemen aset tetap, manajemen aset IT, sistem manajemen SDM, sistem HR, sistem manajemen penjualan, ERP tanpa kode, sistem manajemen multifungsi, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Sistem Manajemen<br/>Bisnis Terintegrasi</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase, mencakup enam modul: <strong>CRM (Manajemen Pelanggan), Manajemen Penjualan, Help Desk (Tiket), Manajemen Proyek, Manajemen Aset Tetap, dan Manajemen SDM</strong>.
+              Siap pakai, tanpa perlu seleksi rumit atau integrasi banyak sistem terpisah.
+            </p>
+
+            <!-- 核心价值 -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Integrasi lintas sistem</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Dukungan 20+ bahasa bawaan</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Karyawan AI + alur kerja</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open source, gratis</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 适用场景标签 -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Perusahaan rintisan</span>
+                  <span class="badge bg-soft-primary me-2">Toko multi-lini bisnis</span>
+                  <span class="badge bg-soft-primary me-2">Fase eksplorasi bisnis</span>
+                  <span class="badge bg-soft-primary">Edukasi dan pelatihan</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Coba Demo Sekarang
+              </a>
+              <a href="/id/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Hubungi Kami
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Sistem Manajemen Bisnis Terintegrasi" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Kolaborasi 6 Modul</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, Manajemen Penjualan, Help Desk, Manajemen Proyek, Manajemen Aset Tetap, dan Manajemen SDM — seluruh proses bisnis tertutup dalam satu sistem</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- 客户管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Manajemen Pelanggan)</h5>
+              <p class="text-muted mt-2">Sistem CRM open source: alur lengkap dari lead, tindak lanjut, konversi, hingga penggabungan dan deduplikasi; tampilan Pelanggan 360 mengagregasikan riwayat pesanan, tiket, proyek, dan aset.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Manajemen tahap lead dan konversi</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tampilan detail Pelanggan 360</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Alat penggabungan / deduplikasi</li>
+              </ul>
+              <a href="/id/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 销售套件 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Penjualan</h5>
+              <p class="text-muted mt-2">Manajemen pesanan penjualan: rantai lengkap dari penawaran, pesanan, faktur, hingga penerimaan pembayaran; alur persetujuan dan analisis piutang sudah tertanam.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Penawaran multi-mata uang</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Alur kerja persetujuan pesanan</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI piutang jatuh tempo</li>
+              </ul>
+              <a href="/id/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 工单系统 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Tiket)</h5>
+              <p class="text-muted mt-2">Sistem tiket customer service: pelaporan masalah oleh pelanggan, penugasan, penanganan, dan penilaian kepuasan; mendukung perhitungan SLA, manajemen prioritas, dan rincian alasan tunggu.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Perhitungan SLA otomatis dan notifikasi keterlambatan</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Dasbor tiket + papan kerja tim</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 level prioritas + klasifikasi AI</li>
+              </ul>
+              <a href="/id/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 项目管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Proyek</h5>
+              <p class="text-muted mt-2">Sistem manajemen proyek ringan: pengelolaan dua tingkat antara proyek dan tugas; mencakup penanggung jawab, progres, tonggak pencapaian, dan peringatan keterlambatan.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Papan status proyek</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Beban kerja penanggung jawab tugas</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Pengingat proyek terlambat</li>
+              </ul>
+              <a href="/id/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 资产管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Aset Tetap</h5>
+              <p class="text-muted mt-2">Manajemen siklus hidup penuh untuk aset IT dan aset kantor — meliputi pembelian, alokasi, pemeliharaan, dan penghapusan; dilengkapi katalog pemasok.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Alokasi / pengembalian aset</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Tiket pemeliharaan</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Analisis pemasok pengadaan</li>
+              </ul>
+              <a href="/id/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR 人事 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen SDM</h5>
+              <p class="text-muted mt-2">Sistem manajemen sumber daya manusia: data karyawan, masuk kerja, resign, cuti, pemantauan masa percobaan, terhubung dengan struktur jabatan dan departemen.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Daftar onboarding / offboarding</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Persetujuan cuti</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Papan karyawan masa percobaan</li>
+              </ul>
+              <a href="/id/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Pelajari selengkapnya <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Kemampuan Platform Dasar</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dibangun di atas NocoBase 2.x, dengan AI, alur kerja, multibahasa, dan multiruang kerja sudah tertanam</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>Karyawan AI</h5>
+            <p class="text-muted small">Lina (lokalisasi), Lexi (penerjemahan), Atlas (kolaborasi), dan peran AI bawaan lainnya, dapat dipanggil sesuai skenario bisnis.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Dukungan Multibahasa</h5>
+            <p class="text-muted small">20+ bahasa bawaan, termasuk Tionghoa, Inggris, Jepang, Korea, Jerman, Prancis, dan lainnya, dengan terjemahan UI penuh.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Mesin Alur Kerja</h5>
+            <p class="text-muted small">Persetujuan, notifikasi, perhitungan SLA, dan pemicu terjadwal; orkestrasi visual, aturan dapat dikonfigurasi tanpa menulis kode.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Isolasi Multiruang Kerja</h5>
+            <p class="text-muted small">Satu sistem melayani beberapa tim atau toko, data terisolasi, izin akses dikelola secara independen.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">Kolaborasi AI</span>
+            <h4 class="title mb-4">Karyawan AI Bawaan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 karyawan AI bawaan mencakup peran bisnis umum, mendukung integrasi Agent eksternal melalui protokol MCP untuk perluasan kapabilitas</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Pemimpin tim — penugasan dan orkestrasi kolaborasi</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Frontend engineer — pembuatan antarmuka dan kode JS block</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Perancang visual — pembuatan grafik dan dasbor</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Analis wawasan — identifikasi tren dan interpretasi KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Analis riset — pengumpulan informasi dan ringkasan</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Pengelola data — pembersihan, penggabungan, dan pengolahan batch</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Penerjemahan dan komunikasi — percakapan pelanggan dan email multibahasa</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Localization engineer — penulisan UI dan i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Asisten email — analisis maksud dan penyusunan balasan</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Karyawan AI Kustom</h6>
+              <p class="text-muted small mb-0">Buat peran / prompt / kombinasi keahlian khusus sesuai kebutuhan bisnis</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Integrasi Agent Eksternal</h6>
+              <p class="text-muted small mb-0">Hubungkan Agent / toolchain Anda sendiri lewat protokol MCP</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Skenario Penggunaan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Solusi terintegrasi sangat cocok untuk skenario berikut</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Pengelolaan global lintas lini bisnis</h5>
+                  <p class="text-muted mb-0">Bisnis mencakup beberapa lini seperti penjualan, customer service, dan proyek; perlu pandangan menyeluruh dalam satu sistem terpadu, tanpa berpindah-pindah antar alat terpisah.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Toko multi-lini bisnis</h5>
+                  <p class="text-muted mb-0">Toko sekaligus menangani penjualan, layanan purnajual, dan pengiriman proyek; lini bisnis banyak tetapi skala terbatas, biaya koordinasi solusi independen tergolong tinggi.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Fase eksplorasi bisnis</h5>
+                  <p class="text-muted mb-0">Model bisnis belum mapan dan ingin menghindari komitmen dini ke solusi tertentu; platform terintegrasi dapat dipakai lebih dulu lalu diiterasi sesuai kebutuhan.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Pengajaran / pelatihan / POC</h5>
+                  <p class="text-muted mb-0">Sebagai contoh lengkap kapabilitas platform NocoBase, dapat digunakan untuk pelatihan internal, demonstrasi solusi, atau proof of concept dengan cakupan proses bisnis umum.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cara Menggunakan?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Tiga langkah untuk menyelesaikan deployment dan mulai memakai sistem manajemen bisnis terintegrasi</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Pasang NocoBase</h5>
+                <p class="text-muted mt-2">Ikuti dokumentasi instalasi resmi untuk men-deploy NocoBase ke lingkungan lokal atau server Anda</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Lihat dokumentasi instalasi</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Setelah dipulihkan, seluruh data preset untuk 6 modul siap dipakai</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Mulai gunakan Sistem Manajemen Bisnis Terintegrasi</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Sistem bisnis terintegrasi yang dibangun di atas NocoBase 2.x. Template dapat langsung dipakai ulang dan diperluas; jika membutuhkan kustomisasi mendalam untuk bisnis tertentu, silakan hubungi kami.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Coba Demo Sekarang
+            </a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Hubungi Kami
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseID>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/id/solutions/asset-management.astro
+++ b/src/pages/id/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseID from "../../../layouts/BaseID.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseID
+  title="Sistem Manajemen Aset Tetap — Manajemen Aset IT dan Kantor Open Source | NocoBase"
+  description="Sistem manajemen aset tetap open source di atas platform tanpa kode NocoBase: manajemen siklus hidup penuh dari pembelian, alokasi, pemeliharaan, hingga penghapusan; mencakup aset IT dan aset kantor; dilengkapi katalog pemasok, tiket pemeliharaan, dan analisis pengadaan."
+  keywords="manajemen aset tetap, manajemen aset IT, sistem manajemen aset, manajemen aset open source, manajemen aset kantor, sistem manajemen aset tetap, siklus hidup aset, sistem manajemen peralatan, stok opname aset, manajemen pemasok, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Manajemen Aset Tetap</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistem Manajemen Aset Tetap</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Manajemen siklus hidup penuh <strong>pembelian → alokasi → pemeliharaan → penghapusan</strong>, mencakup aset IT dan aset kantor, dilengkapi katalog pemasok dan tiket pemeliharaan.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Siklus hidup penuh</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tiket pemeliharaan</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Katalog pemasok</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Aset IT</span>
+                  <span class="badge bg-soft-primary me-2">Aset kantor</span>
+                  <span class="badge bg-soft-primary me-2">Sewa peralatan</span>
+                  <span class="badge bg-soft-primary">Stok opname aset</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Antarmuka Sistem Manajemen Aset Tetap" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Siklus Hidup Aset</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap dari pembelian-masuk gudang hingga penghapusan, setiap aset dapat ditelusuri</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pembelian</div>
+                  <div class="small text-muted">Terhubung pemasok</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Masuk gudang</div>
+                  <div class="small text-muted">Kartu aset</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Alokasi</div>
+                  <div class="small text-muted">Tanda tangan tercatat</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pemeliharaan</div>
+                  <div class="small text-muted">Relasi tiket</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Penghapusan</div>
+                  <div class="small opacity-75">Nilai sisa diarsip</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Pembelian</td>
+                      <td class="py-3 text-muted">Surat pembelian terhubung dengan pemasok dan harga; mendukung berbagai kategori dan jumlah</td>
+                      <td class="py-3 text-muted">Surat pembelian, pemasok, nilai pembelian</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Masuk gudang</td>
+                      <td class="py-3 text-muted">Saat masuk gudang, kartu aset dibuat otomatis (nomor, serial number, masa garansi terinput sekali)</td>
+                      <td class="py-3 text-muted">Kartu aset, nomor unik, masa garansi</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Alokasi</td>
+                      <td class="py-3 text-muted">Aset dipinjamkan ke karyawan / pelanggan / departemen dengan tanda tangan konfirmasi</td>
+                      <td class="py-3 text-muted">Catatan alokasi, pemakai, tanggal mulai-selesai</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pemeliharaan</td>
+                      <td class="py-3 text-muted">Kerusakan / perawatan memunculkan tiket pemeliharaan, terhubung dengan kartu aset</td>
+                      <td class="py-3 text-muted">Tiket pemeliharaan, biaya kumulatif</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penghapusan</td>
+                      <td class="py-3 text-muted">Pencatatan alasan penghapusan (rusak / usang / dijual), dengan catatan penyusutan / nilai sisa</td>
+                      <td class="py-3 text-muted">Catatan penghapusan, nilai sisa, cara pelepasan</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Manajemen aset tetap yang lengkap dari pembelian hingga penghapusan</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pembelian Aset</h5>
+              <p class="text-muted mt-2">Surat pembelian terhubung dengan pemasok dan harga; saat masuk gudang, kartu aset dibuat otomatis dengan nomor aset, serial number, dan masa garansi yang terinput sekali.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Alokasi / Pengembalian</h5>
+              <p class="text-muted mt-2">Aset dipinjamkan ke karyawan / pelanggan dengan tanda tangan tercatat; pengembalian otomatis melepas aset; "riwayat penggunaan" setiap aset dapat ditelusuri penuh.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tiket Pemeliharaan</h5>
+              <p class="text-muted mt-2">Kerusakan / perawatan aset memunculkan tiket pemeliharaan yang terhubung dengan kartu aset; catatan pemeliharaan mengakumulasi biaya untuk membantu keputusan penghapusan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Penghapusan / Penjualan</h5>
+              <p class="text-muted mt-2">Penghapusan aset dengan pencatatan alasan (rusak / usang / dijual); catatan penyusutan / nilai sisa tersimpan dan selaras dengan rekonsiliasi keuangan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Katalog Pemasok</h5>
+              <p class="text-muted mt-2">Profil pemasok + riwayat pembelian; nilai pembelian, kategori, dan syarat pembayaran terlihat jelas untuk membantu pengambilan keputusan pengadaan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Aset</h5>
+              <p class="text-muted mt-2">Distribusi total aset, sedang dipakai, sedang dipelihara, dan dihapus; diagregasikan per tipe, departemen, dan pemakai; data stok opname dapat diekspor sekali klik.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Fitur lainnya dalam pengembangan</h5>
+              <p class="text-muted small mt-2 mb-0">Direncanakan: tugas inventarisasi, perhitungan depresiasi otomatis, scan QR code, alur persetujuan permintaan aset</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Manajemen Penjualan, Help Desk, Manajemen Proyek, dan SDM.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseID>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/id/solutions/crm-v2.astro
+++ b/src/pages/id/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseID from "../../../layouts/BaseID.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 Sales Management System - NocoBase"
-  description="CRM 2.0 sales management system built on NocoBase no-code platform. Modular design with complete sales cycle. Supports AI-assisted lead scoring, opportunity win-rate prediction, and more."
-  keywords="NocoBase CRM, AI CRM, sales management, opportunity management, customer relationship management, lead management, no-code CRM"
+<BaseID
+  title="Sistem CRM (Manajemen Pelanggan) — Open Source, Dapat Di-deploy Sendiri | NocoBase"
+  description="Sistem CRM open source di atas platform tanpa kode NocoBase: manajemen lead, tindak lanjut pelanggan, konversi, penggabungan dan deduplikasi, tampilan Pelanggan 360. Siap pakai, mendukung self-hosting."
+  keywords="sistem CRM, CRM open source, sistem manajemen pelanggan, manajemen hubungan pelanggan, manajemen lead, tindak lanjut pelanggan, Pelanggan 360, CRM tanpa kode, CRM self-hosted, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sales Management System</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Sistem Manajemen Pelanggan</h1>
             <p class="para-desc text-muted">
-              Built on NocoBase no-code platform. Modular design with complete sales cycle. Workflow automation handles routine tasks, AI assists with lead scoring, opportunity analysis, and more.
+              Dibangun di atas platform tanpa kode NocoBase. Mencakup alur lengkap dari lead, tindak lanjut, konversi, hingga penggabungan dan deduplikasi; tampilan Pelanggan 360 mengagregasikan riwayat pesanan, tiket, proyek, dan aset.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Smart Lead Scoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Win-Rate Prediction</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Customer Health Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Modular Design</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Manajemen tahap lead</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tampilan Pelanggan 360</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Penggabungan / deduplikasi</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">B2B Sales</span>
-                  <span class="badge bg-soft-primary me-2">Project Sales</span>
-                  <span class="badge bg-soft-primary me-2">Foreign Trade</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan B2B</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan berbasis proyek</span>
+                  <span class="badge bg-soft-primary me-2">Perdagangan luar negeri</span>
+                  <span class="badge bg-soft-primary">Tim kecil dan menengah</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Sales teams face multiple challenges in daily operations</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Antarmuka Sistem CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inconsistent Lead Quality</h5>
-              </div>
-              <p class="text-muted mb-0">Large volumes of leads with varying quality. Sales waste time on low-quality leads while high-value ones get overlooked.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Delayed Opportunity Follow-up</h5>
-              </div>
-              <p class="text-muted mb-0">Opportunities stall without progress. Sales managers struggle to track team pipeline health, missing optimal closing windows.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Scattered Customer Data</h5>
-              </div>
-              <p class="text-muted mb-0">Customer data scattered across emails, chats, and documents. No complete customer profile for targeted marketing.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inaccurate Sales Forecasts</h5>
-              </div>
-              <p class="text-muted mb-0">Forecasting based on gut feeling without data support. Large prediction gaps affect resource allocation and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High SaaS Costs</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot and other SaaS CRMs charge per seat. Custom development takes long with unpredictable costs.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Data Security Concerns</h5>
-              </div>
-              <p class="text-muted mb-0">Customer and opportunity data stored on third-party clouds, not meeting data localization and privacy compliance requirements.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 system built on NocoBase no-code platform. Workflow automation + AI assistance</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Smart Lead Scoring</h5>
-              <p class="text-muted mt-2">Auto-evaluate lead quality, prioritize high-value leads, recommend optimal contact times</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Win-Rate Prediction</h5>
-              <p class="text-muted mt-2">Predict close probability based on historical data, identify at-risk deals, provide stage progression suggestions</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Customer Health Monitoring</h5>
-              <p class="text-muted mt-2">360-degree customer profile, health scoring, churn risk alerts, proactive relationship maintenance</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Modular Design</h5>
-              <p class="text-muted mt-2">Independent module design, minimal setup requires only Customers + Opportunities, scale as needed</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">Complete Sales Cycle</h4>
-            <p class="para-desc mx-auto text-muted mb-0">From lead acquisition to customer success, unified data flow with AI assistance at every stage</p>
+            <h4 class="title mb-4">Alur Manajemen Pelanggan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dari penerimaan lead hingga tampilan Pelanggan 360, data terhubung dari hulu ke hilir</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Multi-kanal</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tindak lanjut</div>
+                  <div class="small text-muted">Pencatatan jejak</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Konversi</div>
+                  <div class="small text-muted">Pembuatan profil</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pelanggan 360</div>
+                  <div class="small text-muted">Agregasi penuh</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Endapan data</div>
+                  <div class="small opacity-75">Dasbor penjualan</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Stage Conversion</th>
-                      <th class="border-0 py-3">Trigger</th>
-                      <th class="border-0 py-3">AI Assistance</th>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Customer</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulir / impor / input manual, menandai sumber dan tenaga penjualan yang menangani</td>
+                      <td class="py-3 text-muted">Kolam lead, label sumber, alur tahap</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Customer → Opportunity</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">AI analyzes intent, recommends creating opportunity</td>
+                      <td class="py-3">Tindak lanjut</td>
+                      <td class="py-3 text-muted">Pencatatan telepon, email, kunjungan; menentukan waktu tindak lanjut berikutnya</td>
+                      <td class="py-3 text-muted">Garis waktu tindak lanjut, pengingat berikutnya</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Opportunity → Quote</td>
-                      <td class="py-3 text-muted">Enters proposal stage</td>
-                      <td class="py-3 text-primary">AI pricing suggestions, competitor comparison, tiered pricing</td>
+                      <td class="py-3">Konversi</td>
+                      <td class="py-3 text-muted">Konversi lead menjadi pelanggan, mengisi profil (industri / skala / kontak)</td>
+                      <td class="py-3 text-muted">Tabel pelanggan, tabel kontak, relasi lead</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Quote → Order</td>
-                      <td class="py-3 text-muted">Customer accepts quote</td>
-                      <td class="py-3 text-primary">Auto-generate order with product details and pricing</td>
+                      <td class="py-3">Pelanggan 360</td>
+                      <td class="py-3 text-muted">Lihat pelanggan secara penuh: pesanan, tiket, proyek, aset</td>
+                      <td class="py-3 text-muted">Block tertanam, relasi lintas modul</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Endapan data</td>
+                      <td class="py-3 text-muted">Dasbor penjualan mengagregasikan KPI per sales / wilayah / tipe</td>
+                      <td class="py-3 text-muted">Grafik, drill-down detail, ekspor</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Assistance</span>
-            <h4 class="title mb-4">AI Assistance Capabilities</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Through workflow AI nodes, assist with scoring, analysis, writing, and other repetitive tasks</p>
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Lead, pelanggan, tindak lanjut, dan dasbor — mencakup keseharian manajemen hubungan pelanggan secara lengkap</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Workflow Node</span></h5>
-              <span class="badge bg-soft-primary mb-2">Sales Scout</span>
-              <p class="text-muted mt-2 small">Deep opportunity analysis, win-rate prediction, competitive intelligence, deal strategy suggestions</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Impor Lead</h5>
+              <p class="text-muted mt-2">Tiga cara: impor batch Excel, pengumpulan via formulir, dan integrasi API; pemetaan kolom dikonfigurasi secara visual, konflik impor dideduplikasi otomatis.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Insights Analyst</span>
-              <p class="text-muted mt-2 small">Smart lead scoring, customer health assessment, sales data analysis, pipeline forecasting</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aliran Tahap</h5>
+              <p class="text-muted mt-2">Tahap lead (Baru / Telah dihubungi / Telah dikonversi / Ditinggalkan) dapat dikonfigurasi secara visual; perubahan tahap dicatat otomatis, statistik konversi berjalan otomatis.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Editor Assistant</span>
-              <p class="text-muted mt-2 small">Email sentiment/intent analysis, reply drafting, communication summary</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catatan Tindak Lanjut</h5>
+              <p class="text-muted mt-2">Setiap kunjungan, telepon, dan email tercatat; garis waktu memperlihatkan riwayat komunikasi lengkap sehingga serah terima berjalan tanpa hambatan.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Daily Planning</span>
-              <p class="text-muted mt-2 small">Daily priorities, next action suggestions, follow-up planning</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pengingat Tindak Lanjut</h5>
+              <p class="text-muted mt-2">Notifikasi otomatis menjelang waktu tindak lanjut berikutnya; pelanggan yang lama tidak dihubungi dimasukkan ke papan "Perlu diaktifkan kembali" agar tidak terlupa.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language customer communication, content translation, foreign trade email handling</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tampilan Pelanggan 360</h5>
+              <p class="text-muted mt-2">Detail pelanggan mengagregasikan catatan pesanan, tiket, proyek, dan aset; satu layar memperlihatkan gambaran utuh pelanggan tanpa berpindah sistem.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">More AI Employees</h5>
-              <span class="badge bg-soft-secondary mb-2">Expanding</span>
-              <p class="text-muted mt-2 small">More specialized AI employees can be added based on business needs</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Kategori dan Label</h5>
+              <p class="text-muted mt-2">Label multidimensi: tipe pelanggan, industri, skala, dan sumber; mendukung pemfilteran dan analisis agregat berbasis label.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Flexible Architecture</span>
-            <h4 class="title mb-4">Modular Design</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Each module designed independently, can be toggled on/off. Scale your solution to fit your needs</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Module</th>
-                  <th class="border-0 py-3">Required</th>
-                  <th class="border-0 py-3">Description</th>
-                  <th class="border-0 py-3">AI Capabilities</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Customer Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Opportunity Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Lead Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Quote Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Order Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Product Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Email Integration</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Full Suite</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Standard</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Lite</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Trade</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Penggabungan dan Deduplikasi</h5>
+              <p class="text-muted mt-2">Pelanggan yang sama dan terinput ganda diidentifikasi otomatis; penggabungan satu klik menyatukan riwayat tindak lanjut dan relasi tanpa kehilangan data.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Penjualan</h5>
+              <p class="text-muted mt-2">Agregasi KPI berdasarkan sales, wilayah, dan tipe pelanggan; pelanggan baru, tingkat konversi, dan distribusi pelanggan aktif.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Izin Kolom dan Baris</h5>
+              <p class="text-muted mt-2">Konfigurasi kolom yang terlihat berdasarkan peran; sales hanya melihat pelanggan yang ditanganinya, manajer melihat semuanya.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value from Automation</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Workflow automation + AI assistance reduces repetitive work, letting sales focus on customer relationships</p>
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS CRM and custom development</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimension</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">Custom Dev</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of box</td>
-                  <td class="py-3 text-muted">Months of development</td>
-                  <td class="py-3 text-primary">Configure and go, quick launch</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexible customization</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Assistance</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">Workflow AI nodes, use as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Module Flexibility</td>
-                  <td class="py-3 text-muted">Bundled features</td>
-                  <td class="py-3 text-muted">Code changes needed</td>
-                  <td class="py-3 text-primary">Modular, scale as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">Per-seat subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">One-time purchase, long-term use</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy CRM 2.0 system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/id/solution/crm/" target="_blank" class="btn btn-outline-primary">Solution Docs</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/id/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Restore Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan Manajemen Penjualan, Help Desk, Manajemen Proyek, Manajemen Aset Tetap, dan SDM.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/id/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseID>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/id/solutions/crm.astro
+++ b/src/pages/id/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseID from "../../../layouts/BaseID.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="Platform CRM No-Code yang Fleksibel dan Andal"
-  description="Siap digunakan sejak awal, dengan kemampuan kustomisasi mendalam dan kendali penuh atas data. Perluas field, blok, fungsi, dan halaman agar CRM benar-benar sesuai kebutuhan bisnis Anda."
-  keywords="NocoBase CRM, CRM no-code, CRM open source, CRM kustom, manajemen hubungan pelanggan"
+<BaseID
+  title="Sistem CRM (Manajemen Pelanggan) — Open Source, Dapat Di-deploy Sendiri | NocoBase"
+  description="Sistem CRM open source di atas platform tanpa kode NocoBase: manajemen lead, tindak lanjut pelanggan, konversi, penggabungan dan deduplikasi, tampilan Pelanggan 360. Siap pakai, mendukung self-hosting."
+  keywords="sistem CRM, CRM open source, sistem manajemen pelanggan, manajemen hubungan pelanggan, manajemen lead, tindak lanjut pelanggan, Pelanggan 360, CRM tanpa kode, CRM self-hosted, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Platform CRM<br/>No-Code yang Fleksibel dan Andal</h1>
-            <p class="para-desc text-muted">Siap dipakai langsung, dengan fleksibilitas kustomisasi yang kuat untuk menyesuaikan kebutuhan Anda. Perluas field, blok, dan halaman untuk membangun solusi yang pas bagi bisnis Anda, sambil tetap menjaga kendali penuh atas data.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Dibangun dengan NocoBase 1.x (2.0 sedang dikembangkan)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Sistem Manajemen Pelanggan</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Mencakup alur lengkap dari lead, tindak lanjut, konversi, hingga penggabungan dan deduplikasi; tampilan Pelanggan 360 mengagregasikan riwayat pesanan, tiket, proyek, dan aset.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Manajemen tahap lead</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tampilan Pelanggan 360</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Penggabungan / deduplikasi</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industri:</span>
-                  <span class="badge bg-soft-primary">Semua industri</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan B2B</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan berbasis proyek</span>
+                  <span class="badge bg-soft-primary me-2">Perdagangan luar negeri</span>
+                  <span class="badge bg-soft-primary">Tim kecil dan menengah</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Pengembang:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo langsung
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy ke lingkungan Anda
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Antarmuka Sistem CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Apa yang Membuat NocoBase CRM Berbeda</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Berbeda dari produk SaaS dan CRM tertutup lainnya, NocoBase CRM fleksibel dan sepenuhnya berada dalam kendali Anda</p>
+            <h4 class="title mb-4">Alur Manajemen Pelanggan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dari penerimaan lead hingga tampilan Pelanggan 360, data terhubung dari hulu ke hilir</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Sepenuhnya No-Code</h5>
-              <p class="text-muted mt-2">Tidak memerlukan kemampuan pemrograman untuk menyesuaikan CRM</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Mencakup Fitur CRM yang Umum Dibutuhkan</h5>
-              <p class="text-muted mt-2">Manajemen pelanggan, pipeline penjualan, pelacakan peluang, kontak, komunikasi email, persetujuan, dan banyak lagi</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Mudah Diubah dan Dikembangkan</h5>
-              <p class="text-muted mt-2">Mendukung field kustom, proses, dan logika bisnis; arsitektur yang fleksibel memudahkan pengembangan lanjutan</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Kendali Data Penuh</h5>
-              <p class="text-muted mt-2">Kendali penuh atas kode sistem dan data, untuk keamanan dan otonomi perusahaan yang lebih baik</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Coba Fitur NocoBase CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Rasakan langsung hanya dengan beberapa klik</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Visualisasi Data Dashboard</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Demo interaktif
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Multi-kanal</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tindak lanjut</div>
+                  <div class="small text-muted">Pencatatan jejak</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Konversi</div>
+                  <div class="small text-muted">Pembuatan profil</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pelanggan 360</div>
+                  <div class="small text-muted">Agregasi penuh</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Endapan data</div>
+                  <div class="small opacity-75">Dasbor penjualan</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Proses Konversi Lead</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Demo interaktif
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/id/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/id/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulir / impor / input manual, menandai sumber dan tenaga penjualan yang menangani</td>
+                      <td class="py-3 text-muted">Kolam lead, label sumber, alur tahap</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tindak lanjut</td>
+                      <td class="py-3 text-muted">Pencatatan telepon, email, kunjungan; menentukan waktu tindak lanjut berikutnya</td>
+                      <td class="py-3 text-muted">Garis waktu tindak lanjut, pengingat berikutnya</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Konversi</td>
+                      <td class="py-3 text-muted">Konversi lead menjadi pelanggan, mengisi profil (industri / skala / kontak)</td>
+                      <td class="py-3 text-muted">Tabel pelanggan, tabel kontak, relasi lead</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pelanggan 360</td>
+                      <td class="py-3 text-muted">Lihat pelanggan secara penuh: pesanan, tiket, proyek, aset</td>
+                      <td class="py-3 text-muted">Block tertanam, relasi lintas modul</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Endapan data</td>
+                      <td class="py-3 text-muted">Dasbor penjualan mengagregasikan KPI per sales / wilayah / tipe</td>
+                      <td class="py-3 text-muted">Grafik, drill-down detail, ekspor</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/id/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/id/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Lead, pelanggan, tindak lanjut, dan dasbor — mencakup keseharian manajemen hubungan pelanggan secara lengkap</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Impor Lead</h5>
+              <p class="text-muted mt-2">Tiga cara: impor batch Excel, pengumpulan via formulir, dan integrasi API; pemetaan kolom dikonfigurasi secara visual, konflik impor dideduplikasi otomatis.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aliran Tahap</h5>
+              <p class="text-muted mt-2">Tahap lead (Baru / Telah dihubungi / Telah dikonversi / Ditinggalkan) dapat dikonfigurasi secara visual; perubahan tahap dicatat otomatis, statistik konversi berjalan otomatis.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/id/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catatan Tindak Lanjut</h5>
+              <p class="text-muted mt-2">Setiap kunjungan, telepon, dan email tercatat; garis waktu memperlihatkan riwayat komunikasi lengkap sehingga serah terima berjalan tanpa hambatan.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pengingat Tindak Lanjut</h5>
+              <p class="text-muted mt-2">Notifikasi otomatis menjelang waktu tindak lanjut berikutnya; pelanggan yang lama tidak dihubungi dimasukkan ke papan "Perlu diaktifkan kembali" agar tidak terlupa.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Tampilan Pelanggan 360</h5>
+              <p class="text-muted mt-2">Detail pelanggan mengagregasikan catatan pesanan, tiket, proyek, dan aset; satu layar memperlihatkan gambaran utuh pelanggan tanpa berpindah sistem.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Kategori dan Label</h5>
+              <p class="text-muted mt-2">Label multidimensi: tipe pelanggan, industri, skala, dan sumber; mendukung pemfilteran dan analisis agregat berbasis label.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Penggabungan dan Deduplikasi</h5>
+              <p class="text-muted mt-2">Pelanggan yang sama dan terinput ganda diidentifikasi otomatis; penggabungan satu klik menyatukan riwayat tindak lanjut dan relasi tanpa kehilangan data.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Penjualan</h5>
+              <p class="text-muted mt-2">Agregasi KPI berdasarkan sales, wilayah, dan tipe pelanggan; pelanggan baru, tingkat konversi, dan distribusi pelanggan aktif.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Izin Kolom dan Baris</h5>
+              <p class="text-muted mt-2">Konfigurasi kolom yang terlihat berdasarkan peran; sales hanya melihat pelanggan yang ditanganinya, manajer melihat semuanya.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan Manajemen Penjualan, Help Desk, Manajemen Proyek, Manajemen Aset Tetap, dan SDM.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseID>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/id/solutions/hr-management.astro
+++ b/src/pages/id/solutions/hr-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseID from "../../../layouts/BaseID.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseID
+  title="Sistem Manajemen SDM — Manajemen Sumber Daya Manusia Open Source | NocoBase"
+  description="Sistem manajemen SDM open source di atas platform tanpa kode NocoBase: data karyawan, masuk kerja, resign, cuti, pemantauan masa percobaan, struktur jabatan dan departemen. Ringan, dapat di-deploy sendiri, cocok untuk tim HR perusahaan kecil-menengah."
+  keywords="sistem manajemen SDM, sistem manajemen sumber daya manusia, sistem HR open source, sistem manajemen karyawan, manajemen onboarding, manajemen offboarding, persetujuan cuti, manajemen masa percobaan, manajemen struktur organisasi, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Manajemen SDM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistem Manajemen SDM</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Data karyawan dengan pelacakan alur penuh untuk <strong>onboarding, resign, cuti, dan masa percobaan</strong>, terhubung dengan struktur jabatan dan departemen.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Daftar onboarding / offboarding</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Persetujuan cuti</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Papan masa percobaan</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Perusahaan kecil-menengah</span>
+                  <span class="badge bg-soft-primary me-2">Toko ritel berjaringan</span>
+                  <span class="badge bg-soft-primary me-2">HR industri</span>
+                  <span class="badge bg-soft-primary">Kolaborasi lintas departemen</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Antarmuka Sistem Manajemen SDM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Siklus Penuh Karyawan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap manajemen sumber daya manusia dari rekrutmen hingga resign</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Rekrutmen</div>
+                  <div class="small text-muted">Kandidat</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Onboarding</div>
+                  <div class="small text-muted">Pelacakan daftar</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Masa kerja</div>
+                  <div class="small text-muted">Absensi & cuti</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Evaluasi</div>
+                  <div class="small text-muted">Pengangkatan/mutasi</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Resign</div>
+                  <div class="small opacity-75">Serah terima & arsip</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Rekrutmen</td>
+                      <td class="py-3 text-muted">Input kandidat, evaluasi wawancara; setelah lolos dikonversi menjadi profil karyawan</td>
+                      <td class="py-3 text-muted">Tabel kandidat, nilai wawancara</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Onboarding</td>
+                      <td class="py-3 text-muted">Daftar tugas onboarding (tanda tangan kontrak, pembuatan ID card, penerimaan peralatan, pembuatan akun)</td>
+                      <td class="py-3 text-muted">Daftar onboarding, arsip kontrak</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Masa kerja</td>
+                      <td class="py-3 text-muted">Persetujuan absensi harian, cuti, libur pengganti, dan lembur</td>
+                      <td class="py-3 text-muted">Catatan cuti, sisa cuti</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Evaluasi</td>
+                      <td class="py-3 text-muted">Evaluasi masa percobaan, pengangkatan, mutasi, dan promosi</td>
+                      <td class="py-3 text-muted">Formulir evaluasi, perubahan jabatan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Resign</td>
+                      <td class="py-3 text-muted">Daftar resign: serah terima, pengembalian aset, penutupan akun, pengurusan administrasi</td>
+                      <td class="py-3 text-muted">Catatan resign, pelepasan aset</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Manajemen sumber daya manusia yang lengkap dari onboarding hingga resign</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Daftar Karyawan</h5>
+              <p class="text-muted mt-2">Profil karyawan dengan nomor karyawan, tanggal masuk, jabatan, departemen — arsip terpadu, pencarian multidimensi.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Siklus Hidup Karyawan</h5>
+              <p class="text-muted mt-2">Menunggu onboarding → masa percobaan → aktif → offboarding → tidak aktif: 5 status menelusuri arsip karyawan; filter berdasarkan status sekilas.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Struktur Departemen</h5>
+              <p class="text-muted mt-2">Bagan organisasi tree: departemen → sub-departemen, berbasis plugin departments bawaan NocoBase, terhubung dengan izin.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catalog Jabatan</h5>
+              <p class="text-muted mt-2">Definisi jabatan dengan level (junior / menengah / senior / ahli); karyawan terkait jabatan untuk jalur karier dan manajemen izin.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Persetujuan Cuti</h5>
+              <p class="text-muted mt-2">8 jenis cuti (tahunan / sakit / pribadi / pengganti / nikah / orang tua / duka / lainnya); alur persetujuan dapat dikonfigurasi per departemen / atasan langsung.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Izin Tingkat Field</h5>
+              <p class="text-muted mt-2">HR melihat field gaji; manajer melihat info dasar tim — konfigurasi fleksibel melalui izin peran NocoBase.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Fitur lainnya dalam pengembangan</h5>
+              <p class="text-muted small mt-2 mb-0">Direncanakan: checklist onboarding/offboarding, evaluasi masa percobaan, manajemen kontrak & jaminan sosial, kandidat rekrutmen, catatan mutasi/promosi</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Manajemen Penjualan, Help Desk, Manajemen Proyek, dan Manajemen Aset Tetap.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseID>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/id/solutions/project-management.astro
+++ b/src/pages/id/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Tonggak pencapaian</div>
                   <div class="small text-muted">Pengiriman tahap</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Manajemen Tonggak Pencapaian</h5>
               <p class="text-muted mt-2">Titik penting didefinisikan sebagai tonggak (review prototipe, uji internal, peluncuran); progres proyek ditampilkan mengikuti ritme tonggak.</p>

--- a/src/pages/id/solutions/project-management.astro
+++ b/src/pages/id/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseID from "../../../layouts/BaseID.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BaseID
+  title="Sistem Manajemen Proyek — Kolaborasi Proyek Ringan Open Source | NocoBase"
+  description="Sistem manajemen proyek open source di atas platform tanpa kode NocoBase: pengelolaan dua tingkat proyek + tugas, penanggung jawab, progres, tonggak pencapaian, peringatan keterlambatan, distribusi beban kerja. Ringan, dapat di-deploy sendiri, cocok untuk tim kecil-menengah dan kolaborasi proyek lintas departemen."
+  keywords="sistem manajemen proyek, perangkat lunak manajemen proyek, sistem manajemen tugas, manajemen proyek open source, manajemen proyek ringan, manajemen tugas, kolaborasi proyek, pelacakan proyek, manajemen tonggak pencapaian, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,336 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Manajemen Proyek</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistem Manajemen Proyek</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Pengelolaan dua tingkat <strong>proyek + tugas</strong>, mencakup penanggung jawab, progres, tonggak pencapaian, peringatan keterlambatan, dan distribusi beban kerja; ringan dan dapat di-deploy sendiri.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Dua tingkat proyek + tugas</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Peringatan keterlambatan</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Pelacakan tonggak pencapaian</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Proyek pengiriman</span>
+                  <span class="badge bg-soft-primary me-2">IT internal</span>
+                  <span class="badge bg-soft-primary me-2">Kolaborasi lintas departemen</span>
+                  <span class="badge bg-soft-primary">Tim kecil-menengah</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Antarmuka Sistem Manajemen Proyek" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Alur Proyek</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap dari inisiasi hingga penutupan, tonggak pencapaian dan peringatan keterlambatan berjalan otomatis</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Inisiasi</div>
+                  <div class="small text-muted">Terhubung pelanggan</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pemecahan tugas</div>
+                  <div class="small text-muted">Penanggung jawab</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pelacakan progres</div>
+                  <div class="small text-muted">Peringatan keterlambatan</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tonggak pencapaian</div>
+                  <div class="small text-muted">Pengiriman tahap</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Penutupan</div>
+                  <div class="small opacity-75">Review & arsip</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Inisiasi</td>
+                      <td class="py-3 text-muted">Buat proyek, hubungkan ke pelanggan (proyek pengiriman) atau aset (proyek IT), tentukan project manager</td>
+                      <td class="py-3 text-muted">Profil proyek, relasi pelanggan, penanggung jawab</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pemecahan tugas</td>
+                      <td class="py-3 text-muted">Pecah tugas, tetapkan penanggung jawab, waktu mulai-selesai, dan relasi ketergantungan</td>
+                      <td class="py-3 text-muted">Tabel tugas, penanggung jawab, diagram ketergantungan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pelacakan progres</td>
+                      <td class="py-3 text-muted">Anggota memperbarui progres tugas; tugas yang lewat tenggat ditandai merah otomatis</td>
+                      <td class="py-3 text-muted">Persentase progres, penanda keterlambatan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tonggak pencapaian</td>
+                      <td class="py-3 text-muted">Titik penting didefinisikan sebagai tonggak (review / uji internal / peluncuran); deliverable per tahap dicatat</td>
+                      <td class="py-3 text-muted">Daftar tonggak, lampiran deliverable</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penutupan</td>
+                      <td class="py-3 text-muted">Proyek selesai diarsipkan, jam kerja dan biaya tercatat</td>
+                      <td class="py-3 text-muted">Laporan penutupan, total jam kerja</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Pelacakan proyek ringan yang lengkap dari inisiasi hingga penutupan</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/id/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/id/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dua tingkat proyek + tugas</h5>
+              <p class="text-muted mt-2">Satu proyek dipecah menjadi beberapa tugas; penanggung jawab, waktu mulai-selesai, dan progres tugas dikelola secara independen; papan proyek menampilkan status semua tugas.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/id/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/id/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Tonggak Pencapaian</h5>
+              <p class="text-muted mt-2">Titik penting didefinisikan sebagai tonggak (review prototipe, uji internal, peluncuran); progres proyek ditampilkan mengikuti ritme tonggak.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Peringatan Keterlambatan</h5>
+              <p class="text-muted mt-2">Tugas yang melewati tenggat ditandai merah otomatis, daftar proyek terlambat diperbarui secara real-time, sehingga manajer langsung melihat titik risiko.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Penanggung Jawab dan Beban Kerja</h5>
+              <p class="text-muted mt-2">Jumlah tugas dan beban kerja diagregasikan per penanggung jawab; siapa yang sibuk, siapa yang senggang, dan siapa yang sering terlambat — semuanya terlihat dengan jelas.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Papan Status Proyek</h5>
+              <p class="text-muted mt-2">KPI diagregasikan menurut tipe proyek, status, dan penanggung jawab; proyek berjalan, telah ditutup, dan terlambat ditampilkan terpisah.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Relasi Pelanggan dan Aset</h5>
+              <p class="text-muted mt-2">Proyek dapat dihubungkan dengan pelanggan (proyek pengiriman) atau aset (proyek IT); halaman detail pelanggan memperlihatkan riwayat proyek terkait.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Fitur lainnya dalam pengembangan</h5>
+              <p class="text-muted small mt-2 mb-0">Direncanakan: grafik ketergantungan tugas, pencatatan waktu & biaya, arsip deliverable, tampilan Gantt chart</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/id/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Manajemen Penjualan, Help Desk, Manajemen Aset Tetap, dan SDM.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseID>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/id/solutions/sales-management.astro
+++ b/src/pages/id/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI Piutang</h5>
-              <p class="text-muted mt-2">Daftar piutang jatuh tempo dan analisis umur piutang (bucket 30 / 60 / 90 hari); diagregasikan per pelanggan dan per sales agar penagihan jelas terlihat.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-mata Uang dan Kurs</h5>
-              <p class="text-muted mt-2">Penawaran dan pesanan dalam berbagai mata uang seperti USD/EUR/CNY; tabel kurs dipelihara manual atau via impor; konversi ke mata uang lokal otomatis.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Pengiriman dan Logistik</h5>
-              <p class="text-muted mt-2">Surat jalan terhubung dengan pesanan dan nomor resi logistik; mendukung pengiriman bertahap atau parsial; status disinkronkan otomatis ke pesanan.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Dasbor Penjualan</h5>

--- a/src/pages/id/solutions/sales-management.astro
+++ b/src/pages/id/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseID from "../../../layouts/BaseID.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseID
+  title="Sistem Manajemen Penjualan — Pesanan Penjualan dan Piutang Open Source | NocoBase"
+  description="Sistem manajemen penjualan open source di atas platform tanpa kode NocoBase: alur lengkap dari penawaran, pesanan penjualan, faktur, hingga penerimaan pembayaran, dengan alur persetujuan, multi-mata uang, KPI piutang, dan analisis keterlambatan yang sudah tertanam."
+  keywords="sistem manajemen penjualan, manajemen pesanan penjualan, penawaran, manajemen faktur, manajemen piutang, manajemen penerimaan pembayaran, alur penjualan, persetujuan penjualan, manajemen penjualan open source, penawaran multi-mata uang, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Manajemen Penjualan</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Sistem Manajemen Penjualan</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Alur lengkap <strong>penawaran → pesanan → faktur → penerimaan pembayaran</strong>, dengan alur kerja persetujuan penjualan, penawaran multi-mata uang, KPI piutang, dan analisis keterlambatan yang sudah tertanam.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Penawaran multi-mata uang</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Alur persetujuan pesanan</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI piutang</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan B2B</span>
+                  <span class="badge bg-soft-primary me-2">Pesanan luar negeri</span>
+                  <span class="badge bg-soft-primary me-2">Penjualan peralatan</span>
+                  <span class="badge bg-soft-primary">Manajemen piutang</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Antarmuka Sistem Manajemen Penjualan" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Alur Penjualan</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap dari penawaran hingga penerimaan pembayaran, persetujuan dan KPI piutang terhubung dari hulu ke hilir</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Penawaran</div>
+                  <div class="small text-muted">Multi-mata uang</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pesanan</div>
+                  <div class="small text-muted">Alur persetujuan</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pengiriman</div>
+                  <div class="small text-muted">Pelacakan logistik</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Faktur</div>
+                  <div class="small text-muted">Pra-isi pelanggan</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Penerimaan</div>
+                  <div class="small opacity-75">KPI piutang</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Penawaran</td>
+                      <td class="py-3 text-muted">Pilih pelanggan / produk, buat penawaran multi-mata uang, mendukung diskon, tarif pajak, masa berlaku</td>
+                      <td class="py-3 text-muted">Penawaran, rincian produk, ekspor PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pesanan</td>
+                      <td class="py-3 text-muted">Penawaran dikonversi menjadi pesanan; diskon berlebih dan pesanan bernilai besar memicu persetujuan</td>
+                      <td class="py-3 text-muted">Pesanan penjualan, alur persetujuan, rincian pesanan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pengiriman</td>
+                      <td class="py-3 text-muted">Setelah pesanan dikonfirmasi, surat jalan dicatat dan dihubungkan dengan nomor resi logistik</td>
+                      <td class="py-3 text-muted">Surat jalan, nomor resi, alur status</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Faktur</td>
+                      <td class="py-3 text-muted">Faktur diterbitkan setelah pesanan atau pengiriman; NPWP/alamat dari profil pelanggan terisi otomatis</td>
+                      <td class="py-3 text-muted">Catatan faktur, status penerbitan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penerimaan</td>
+                      <td class="py-3 text-muted">Pencatatan pembayaran bertahap; KPI piutang diagregasikan berdasarkan umur piutang</td>
+                      <td class="py-3 text-muted">Catatan penerimaan, saldo piutang, bucket umur piutang</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Alur lengkap penawaran, pesanan, faktur, dan penerimaan + persetujuan dan analisis piutang</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Penawaran</h5>
+              <p class="text-muted mt-2">Penawaran multi-mata uang, mendukung diskon, tarif pajak, dan masa berlaku; ekspor PDF satu klik untuk dikirim ke pelanggan; mendukung konversi ke pesanan penjualan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pesanan Penjualan</h5>
+              <p class="text-muted mt-2">Alur status pesanan (draf / dalam persetujuan / dikonfirmasi / dikirim / ditutup), terhubung dengan pelanggan dan produk, rincian pesanan dapat diedit per baris.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Alur Kerja Persetujuan Pesanan</h5>
+              <p class="text-muted mt-2">Diskon berlebih, pesanan bernilai besar, dan klausa khusus memicu persetujuan; node persetujuan dapat dikonfigurasi fleksibel berdasarkan departemen, jabatan, dan ambang nominal.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Manajemen Faktur</h5>
+              <p class="text-muted mt-2">Faktur diterbitkan dari pesanan, status penerbitan dilacak; NPWP, alamat, dan catatan dari profil pelanggan terisi otomatis untuk mengurangi kesalahan input.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catatan Penerimaan Pembayaran</h5>
+              <p class="text-muted mt-2">Penerimaan bertahap, pembayaran parsial; saldo piutang dihitung otomatis; status pembayaran diagregasikan per pelanggan dan per pesanan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI Piutang</h5>
+              <p class="text-muted mt-2">Daftar piutang jatuh tempo dan analisis umur piutang (bucket 30 / 60 / 90 hari); diagregasikan per pelanggan dan per sales agar penagihan jelas terlihat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Multi-mata Uang dan Kurs</h5>
+              <p class="text-muted mt-2">Penawaran dan pesanan dalam berbagai mata uang seperti USD/EUR/CNY; tabel kurs dipelihara manual atau via impor; konversi ke mata uang lokal otomatis.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pengiriman dan Logistik</h5>
+              <p class="text-muted mt-2">Surat jalan terhubung dengan pesanan dan nomor resi logistik; mendukung pengiriman bertahap atau parsial; status disinkronkan otomatis ke pesanan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Penjualan</h5>
+              <p class="text-muted mt-2">Nilai penjualan, jumlah pesanan, dan tingkat penerimaan pembayaran diagregasikan per sales, wilayah, dan produk; tren bulanan/kuartalan jelas terlihat.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Help Desk, Manajemen Proyek, Manajemen Aset Tetap, dan SDM.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseID>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/id/solutions/ticketing-v2.astro
+++ b/src/pages/id/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseID from "../../../layouts/BaseID.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI-Powered Intelligent Ticketing System - NocoBase"
-  description="NocoBase AI-powered intelligent ticketing system with T-shaped data architecture supporting multiple business scenarios. AI employee team for auto-classification, smart replies, and knowledge recommendations. Full SLA monitoring for complete ticket lifecycle management."
-  keywords="NocoBase ticketing system, AI ticketing, intelligent customer service, SLA management, knowledge base, ticket classification"
+<BaseID
+  title="Help Desk (Tiket) — Sistem Tiket Customer Service Open Source | NocoBase"
+  description="Sistem tiket open source di atas platform tanpa kode NocoBase: pelaporan masalah oleh pelanggan, penugasan cerdas, perhitungan SLA, prioritas, klasifikasi AI, penilaian kepuasan, dan papan kerja customer service. Siap pakai, cocok untuk tim customer service kecil-menengah dan tim layanan purnajual."
+  keywords="sistem tiket, sistem tiket customer service, tiket open source, help desk, sistem ticketing, manajemen tiket, manajemen SLA, sistem purnajual, sistem layanan pelanggan, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,336 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI-Powered<br/>Intelligent Ticketing</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Help Desk (Tiket)</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tiket)</h1>
             <p class="para-desc text-muted">
-              Let support teams focus on solving problems, not navigating complex workflows. Built on NocoBase no-code platform with T-shaped data architecture for unified multi-business management. AI employee team powers the entire ticket lifecycle from creation to closure.
+              Dibangun di atas platform tanpa kode NocoBase. Alur lengkap <strong>pelaporan oleh pelanggan → penugasan cerdas → penanganan → penilaian kepuasan</strong>, dengan perhitungan SLA, manajemen prioritas, klasifikasi AI, dan papan kerja customer service yang sudah tertanam.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Multi-source Intake</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI Smart Routing</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Full SLA Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Auto Knowledge Capture</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Perhitungan SLA otomatis</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 level prioritas</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Klasifikasi AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Equipment Repair</span>
-                  <span class="badge bg-soft-primary me-2">IT Support</span>
-                  <span class="badge bg-soft-primary me-2">Customer Complaints</span>
-                  <span class="badge bg-soft-primary">Inquiries</span>
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Customer service & purnajual</span>
+                  <span class="badge bg-soft-primary me-2">IT service desk</span>
+                  <span class="badge bg-soft-primary me-2">Pemeliharaan peralatan</span>
+                  <span class="badge bg-soft-primary">Customer service SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha version is now live. Try it out - we're actively improving.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Antarmuka Sistem Tiket" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Enterprises face diverse service requests with scattered sources, varying workflows, and lack of unified management</p>
+            <h4 class="title mb-4">Alur Penanganan Tiket</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap dari pelaporan pelanggan hingga penilaian penutupan, SLA dihitung di setiap tahap</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High Cost, Slow Customization</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Fragmented Systems, Data Silos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Slow Response, No Transparency</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Quality Hard to Ensure</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Knowledge Can't Accumulate</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Missing AI Capabilities</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Universal ticketing platform built on NocoBase no-code: unified intake, smart distribution, multi-business support, closed-loop feedback</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-source Intake</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI Smart Routing</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Full SLA Monitoring</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">T-Shaped Data Architecture</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Equipment Repair</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT Support</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">AI Employee Team</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Pembuatan</div>
+                  <div class="small text-muted">Multi-kanal</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Klasifikasi cerdas</div>
+                  <div class="small text-muted">Identifikasi AI</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Penugasan</div>
+                  <div class="small text-muted">Aturan per grup</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Penanganan</div>
+                  <div class="small text-muted">Perhitungan SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Penilaian</div>
+                  <div class="small opacity-75">Penutupan & arsip</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Pembuatan</td>
+                      <td class="py-3 text-muted">Pengiriman lewat email pelanggan, formulir, dan IM; terhubung dengan pelanggan dan produk</td>
+                      <td class="py-3 text-muted">Nomor tiket, sumber, profil pelanggan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Klasifikasi cerdas</td>
+                      <td class="py-3 text-muted">AI mengidentifikasi kategori masalah (akun / fitur / Bug), prioritas diatur otomatis</td>
+                      <td class="py-3 text-muted">Label kategori, prioritas, tingkat keyakinan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penugasan</td>
+                      <td class="py-3 text-muted">Penugasan ke grup / agent sesuai aturan; tiket darurat secara otomatis memberi tahu petugas jaga</td>
+                      <td class="py-3 text-muted">Penanggung jawab, catatan penugasan, antrian grup</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penanganan</td>
+                      <td class="py-3 text-muted">Agent menangani dan berkomunikasi dengan pelanggan; perhitungan SLA dengan peringatan sebelum lewat tenggat</td>
+                      <td class="py-3 text-muted">Log penanganan, status SLA, alasan tunggu</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penilaian</td>
+                      <td class="py-3 text-muted">Setelah penutupan, pelanggan diminta menilai (1-5 bintang + teks); diagregasikan per agent / produk</td>
+                      <td class="py-3 text-muted">Catatan kepuasan, tiket arsip, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Manajemen keseharian tiket customer service yang lengkap dari penerimaan hingga penutupan</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Perhitungan SLA dan Peringatan</h5>
+              <p class="text-muted mt-2">Tenggat respons / penyelesaian dihitung otomatis berdasarkan prioritas; peringatan dikirim sebelum tenggat, tiket lewat tenggat ditandai merah; tingkat pencapaian SLA dapat ditampilkan di dasbor.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 Level Prioritas</h5>
+              <p class="text-muted mt-2">Empat tingkat: Darurat, Tinggi, Sedang, Rendah, masing-masing dengan tenggat respons berbeda; tiket darurat dipindahkan ke atas otomatis dan petugas jaga diberi tahu.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Klasifikasi AI</h5>
+              <p class="text-muted mt-2">AI mengidentifikasi kategori masalah pada tiket baru (masalah akun / konsultasi fitur / laporan Bug, dll.), lalu menugaskannya ke grup yang sesuai berdasarkan aturan.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Rincian Alasan Tunggu</h5>
+              <p class="text-muted mt-2">"Menunggu balasan pelanggan", "Menunggu pihak ketiga", "Menunggu peninjauan kebutuhan" — tiket yang menunggu tidak dihitung sebagai lewat SLA, adil dan masuk akal.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Papan Kerja Customer Service</h5>
+              <p class="text-muted mt-2">Agent yang login langsung melihat tiket yang ditugaskan ke dirinya; diurutkan menurut tenggat, satu layar menampilkan yang menunggu, dalam penanganan, dan akan lewat tenggat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Tiket</h5>
+              <p class="text-muted mt-2">Distribusi tiket baru hari ini / ditutup / menunggu / lewat tenggat; diagregasikan berdasarkan agent, pelanggan, dan lini produk, sehingga manajer dapat melihat gambaran menyeluruh.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Fitur lainnya dalam pengembangan</h5>
+              <p class="text-muted small mt-2 mb-0">Direncanakan: penilaian kepuasan, alur transfer & eskalasi, template balasan, integrasi knowledge base</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Manajemen Penjualan, Manajemen Proyek, Manajemen Aset Tetap, dan SDM.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/id/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseID>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/id/solutions/ticketing.astro
+++ b/src/pages/id/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseID from "../../../layouts/BaseID.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BaseID
+  title="Help Desk (Tiket) — Sistem Tiket Customer Service Open Source | NocoBase"
+  description="Sistem tiket open source di atas platform tanpa kode NocoBase: pelaporan masalah oleh pelanggan, penugasan cerdas, perhitungan SLA, prioritas, klasifikasi AI, penilaian kepuasan, dan papan kerja customer service. Siap pakai, cocok untuk tim customer service kecil-menengah dan tim layanan purnajual."
+  keywords="sistem tiket, sistem tiket customer service, tiket open source, help desk, sistem ticketing, manajemen tiket, manajemen SLA, sistem purnajual, sistem layanan pelanggan, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,336 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/id/solutions/all-in-one" class="text-muted small text-decoration-none">Sistem Manajemen Bisnis Terintegrasi</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">modul Help Desk (Tiket)</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tiket)</h1>
+            <p class="para-desc text-muted">
+              Dibangun di atas platform tanpa kode NocoBase. Alur lengkap <strong>pelaporan oleh pelanggan → penugasan cerdas → penanganan → penilaian kepuasan</strong>, dengan perhitungan SLA, manajemen prioritas, klasifikasi AI, dan papan kerja customer service yang sudah tertanam.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Perhitungan SLA otomatis</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 level prioritas</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Klasifikasi AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, gratis</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Skenario penggunaan:</span>
+                  <span class="badge bg-soft-primary me-2">Customer service & purnajual</span>
+                  <span class="badge bg-soft-primary me-2">IT service desk</span>
+                  <span class="badge bg-soft-primary me-2">Pemeliharaan peralatan</span>
+                  <span class="badge bg-soft-primary">Customer service SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+              <a href="/id/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Lihat Solusi Lengkap</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Antarmuka Sistem Tiket" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Alur Penanganan Tiket</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Siklus tertutup lengkap dari pelaporan pelanggan hingga penilaian penutupan, SLA dihitung di setiap tahap</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/id/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/id/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pembuatan</div>
+                  <div class="small text-muted">Multi-kanal</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Klasifikasi cerdas</div>
+                  <div class="small text-muted">Identifikasi AI</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Penugasan</div>
+                  <div class="small text-muted">Aturan per grup</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Penanganan</div>
+                  <div class="small text-muted">Perhitungan SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Penilaian</div>
+                  <div class="small opacity-75">Penutupan & arsip</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Tahap</th>
+                      <th class="border-0 py-3">Aksi Kunci</th>
+                      <th class="border-0 py-3">Catatan Sistem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Pembuatan</td>
+                      <td class="py-3 text-muted">Pengiriman lewat email pelanggan, formulir, dan IM; terhubung dengan pelanggan dan produk</td>
+                      <td class="py-3 text-muted">Nomor tiket, sumber, profil pelanggan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Klasifikasi cerdas</td>
+                      <td class="py-3 text-muted">AI mengidentifikasi kategori masalah (akun / fitur / Bug), prioritas diatur otomatis</td>
+                      <td class="py-3 text-muted">Label kategori, prioritas, tingkat keyakinan</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penugasan</td>
+                      <td class="py-3 text-muted">Penugasan ke grup / agent sesuai aturan; tiket darurat secara otomatis memberi tahu petugas jaga</td>
+                      <td class="py-3 text-muted">Penanggung jawab, catatan penugasan, antrian grup</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penanganan</td>
+                      <td class="py-3 text-muted">Agent menangani dan berkomunikasi dengan pelanggan; perhitungan SLA dengan peringatan sebelum lewat tenggat</td>
+                      <td class="py-3 text-muted">Log penanganan, status SLA, alasan tunggu</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Penilaian</td>
+                      <td class="py-3 text-muted">Setelah penutupan, pelanggan diminta menilai (1-5 bintang + teks); diagregasikan per agent / produk</td>
+                      <td class="py-3 text-muted">Catatan kepuasan, tiket arsip, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/id/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/id/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/id/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Fitur Utama</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Manajemen keseharian tiket customer service yang lengkap dari penerimaan hingga penutupan</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Perhitungan SLA dan Peringatan</h5>
+              <p class="text-muted mt-2">Tenggat respons / penyelesaian dihitung otomatis berdasarkan prioritas; peringatan dikirim sebelum tenggat, tiket lewat tenggat ditandai merah; tingkat pencapaian SLA dapat ditampilkan di dasbor.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 Level Prioritas</h5>
+              <p class="text-muted mt-2">Empat tingkat: Darurat, Tinggi, Sedang, Rendah, masing-masing dengan tenggat respons berbeda; tiket darurat dipindahkan ke atas otomatis dan petugas jaga diberi tahu.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Klasifikasi AI</h5>
+              <p class="text-muted mt-2">AI mengidentifikasi kategori masalah pada tiket baru (masalah akun / konsultasi fitur / laporan Bug, dll.), lalu menugaskannya ke grup yang sesuai berdasarkan aturan.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Rincian Alasan Tunggu</h5>
+              <p class="text-muted mt-2">"Menunggu balasan pelanggan", "Menunggu pihak ketiga", "Menunggu peninjauan kebutuhan" — tiket yang menunggu tidak dihitung sebagai lewat SLA, adil dan masuk akal.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Papan Kerja Customer Service</h5>
+              <p class="text-muted mt-2">Agent yang login langsung melihat tiket yang ditugaskan ke dirinya; diurutkan menurut tenggat, satu layar menampilkan yang menunggu, dalam penanganan, dan akan lewat tenggat.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dasbor Tiket</h5>
+              <p class="text-muted mt-2">Distribusi tiket baru hari ini / ditutup / menunggu / lewat tenggat; diagregasikan berdasarkan agent, pelanggan, dan lini produk, sehingga manajer dapat melihat gambaran menyeluruh.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Fitur lainnya dalam pengembangan</h5>
+              <p class="text-muted small mt-2 mb-0">Direncanakan: penilaian kepuasan, alur transfer & eskalasi, template balasan, integrasi knowledge base</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Unduh dan Deploy</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Modul ini termasuk dalam template backup Sistem Manajemen Bisnis Terintegrasi, di-deploy secara terpadu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Unduh template backup</h5>
+                <p class="text-muted mt-2">Backup solusi terintegrasi; setelah dipulihkan mencakup data preset untuk seluruh 6 modul, termasuk modul ini</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Unduh backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Atau unduh arsip SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Lihat dokumentasi instalasi</h5>
+                <p class="text-muted mt-2">Langkah pemulihan terperinci, pertanyaan umum, dan catatan penting sedang dipersiapkan</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Segera hadir</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Mulai Gunakan</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Modul ini juga terintegrasi dalam <a href="/id/solutions/all-in-one">Sistem Manajemen Bisnis Terintegrasi</a>, dapat digunakan terpisah atau berkolaborasi dengan CRM, Manajemen Penjualan, Manajemen Proyek, Manajemen Aset Tetap, dan SDM.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Coba Demo Online</a>
+            <a href="/id/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Hubungi Kami</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseID>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/ja/solutions/all-in-one.astro
+++ b/src/pages/ja/solutions/all-in-one.astro
@@ -1,0 +1,592 @@
+---
+import BaseJA from "../../../layouts/BaseJA.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseJA
+  title="一体型業務管理システム - CRM / ヘルプデスク / プロジェクト管理 / 固定資産 / HR | NocoBase"
+  description="オープンソースの一体型業務管理システム。CRM(顧客管理)、販売管理、ヘルプデスク(チケット)、プロジェクト管理、固定資産管理、HR 人事管理の 6 モジュールを統合。NocoBase ノーコードプラットフォーム上に構築されており、すぐに使えて中小規模チームの短期間立ち上げに適しています。"
+  keywords="一体型業務管理システム, CRM, OSS CRM, ヘルプデスク, ヘルプデスクシステム, プロジェクト管理, 固定資産管理, IT 資産管理, HR システム, 人事管理システム, 販売管理, ノーコード ERP, オールインワン業務システム, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">一体型<br/>業務管理システム</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。<strong>CRM(顧客管理)、販売管理、ヘルプデスク、プロジェクト管理、固定資産管理、HR 人事管理</strong> の 6 モジュールを網羅。すぐに使え、複雑なシステム選定や複数システムの連携を必要としません。
+            </p>
+
+            <!-- 核心价值 -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">複数システムの統合</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">20 言語以上に対応</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI 社員 + ワークフロー</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">オープンソース無料</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 适用场景标签 -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">スタートアップ</span>
+                  <span class="badge bg-soft-primary me-2">複数事業を抱える店舗</span>
+                  <span class="badge bg-soft-primary me-2">事業の試行段階</span>
+                  <span class="badge bg-soft-primary">教育・研修</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Demo を体験
+              </a>
+              <a href="/ja/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>お問い合わせ
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="一体型業務管理システム" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 モジュールの連携</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM、販売管理、ヘルプデスク、プロジェクト管理、固定資産管理、HR 人事管理。すべての業務プロセスを同一システム内で完結できます。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- 客户管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM(顧客管理)</h5>
+              <p class="text-muted mt-2">オープンソースの CRM。リード、フォローアップ、転換、マージ・重複排除の一連の流れに対応。顧客 360 ビューで受注・チケット・プロジェクト・資産の履歴を集約します。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>リードステージの管理と転換</li>
+                <li><i class="uil uil-check text-primary me-1"></i>顧客 360 詳細ビュー</li>
+                <li><i class="uil uil-check text-primary me-1"></i>マージ / 重複排除ツール</li>
+              </ul>
+              <a href="/ja/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 销售套件 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">販売管理</h5>
+              <p class="text-muted mt-2">販売案件管理。見積、受注、請求、入金までの一連の流れをカバー。承認ワークフローと売掛金分析を標準搭載しています。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>多通貨対応の見積</li>
+                <li><i class="uil uil-check text-primary me-1"></i>受注承認ワークフロー</li>
+                <li><i class="uil uil-check text-primary me-1"></i>延滞債権 KPI</li>
+              </ul>
+              <a href="/ja/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 工单系统 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">ヘルプデスク(チケット)</h5>
+              <p class="text-muted mt-2">カスタマーサポートのチケットシステム。顧客からの問い合わせ、振り分け、対応、満足度評価まで対応。SLA 計測、優先度管理、待機理由の細分化をサポートします。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>SLA 自動計測と超過通知</li>
+                <li><i class="uil uil-check text-primary me-1"></i>チケットダッシュボード + チーム作業画面</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 段階の優先度 + AI 自動分類</li>
+              </ul>
+              <a href="/ja/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 项目管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">プロジェクト管理</h5>
+              <p class="text-muted mt-2">軽量なプロジェクト管理。プロジェクトとタスクの 2 階層で管理し、担当者、進捗、マイルストーン、遅延アラートまで網羅します。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>プロジェクトステータスボード</li>
+                <li><i class="uil uil-check text-primary me-1"></i>タスク担当者の作業量</li>
+                <li><i class="uil uil-check text-primary me-1"></i>遅延プロジェクト通知</li>
+              </ul>
+              <a href="/ja/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 资产管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">固定資産管理</h5>
+              <p class="text-muted mt-2">IT 資産・オフィス資産のライフサイクル管理。購入、配布、メンテナンス、廃棄までを一貫管理し、仕入先台帳も標準搭載しています。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>資産の貸出 / 返却</li>
+                <li><i class="uil uil-check text-primary me-1"></i>メンテナンスチケット</li>
+                <li><i class="uil uil-check text-primary me-1"></i>仕入先・購入分析</li>
+              </ul>
+              <a href="/ja/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR 人事 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR 人事管理</h5>
+              <p class="text-muted mt-2">人事管理システム。従業員台帳、入社、退職、休暇、試用期間の追跡に対応し、職位と部門の組織構造と連携します。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>入社 / 退職チェックリスト</li>
+                <li><i class="uil uil-check text-primary me-1"></i>休暇申請承認</li>
+                <li><i class="uil uil-check text-primary me-1"></i>試用期間従業員ボード</li>
+              </ul>
+              <a href="/ja/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">詳細を見る <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">プラットフォーム基盤の能力</h4>
+            <p class="para-desc mx-auto text-muted mb-0">NocoBase 2.x をベースに、AI、ワークフロー、多言語、マルチワークスペースを標準装備</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI 社員</h5>
+            <p class="text-muted small">Lina(ローカリゼーション)、Lexi(翻訳)、Atlas(チーム連携)など、業務シーンごとに呼び出せる AI 役割を内蔵。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>多言語対応</h5>
+            <p class="text-muted small">日本語・中国語・英語・韓国語・ドイツ語・フランス語など 20 以上の言語に対応。UI 全体の翻訳が完了しています。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>ワークフローエンジン</h5>
+            <p class="text-muted small">承認、通知、SLA 計測、スケジュールトリガーをビジュアルに編集。コードを書かずにルールを設定できます。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>マルチワークスペース</h5>
+            <p class="text-muted small">1 つのシステムで複数チームや店舗を運用可能。データは相互に分離され、権限も独立して管理できます。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI 連携</span>
+            <h4 class="title mb-4">標準搭載の AI 社員</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 人のプリセット AI 社員が代表的な業務ロールをカバー。MCP プロトコルで外部 Agent を接続して機能を拡張できます。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">チームリーダー — タスク振り分けと連携の組み立て</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">フロントエンドエンジニア — UI と JS ブロックのコード生成</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">ビジュアル設計 — チャートとダッシュボードの構築</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">インサイト分析 — トレンドの把握と KPI 解釈</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">リサーチ分析 — 情報収集と要約</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">データ整備 — クレンジング・マージ・一括整理</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">翻訳・コミュニケーション — 多言語の顧客対話とメール</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">ローカリゼーションエンジニア — UI 文言と i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">メールアシスタント — 意図解析と返信ドラフト作成</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">カスタム AI 社員</h6>
+              <p class="text-muted small mb-0">業務に合わせて専用のロール / プロンプト / スキルを作成</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">外部 Agent の接続</h6>
+              <p class="text-muted small mb-0">MCP プロトコルで自社の Agent / ツールチェーンを接続</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">想定シーン</h4>
+            <p class="para-desc mx-auto text-muted mb-0">統合ソリューションは以下のような場面で特に効果を発揮します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>複数事業を横断した全体管理</h5>
+                  <p class="text-muted mb-0">販売、カスタマーサポート、プロジェクトといった複数の領域を統一システムで俯瞰し、別々のツールを行き来せずに済みます。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>複数事業を抱える店舗</h5>
+                  <p class="text-muted mb-0">店舗で販売、アフターサポート、プロジェクト納品まで担当するなど、業務領域は広いが規模は限られているケース。個別のシステムでは連携コストが高くなります。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>事業の試行段階</h5>
+                  <p class="text-muted mb-0">事業内容が固まっていない時期に、特定の製品に過度にロックインせず、まず統合プラットフォームで運用を始めて、要件に応じて段階的に磨き込めます。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>教育 / 研修 / PoC</h5>
+                  <p class="text-muted mb-0">NocoBase の機能を一通り体験できるサンプルとして、社内研修、提案デモ、概念実証(PoC)に活用でき、典型的な業務プロセスを網羅しています。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">使い方</h4>
+            <p class="para-desc mx-auto text-muted mb-0">3 つのステップでデプロイして、一体型業務管理システムの利用を開始できます。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>NocoBase をインストール</h5>
+                <p class="text-muted mt-2">公式インストールガイドに従って、ローカルまたはサーバー環境に NocoBase をデプロイします。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">インストール手順を見る</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">復元するだけで 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">一体型業務管理システムを始める</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            NocoBase 2.x をベースに構築された統合業務システムです。テンプレートはそのまま再利用・拡張できます。特定業務向けに深くカスタマイズしたい場合もお気軽にご相談ください。
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Demo を体験
+            </a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>お問い合わせ
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseJA>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/ja/solutions/asset-management.astro
+++ b/src/pages/ja/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseJA from "../../../layouts/BaseJA.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseJA
+  title="固定資産管理 — オープンソースの IT 資産・オフィス資産管理 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースの固定資産管理。購入、配布、メンテナンス、廃棄までライフサイクル全体を管理。IT 資産とオフィス資産を網羅し、仕入先台帳、メンテナンスチケット、購入分析を標準搭載しています。"
+  keywords="固定資産管理, IT 資産管理, 資産管理システム, オープンソース 資産管理, オフィス資産管理, 固定資産管理システム, 資産ライフサイクル, 機器管理, 資産棚卸, 仕入先管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">固定資産管理モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">固定資産管理</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。<strong>購入 → 配布 → メンテナンス → 廃棄</strong> までライフサイクル全体を管理し、IT 資産とオフィス資産を網羅。仕入先台帳とメンテナンスチケットも標準搭載しています。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">ライフサイクル全体</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">メンテナンスチケット</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">仕入先台帳</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">IT 資産</span>
+                  <span class="badge bg-soft-primary me-2">オフィス資産</span>
+                  <span class="badge bg-soft-primary me-2">機器レンタル</span>
+                  <span class="badge bg-soft-primary">資産棚卸</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="固定資産管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">資産のライフサイクル</h4>
+            <p class="para-desc mx-auto text-muted mb-0">購入・入庫から廃棄・抹消までを一気通貫で管理し、すべての資産を追跡できます。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">購入</div>
+                  <div class="small text-muted">仕入先連携</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">入庫</div>
+                  <div class="small text-muted">資産カード</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">配布</div>
+                  <div class="small text-muted">承認記録</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">メンテ</div>
+                  <div class="small text-muted">チケット連携</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">廃棄</div>
+                  <div class="small opacity-75">残存簿価保管</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">購入</td>
+                      <td class="py-3 text-muted">仕入先と価格を紐付けた購入伝票を作成。複数品目・複数数量に対応</td>
+                      <td class="py-3 text-muted">購入伝票、仕入先、購入金額</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入庫</td>
+                      <td class="py-3 text-muted">入庫と同時に資産カードを自動生成(資産番号、シリアル番号、保証期間を一括登録)</td>
+                      <td class="py-3 text-muted">資産カード、固有番号、保証期間</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">配布</td>
+                      <td class="py-3 text-muted">従業員 / 顧客 / 部門へ貸し出し、承認を記録</td>
+                      <td class="py-3 text-muted">配布記録、利用者、貸出期間</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">メンテナンス</td>
+                      <td class="py-3 text-muted">故障 / 保守時にメンテナンスチケットを発行し、資産カードと関連付け</td>
+                      <td class="py-3 text-muted">メンテナンスチケット、累積コスト</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">廃棄</td>
+                      <td class="py-3 text-muted">廃棄理由(損傷 / 旧型 / 売却)を登録し、減価償却 / 残存簿価を記録</td>
+                      <td class="py-3 text-muted">廃棄記録、残存簿価、処分方法</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">購入から廃棄までの固定資産管理を一気通貫で実現します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">資産の購入</h5>
+              <p class="text-muted mt-2">購入伝票で仕入先と価格を関連付け、入庫時に資産カードを自動生成。資産番号、シリアル番号、保証期間を 1 度に登録します。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">貸出 / 返却</h5>
+              <p class="text-muted mt-2">従業員や顧客への貸出を承認とともに記録。返却時には自動でリリースされ、各資産の「利用履歴」を完全にトレースできます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">メンテナンスチケット</h5>
+              <p class="text-muted mt-2">故障や保守は資産カードと関連付けてメンテナンスチケットを発行。記録に累積コストを反映し、廃棄判断の判断材料になります。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">廃棄 / 売却</h5>
+              <p class="text-muted mt-2">廃棄理由(損傷 / 旧型 / 売却)を登録し、減価償却や残存簿価も記録。会計とも整合する形で保管できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">仕入先台帳</h5>
+              <p class="text-muted mt-2">仕入先情報と購入履歴を一元管理。金額、品目、支払条件を可視化し、調達判断をサポートします。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">資産ダッシュボード</h5>
+              <p class="text-muted mt-2">資産総数、使用中、メンテナンス中、廃棄済の分布を表示。種別・部門・利用者で集計でき、棚卸データのエクスポートも可能です。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">機能拡張中</h5>
+              <p class="text-muted small mt-2 mb-0">予定:棚卸タスク、減価償却の自動計算、QR コードスキャン、資産貸出申請フロー</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・販売管理・ヘルプデスク・プロジェクト管理・HR と連携しても利用できます。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseJA>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/ja/solutions/crm-v2.astro
+++ b/src/pages/ja/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseJA from "../../../layouts/BaseJA.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 営業管理システム - NocoBase"
-  description="NocoBaseノーコードプラットフォームで構築したCRM 2.0営業管理システム。モジュール設計で完全な販売サイクルを管理。AIによるリードスコアリング、商談勝率予測などをサポート。"
-  keywords="NocoBase CRM, AI CRM, 営業管理, 商談管理, 顧客関係管理, リード管理, ノーコードCRM"
+<BaseJA
+  title="CRM(顧客管理)— オープンソース・セルフホスト可能 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソース CRM。リード管理、顧客フォロー、転換、マージ・重複排除、顧客 360 ビューを標準装備。すぐに使え、セルフホストにも対応します。"
+  keywords="CRM, オープンソース CRM, 顧客管理システム, 顧客関係管理, リード管理, 顧客フォロー, 顧客 360, ノーコード CRM, セルフホスト CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>営業管理システム</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>顧客管理システム</h1>
             <p class="para-desc text-muted">
-              NocoBaseノーコードプラットフォームで構築。モジュール設計で完全な販売サイクルを管理。ワークフロー自動化で定型業務を処理し、AIがリードスコアリング、商談分析などをアシスト。
+              NocoBase ノーコードプラットフォーム上に構築。リード、フォローアップ、転換、マージ・重複排除までの一連の流れをカバーし、顧客 360 ビューで受注・チケット・プロジェクト・資産の履歴を集約します。
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">スマートリードスコアリング</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">勝率予測</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">顧客ヘルス監視</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">モジュール設計</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">リードステージ管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">顧客 360 ビュー</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">マージ / 重複排除</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">ユースケース：</span>
-                  <span class="badge bg-soft-primary me-2">B2B営業</span>
-                  <span class="badge bg-soft-primary me-2">プロジェクト販売</span>
-                  <span class="badge bg-soft-primary me-2">外贸取引</span>
-                  <span class="badge bg-soft-primary">全業種対応</span>
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">B2B 営業</span>
+                  <span class="badge bg-soft-primary me-2">プロジェクト型営業</span>
+                  <span class="badge bg-soft-primary me-2">貿易</span>
+                  <span class="badge bg-soft-primary">中小チーム</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>使い方
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 システム画面"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">このような課題はありませんか？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">営業チームが日々の業務で直面する複数の課題</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 顧客管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">リード品質のばらつき</h5>
-              </div>
-              <p class="text-muted mb-0">大量のリードの質がまちまち。営業が質の低いリードに時間を浪費し、高価値案件を見逃してしまう。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">商談フォローアップの遅れ</h5>
-              </div>
-              <p class="text-muted mb-0">商談が停滞しても気づかない。マネージャーはチームのパイプラインを把握できず、最適なクロージングタイミングを逃す。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">顧客データの分散</h5>
-              </div>
-              <p class="text-muted mb-0">顧客情報がメール・チャット・ドキュメントに散在。完全な顧客プロフィールがなく、的確なアプローチができない。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">不正確な売上予測</h5>
-              </div>
-              <p class="text-muted mb-0">データ根拠なく勘に頼った予測。大きな誤差がリソース配分や意思決定に影響する。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">SaaSコストの高さ</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce、HubSpotなどはシートごとの課金。カスタム開発は長期化しコストが読めない。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">データセキュリティへの不安</h5>
-              </div>
-              <p class="text-muted mb-0">顧客・商談データがサードパーティクラウドに保存され、データローカライズやプライバシー規制に対応できない。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">私たちのソリューション</h4>
-            <p class="para-desc mx-auto text-muted mb-0">NocoBaseノーコードプラットフォームで構築したCRM 2.0システム。ワークフロー自動化 + AIアシスタント</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">スマートリードスコアリング</h5>
-              <p class="text-muted mt-2">リード品質を自動評価、高価値リードを優先、最適コンタクト時間を推奨</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">勝率予測</h5>
-              <p class="text-muted mt-2">過去データに基づいてクロージング確率を予測、リスク案件を特定、ステージ進行の提案</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">顧客ヘルス監視</h5>
-              <p class="text-muted mt-2">360度顧客プロフィール、ヘルススコアリング、解約リスクアラート、関係維持のプロアクティブ管理</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">モジュール設計</h5>
-              <p class="text-muted mt-2">独立したモジュール設計、最小構成は顧客＋商談のみ、必要に応じて拡張可能</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">コア設計</span>
-            <h4 class="title mb-4">完全な販売サイクル</h4>
-            <p class="para-desc mx-auto text-muted mb-0">リード獲得から顧客サクセスまで、統一されたデータフローと各ステージでのAIアシスト</p>
+            <h4 class="title mb-4">顧客管理プロセス</h4>
+            <p class="para-desc mx-auto text-muted mb-0">リード受領から顧客 360 ビューまで、データを一気通貫で連携します。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">リード</div>
-                  <div class="small text-muted">AIスコアリング</div>
+                  <div class="small text-muted">複数チャネル</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">顧客</div>
-                  <div class="small text-muted">360プロフィール</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">フォロー</div>
+                  <div class="small text-muted">履歴記録</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">商談</div>
-                  <div class="small text-muted">勝率予測</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">顧客化</div>
+                  <div class="small text-muted">情報登録</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">見積</div>
-                  <div class="small text-muted">多通貨対応</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">顧客 360</div>
+                  <div class="small text-muted">全体集約</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">受注</div>
-                  <div class="small opacity-75">入金管理</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">データ蓄積</div>
+                  <div class="small opacity-75">営業ボード</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">ステージ転換</th>
-                      <th class="border-0 py-3">トリガー</th>
-                      <th class="border-0 py-3">AIアシスト</th>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">リード → 顧客</td>
-                      <td class="py-3 text-muted">有効な見込み客として確認</td>
-                      <td class="py-3 text-primary">AIスコア閾値で転換リマインダーをトリガー</td>
+                      <td class="py-3">リード</td>
+                      <td class="py-3 text-muted">フォーム / インポート / 手入力で登録、流入元と担当営業をマーキング</td>
+                      <td class="py-3 text-muted">リードプール、流入元タグ、ステージ遷移</td>
                     </tr>
                     <tr>
-                      <td class="py-3">顧客 → 商談</td>
-                      <td class="py-3 text-muted">明確なニーズを確認</td>
-                      <td class="py-3 text-primary">AIがインテントを分析し、商談作成を推奨</td>
+                      <td class="py-3">フォロー</td>
+                      <td class="py-3 text-muted">電話、メール、訪問の記録を残し、次回フォロー予定を設定</td>
+                      <td class="py-3 text-muted">フォロータイムライン、次回リマインド</td>
                     </tr>
                     <tr>
-                      <td class="py-3">商談 → 見積</td>
-                      <td class="py-3 text-muted">提案ステージに移行</td>
-                      <td class="py-3 text-primary">AI価格提案、競合比較、段階的価格設定</td>
+                      <td class="py-3">顧客化</td>
+                      <td class="py-3 text-muted">リードを顧客に変換し、顧客情報(業界 / 規模 / 担当者)を登録</td>
+                      <td class="py-3 text-muted">顧客テーブル、担当者テーブル、リード紐付け</td>
                     </tr>
                     <tr>
-                      <td class="py-3">見積 → 受注</td>
-                      <td class="py-3 text-muted">顧客が見積を承認</td>
-                      <td class="py-3 text-primary">製品詳細と価格を含む受注を自動生成</td>
+                      <td class="py-3">顧客 360</td>
+                      <td class="py-3 text-muted">顧客の全体像(受注、チケット、プロジェクト、資産)を確認</td>
+                      <td class="py-3 text-muted">埋め込みブロック、モジュール横断の関連付け</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">データ蓄積</td>
+                      <td class="py-3 text-muted">営業ボードで担当者 / 地域 / 種別ごとに KPI を集計</td>
+                      <td class="py-3 text-muted">チャート、明細ドリルダウン、エクスポート</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AIアシスト</span>
-            <h4 class="title mb-4">AIアシスト機能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">ワークフローのAIノードを通じて、スコアリング・分析・ライティングなどの反復作業をアシスト</p>
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">リード、顧客、フォロー、ダッシュボードまで、顧客関係管理の日常を一通りカバーします。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">ワークフローノード</span></h5>
-              <span class="badge bg-soft-primary mb-2">営業スカウト</span>
-              <p class="text-muted mt-2 small">深い商談分析、勝率予測、競合インテリジェンス、案件戦略の提案</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">リードのインポート</h5>
+              <p class="text-muted mt-2">Excel 一括インポート、フォーム収集、API 連携の 3 つの方法に対応。フィールドマッピングをビジュアルに設定でき、重複は自動的に排除されます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">インサイトアナリスト</span>
-              <p class="text-muted mt-2 small">スマートリードスコアリング、顧客ヘルス評価、営業データ分析、パイプライン予測</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">ステージ遷移</h5>
+              <p class="text-muted mt-2">リードのステージ(新規 / 接触済 / 顧客化 / 失注)はビジュアルに設定可能。変更は自動で履歴に残り、転換率も自動集計されます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">エディターアシスタント</span>
-              <p class="text-muted mt-2 small">メール感情・インテント分析、返信下書き、コミュニケーションサマリー</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フォロー記録</h5>
+              <p class="text-muted mt-2">訪問、電話、メールの内容を都度記録。タイムラインで履歴をたどれるので、担当引き継ぎもスムーズです。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">デイリープランニング</span>
-              <p class="text-muted mt-2 small">今日の優先タスク、次のアクション提案、フォローアップ計画</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フォローリマインド</h5>
+              <p class="text-muted mt-2">次回フォロー予定の前に自動通知。長期間連絡のない顧客は「再アプローチ対象」ボードに表示され、抜け漏れを防ぎます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻訳担当</span>
-              <p class="text-muted mt-2 small">多言語顧客コミュニケーション、コンテンツ翻訳、外贸メール対応</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">顧客 360 ビュー</h5>
+              <p class="text-muted mt-2">顧客詳細画面で受注・チケット・プロジェクト・資産を集約表示。複数システムを切り替えずに、1 画面で全体像を把握できます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">AIメンバーを追加</h5>
-              <span class="badge bg-soft-secondary mb-2">拡張中</span>
-              <p class="text-muted mt-2 small">ビジネスニーズに応じて、より多くの専門AIメンバーを追加可能</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分類とタグ</h5>
+              <p class="text-muted mt-2">顧客の種類、業界、規模、流入元を多軸タグで管理。タグでの絞り込みや集計分析に活用できます。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">柔軟なアーキテクチャ</span>
-            <h4 class="title mb-4">モジュール設計</h4>
-            <p class="para-desc mx-auto text-muted mb-0">各モジュールは独立設計で、オン/オフ切り替え可能。ニーズに合わせてスケールアップ</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">モジュール</th>
-                  <th class="border-0 py-3">必須/任意</th>
-                  <th class="border-0 py-3">内容</th>
-                  <th class="border-0 py-3">AI機能</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">顧客管理</td>
-                  <td class="py-3"><span class="badge bg-success">必須</span></td>
-                  <td class="py-3 text-muted">顧客記録、連絡先、階層、意思決定チェーン</td>
-                  <td class="py-3 text-primary">ヘルススコアリング、解約アラート</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">商談管理</td>
-                  <td class="py-3"><span class="badge bg-success">必須</span></td>
-                  <td class="py-3 text-muted">営業ファネル、ステージ進行、活動記録</td>
-                  <td class="py-3 text-primary">勝率予測、リスク特定</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">リード管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">任意</span></td>
-                  <td class="py-3 text-muted">リード取込、ステータスワークフロー、転換追跡</td>
-                  <td class="py-3 text-primary">スマートスコアリング、最適コンタクト時間</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">見積管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">任意</span></td>
-                  <td class="py-3 text-muted">多通貨、段階的価格、バージョン管理、承認フロー</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">受注管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">任意</span></td>
-                  <td class="py-3 text-muted">受注作成、入金追跡</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">製品管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">任意</span></td>
-                  <td class="py-3 text-muted">製品カタログ、カテゴリ、段階的価格</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">メール連携</td>
-                  <td class="py-3"><span class="badge bg-secondary">任意</span></td>
-                  <td class="py-3 text-muted">メール送受信、CRM連携</td>
-                  <td class="py-3 text-primary">サマリー、感情分析</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">フルスイート</span>
-                  <p class="small text-muted mb-0">全7モジュール<br/>完全なB2B営業チーム向け</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">スタンダード</span>
-                  <p class="small text-muted mb-0">顧客+商談+見積+受注<br/>中小企業の営業管理</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">ライト</span>
-                  <p class="small text-muted mb-0">顧客+商談<br/>シンプルな追跡</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">トレード</span>
-                  <p class="small text-muted mb-0">顧客+商談+見積+メール<br/>外贸取引向け</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">マージ・重複排除</h5>
+              <p class="text-muted mt-2">同一顧客の重複登録を自動検出。ワンクリックで統合でき、フォロー履歴や関連レコードもそのまま引き継がれます。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">営業ダッシュボード</h5>
+              <p class="text-muted mt-2">営業担当・地域・顧客タイプ別に KPI を集計。新規顧客数、転換率、アクティブ顧客の分布をひと目で把握できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フィールド・行単位の権限</h5>
+              <p class="text-muted mt-2">ロールごとに表示フィールドを設定可能。営業担当は担当顧客のみ、管理者は全顧客を閲覧できます。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">自動化がもたらす価値</h4>
-            <p class="para-desc mx-auto text-muted mb-0">ワークフロー自動化 + AIアシストで反復作業を削減し、営業が顧客関係に集中できる</p>
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">リードスクリーニング効率向上</h5>
-              <p class="text-muted small mb-0">AI自動スコアリングで手動選別時間を削減</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">フォローアップ効率向上</h5>
-              <p class="text-muted small mb-0">勝率予測で高価値案件に集中</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">解約率低下</h5>
-              <p class="text-muted small mb-0">ヘルス評価でリスクを早期発見</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">成約率改善</h5>
-              <p class="text-muted small mb-0">AI戦略提案でクロージングを加速</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">なぜ私たちを選ぶのか？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">従来のSaaS CRMやカスタム開発との比較</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">比較項目</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">カスタム開発</th>
-                  <th class="border-0 py-3 text-primary">NocoBaseソリューション</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">導入までの時間</td>
-                  <td class="py-3 text-muted">すぐに使える</td>
-                  <td class="py-3 text-muted">数ヶ月の開発</td>
-                  <td class="py-3 text-primary">設定ですぐに開始</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">カスタマイズ</td>
-                  <td class="py-3 text-muted">制限あり</td>
-                  <td class="py-3 text-muted">完全制御</td>
-                  <td class="py-3 text-primary">ノーコードで柔軟にカスタマイズ</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">データセキュリティ</td>
-                  <td class="py-3 text-muted">クラウドホスト</td>
-                  <td class="py-3 text-muted">セルフホスト</td>
-                  <td class="py-3 text-primary">セルフホスト、完全なデータ制御</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AIアシスト</td>
-                  <td class="py-3 text-muted">限定/追加費用</td>
-                  <td class="py-3 text-muted">自社開発が必要</td>
-                  <td class="py-3 text-primary">ワークフローAIノード、必要時に活用</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">モジュール柔軟性</td>
-                  <td class="py-3 text-muted">機能固定</td>
-                  <td class="py-3 text-muted">コード変更が必要</td>
-                  <td class="py-3 text-primary">モジュール式、必要に応じて拡張</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">総コスト</td>
-                  <td class="py-3 text-muted">シートごとのサブスク</td>
-                  <td class="py-3 text-muted">高い開発コスト</td>
-                  <td class="py-3 text-primary">一度購入、長期利用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">使い方</h4>
-            <p class="para-desc mx-auto text-muted mb-0">3つのステップでCRM 2.0をお使いの環境にデプロイ</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>NocoBaseをインストール</h5>
-                <p class="text-muted mt-2">インストールガイドに従って、NocoBaseをサーバーにデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">インストールガイド</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>ソリューションを理解</h5>
-                <p class="text-muted mt-2">ソリューションドキュメントを読んで、機能・アーキテクチャ・ユースケースを理解</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/" target="_blank" class="btn btn-outline-primary">ソリューション概要</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>システムに復元</h5>
-                <p class="text-muted mt-2">復元チュートリアルに従って、NocoBase環境にCRM 2.0をデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/en/solution/crm/installation" target="_blank" class="btn btn-outline-primary">復元チュートリアル</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">CRM 2.0 を使ってみよう</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            NocoBase 2.x で構築したモジュール式CRMシステム。カスタムニーズがある方、詳細を知りたい方は、お気軽にお問い合わせください。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、販売管理・ヘルプデスク・プロジェクト管理・固定資産管理・HR と連携しても利用できます。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/ja/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>お問い合わせ
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseJA>
 
 <style>
-/* CRM 2.0ページスタイル */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AIアバタースタイル */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/ja/solutions/crm.astro
+++ b/src/pages/ja/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseJA from "../../../layouts/BaseJA.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// インタラクティブデモデータをインポート
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-ja.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-ja.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-ja.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-ja.json";
-
-// プラグインデータを取得
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// CRMで使用するプラグインの定義
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// 名前でプラグインを検索
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// CRM関連プラグインを取得
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// デバッグ情報
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// 元のデータはJSONファイルに移動しました
 ---
 
-<Layout
-  title="ノーコードで柔軟かつ強力なCRMプラットフォーム"
-  description="すぐに使えます。究極のカスタマイズ機能を提供し、データ主権を完全に保証します。この基盤の上にフィールド、ブロック、機能、ページを自由に拡張して、ビジネスニーズに完全に適合させることができます。"
-  keywords="NocoBase CRM, 顧客関係管理, ノーコードCRM, オープンソースCRM, カスタムCRM"
+<BaseJA
+  title="CRM(顧客管理)— オープンソース・セルフホスト可能 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソース CRM。リード管理、顧客フォロー、転換、マージ・重複排除、顧客 360 ビューを標準装備。すぐに使え、セルフホストにも対応します。"
+  keywords="CRM, オープンソース CRM, 顧客管理システム, 顧客関係管理, リード管理, 顧客フォロー, 顧客 360, ノーコード CRM, セルフホスト CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">ノーコードで柔軟かつ強力な<br/>CRMプラットフォーム</h1>
-            <p class="para-desc text-muted">すぐに使えます。究極のカスタマイズ機能を提供し、データ主権を完全に保証します。この基盤の上にフィールド、ブロック、機能、ページを自由に拡張して、ビジネスニーズに完全に適合させることができます。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> NocoBase 1.x で構築（2.0 開発中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>顧客管理システム</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。リード、フォローアップ、転換、マージ・重複排除までの一連の流れをカバーし、顧客 360 ビューで受注・チケット・プロジェクト・資産の履歴を集約します。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">リードステージ管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">顧客 360 ビュー</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">マージ / 重複排除</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">対象業界：</span>
-                  <span class="badge bg-soft-primary">全業界</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">B2B 営業</span>
+                  <span class="badge bg-soft-primary me-2">プロジェクト型営業</span>
+                  <span class="badge bg-soft-primary me-2">貿易</span>
+                  <span class="badge bg-soft-primary">中小チーム</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開発者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>ライブデモ
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>自分の環境にデプロイ
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                お使いのブラウザはHTML5ビデオをサポートしていません。
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 顧客管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase CRM のユニークな特徴</h4>
-            <p class="para-desc mx-auto text-muted mb-0">SaaSや他のCRMシステムとは異なり、NocoBase CRMは柔軟性と完全制御を実現</p>
+            <h4 class="title mb-4">顧客管理プロセス</h4>
+            <p class="para-desc mx-auto text-muted mb-0">リード受領から顧客 360 ビューまで、データを一気通貫で連携します。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完全ノーコード構築</h5>
-              <p class="text-muted mt-2">プログラミングスキル不要でCRMをカスタマイズ可能</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">一般的なCRM機能をカバー</h5>
-              <p class="text-muted mt-2">顧客管理、営業パイプライン、商談追跡、連絡先管理、メール通信、承認プロセスなどの機能モジュール</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">自由な変更と拡張</h5>
-              <p class="text-muted mt-2">カスタムフィールド、プロセス、ビジネスロジックをサポート、柔軟なアーキテクチャで「二次開発」が簡単</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">オープンソース、完全なデータ制御</h5>
-              <p class="text-muted mt-2">システムコードとデータを完全制御、企業データセキュリティを保証</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase CRM の機能をお試しください</h4>
-            <p class="para-desc mx-auto text-muted mb-0">数回のクリックで素早く体験</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">ダッシュボードデータ可視化</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>インタラクティブデモ
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">リード</div>
+                  <div class="small text-muted">複数チャネル</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">フォロー</div>
+                  <div class="small text-muted">履歴記録</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">顧客化</div>
+                  <div class="small text-muted">情報登録</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">顧客 360</div>
+                  <div class="small text-muted">全体集約</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">データ蓄積</div>
+                  <div class="small opacity-75">営業ボード</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">リード変換プロセス</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>インタラクティブデモ
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">商談から受注へ</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>インタラクティブデモ
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- 拡張機能インタラクティブデモを使用 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>今すぐ試す
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>自分の環境にコピー
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM 開発・拡張チュートリアル</h4>
-            <p class="para-desc mx-auto text-muted mb-0">NocoBase を使用してプロフェッショナルなCRMシステムを構築・拡張する方法を学びます</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">基本設定とカスタマイズ</h5>
-                <p class="text-muted text-center">データモデルの作成、フィールド関係のカスタマイズ、権限とインターフェースレイアウトの設定を学びます</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">データ分析・可視化</h5>
-                <p class="text-muted text-center">売上データ分析ダッシュボードを構築し、パフォーマンス監視とデータ可視化を実現します</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">プロセス自動化</h5>
-                <p class="text-muted text-center">営業プロセス、承認ワークフロー、ビジネスルールの自動化を設定します</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">システム統合・拡張</h5>
-                <p class="text-muted text-center">サードパーティシステムとの統合、モバイル対応、その他の高度な拡張機能</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM で使用されている商用プラグイン</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRMコアはオープンソース、商用プラグインで機能を充実</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 動的に生成されるプラグインカード -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_jp || plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_jp || plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_jp || plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳細</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用、1年間のアップグレード</span><br>
-                          <a href="/ja/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用とアップグレード</span><br>
-                          <a class="text-muted" href="/ja/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- レイアウト用のプレースホルダーカード -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">より多くのプラグインが近日公開予定</h6>
-                  <p class="text-muted small">私たちはより多くの有用な商用プラグインを開発中です。お楽しみに</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">リード</td>
+                      <td class="py-3 text-muted">フォーム / インポート / 手入力で登録、流入元と担当営業をマーキング</td>
+                      <td class="py-3 text-muted">リードプール、流入元タグ、ステージ遷移</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">フォロー</td>
+                      <td class="py-3 text-muted">電話、メール、訪問の記録を残し、次回フォロー予定を設定</td>
+                      <td class="py-3 text-muted">フォロータイムライン、次回リマインド</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">顧客化</td>
+                      <td class="py-3 text-muted">リードを顧客に変換し、顧客情報(業界 / 規模 / 担当者)を登録</td>
+                      <td class="py-3 text-muted">顧客テーブル、担当者テーブル、リード紐付け</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">顧客 360</td>
+                      <td class="py-3 text-muted">顧客の全体像(受注、チケット、プロジェクト、資産)を確認</td>
+                      <td class="py-3 text-muted">埋め込みブロック、モジュール横断の関連付け</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">データ蓄積</td>
+                      <td class="py-3 text-muted">営業ボードで担当者 / 地域 / 種別ごとに KPI を集計</td>
+                      <td class="py-3 text-muted">チャート、明細ドリルダウン、エクスポート</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ja/plugins-commercial" class="btn btn-primary me-3">すべての商用プラグインを見る</a>
-          <a href="/ja/commercial" class="btn btn-outline-primary">価格について詳しく</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">使用方法</h4>
-            <p class="para-desc mx-auto text-muted mb-0">3つのステップで NocoBase CRM を環境に素早くデプロイ</p>
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">リード、顧客、フォロー、ダッシュボードまで、顧客関係管理の日常を一通りカバーします。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>NocoBase をインストール</h5>
-                                  <p class="text-muted mt-2">インストールドキュメントに従って、NocoBase をサーバーにデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">インストールドキュメント</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">リードのインポート</h5>
+              <p class="text-muted mt-2">Excel 一括インポート、フォーム収集、API 連携の 3 つの方法に対応。フィールドマッピングをビジュアルに設定でき、重複は自動的に排除されます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>CRM テンプレートファイルをダウンロード</h5>
-                <p class="text-muted mt-2">NocoBase CRM システムの完全なテンプレートファイルを取得、2つの形式をサポート</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">SQL ファイルをダウンロード</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">バックアップファイル (.nbdata) をダウンロード</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">ステージ遷移</h5>
+              <p class="text-muted mt-2">リードのステージ(新規 / 接触済 / 顧客化 / 失注)はビジュアルに設定可能。変更は自動で履歴に残り、転換率も自動集計されます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>システム内で復元</h5>
-                <p class="text-muted mt-2">テンプレートファイルを NocoBase システムにインポートしてデプロイを完了</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/ja/solution/crm/v1" class="btn btn-outline-primary">復元チュートリアル</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フォロー記録</h5>
+              <p class="text-muted mt-2">訪問、電話、メールの内容を都度記録。タイムラインで履歴をたどれるので、担当引き継ぎもスムーズです。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フォローリマインド</h5>
+              <p class="text-muted mt-2">次回フォロー予定の前に自動通知。長期間連絡のない顧客は「再アプローチ対象」ボードに表示され、抜け漏れを防ぎます。</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">顧客 360 ビュー</h5>
+              <p class="text-muted mt-2">顧客詳細画面で受注・チケット・プロジェクト・資産を集約表示。複数システムを切り替えずに、1 画面で全体像を把握できます。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分類とタグ</h5>
+              <p class="text-muted mt-2">顧客の種類、業界、規模、流入元を多軸タグで管理。タグでの絞り込みや集計分析に活用できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">マージ・重複排除</h5>
+              <p class="text-muted mt-2">同一顧客の重複登録を自動検出。ワンクリックで統合でき、フォロー履歴や関連レコードもそのまま引き継がれます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">営業ダッシュボード</h5>
+              <p class="text-muted mt-2">営業担当・地域・顧客タイプ別に KPI を集計。新規顧客数、転換率、アクティブ顧客の分布をひと目で把握できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フィールド・行単位の権限</h5>
+              <p class="text-muted mt-2">ロールごとに表示フィールドを設定可能。営業担当は担当顧客のみ、管理者は全顧客を閲覧できます。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">NocoBase CRM を使う準備はできていますか？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1分で専用CRMデモをデプロイ。データ構造の設定からインターフェースレイアウト、プロセスロジックまで、すべてNocoBaseの視覚的設定で完了し、一行のコードも書く必要はありません。
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、販売管理・ヘルプデスク・プロジェクト管理・固定資産管理・HR と連携しても利用できます。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>ライブデモ
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>自分の環境にデプロイ
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseJA>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // 最初に大きな再生ボタンをクリックした時のみ再生を開始
-  playButton.addEventListener('click', function() {
-    // コントロールバーを追加
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // 再生を開始し、再生ボタンを非表示
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // ビデオ終了時に再生ボタンを表示、コントロールバーを削除
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/ja/solutions/hr-management.astro
+++ b/src/pages/ja/solutions/hr-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseJA from "../../../layouts/BaseJA.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseJA
+  title="HR 人事管理 — オープンソースの人事システム | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースの HR 人事管理。従業員台帳、入社、退職、休暇、試用期間の追跡、職位と部門の組織構造に対応。軽量でセルフホストでき、中小企業の HR チームに適しています。"
+  keywords="HR 人事管理, 人事管理システム, オープンソース HR, 従業員管理, 入社管理, 退職管理, 休暇承認, 試用期間管理, 組織構造管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">HR 人事モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR 人事管理</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。従業員台帳、<strong>入社、退職、休暇、試用期間</strong> の流れを全体的に追跡し、職位と部門の組織構造と連動します。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">入社 / 退職チェックリスト</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">休暇承認</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">試用期間ボード</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">中小企業</span>
+                  <span class="badge bg-soft-primary me-2">チェーン店舗</span>
+                  <span class="badge bg-soft-primary me-2">業界別 HR</span>
+                  <span class="badge bg-soft-primary">部門横断の連携</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="HR 人事管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">従業員ライフサイクル</h4>
+            <p class="para-desc mx-auto text-muted mb-0">採用から退職までを一気通貫で管理する人事プロセスを実現します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">採用</div>
+                  <div class="small text-muted">候補者</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">入社</div>
+                  <div class="small text-muted">リスト追跡</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">在籍管理</div>
+                  <div class="small text-muted">勤怠・休暇</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">評価</div>
+                  <div class="small text-muted">本採用 / 異動</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">退職</div>
+                  <div class="small opacity-75">引継ぎ・保管</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">採用</td>
+                      <td class="py-3 text-muted">候補者の登録、面接評価。通過後に従業員ファイルに変換</td>
+                      <td class="py-3 text-muted">候補者テーブル、面接評価</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入社</td>
+                      <td class="py-3 text-muted">入社タスクリスト(雇用契約、社員証、機材配布、アカウント開設)</td>
+                      <td class="py-3 text-muted">入社チェックリスト、契約書</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">在籍管理</td>
+                      <td class="py-3 text-muted">日々の勤怠、休暇、振替、残業の承認</td>
+                      <td class="py-3 text-muted">休暇記録、休暇残日数</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評価</td>
+                      <td class="py-3 text-muted">試用期間評価、本採用、異動、昇格</td>
+                      <td class="py-3 text-muted">評価表、職位変更</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">退職</td>
+                      <td class="py-3 text-muted">退職チェックリスト:引継ぎ、資産返却、アカウント停止、手続き</td>
+                      <td class="py-3 text-muted">退職記録、資産リリース</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">入社から退職までの人事業務を一気通貫で管理します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">従業員台帳</h5>
+              <p class="text-muted mt-2">従業員プロフィール、社員番号、入社日、職位、部門 — 統一档案、多次元で検索可能</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">従業員ライフサイクル</h5>
+              <p class="text-muted mt-2">入社待ち → 試用期間 → 在職 → 退職中 → 退職済み:5 つのステータスで従業員レコード全体を貫通、ステータスでフィルタ可能</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">部門組織構造</h5>
+              <p class="text-muted mt-2">ツリー型組織図:部門 → 子部門、NocoBase 内蔵 departments プラグインベース、権限と連動</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">ポジション台帳</h5>
+              <p class="text-muted mt-2">ポジション定義と職位レベル(初級/中級/上級/エキスパート);従業員にポジション割り当て、キャリアパスと権限管理に便利</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">休暇承認</h5>
+              <p class="text-muted mt-2">8 種類の休暇(年次/病気/私用/振替/結婚/育児/慶弔/その他);部門/直属上司ごとに承認フロー設定可能</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">フィールド単位の権限</h5>
+              <p class="text-muted mt-2">HR は給与フィールドを閲覧、マネージャーはチームメンバーの基本情報のみ — NocoBase ロール権限で柔軟に設定</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">機能拡張中</h5>
+              <p class="text-muted small mt-2 mb-0">予定:入社/退職チェックリスト、試用期間評価、契約・社会保険管理、採用候補者、異動/昇格記録</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・販売管理・ヘルプデスク・プロジェクト管理・固定資産管理 と連携しても利用できます。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseJA>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/ja/solutions/project-management.astro
+++ b/src/pages/ja/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">マイルストーン</div>
                   <div class="small text-muted">中間納品</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">マイルストーン管理</h5>
               <p class="text-muted mt-2">主要ノード(プロトタイプレビュー、内部テスト、リリース)をマイルストーンに設定し、進捗をマイルストーン単位で可視化します。</p>

--- a/src/pages/ja/solutions/project-management.astro
+++ b/src/pages/ja/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseJA from "../../../layouts/BaseJA.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// インタラクティブデモデータをインポート
-import projectDemoGuides from "../../../data/project-management-demo-ja.json";
-
-// プラグインデータを取得
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// プロジェクト管理で使用するプラグインを定義
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// 名前でプラグインを検索
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// プロジェクト管理関連プラグインを取得
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// デバッグ情報
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="包括的な研発プロジェクト管理ソリューション"
-  description="NocoBase 研発プロジェクト管理システムは、完全な開発ライフサイクル管理機能を提供します。要件計画、タスク割り当て、進捗追跡から品質管理まで、全プロセスのデジタル管理とチームコラボレーションを実現します。"
-  keywords="NocoBase 研発プロジェクト管理, タスク管理, チームコラボレーション, アジャイル開発, 品質管理"
+<BaseJA
+  title="プロジェクト管理 — 軽量なオープンソースのプロジェクト連携 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースのプロジェクト管理。プロジェクトとタスクの 2 階層管理、担当者、進捗、マイルストーン、遅延アラート、作業量分布に対応。軽量でセルフホストでき、中小規模チームや部門横断のプロジェクト連携に適しています。"
+  keywords="プロジェクト管理, プロジェクト管理システム, タスク管理, オープンソース プロジェクト管理, 軽量プロジェクト管理, タスク管理システム, プロジェクト連携, プロジェクト追跡, マイルストーン管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,458 +14,337 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">包括的な<br/>研発プロジェクト管理ソリューション</h1>
-            <p class="para-desc text-muted">NocoBase で構築された強力で柔軟な研発プロジェクト管理プラットフォーム。アジャイル、ウォーターフォール、ハイブリッドなど、複数の開発手法をサポート。要件、タスク、チーム、イテレーション、品質を一つのプラットフォームで管理。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> NocoBase 1.x で構築（2.0 開発中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">プロジェクト管理モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">プロジェクト管理</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。<strong>プロジェクト + タスク</strong> の 2 階層管理で、担当者、進捗、マイルストーン、遅延アラート、作業量分布までカバーします。軽量でセルフホスト可能です。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">プロジェクト+タスク 2 階層</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">遅延アラート</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">マイルストーン追跡</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
             </div>
 
-            <!-- タグ -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">適用業界：</span>
-                  <span class="badge bg-soft-primary">研発</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">納品プロジェクト</span>
+                  <span class="badge bg-soft-primary me-2">社内 IT</span>
+                  <span class="badge bg-soft-primary me-2">部門横断の連携</span>
+                  <span class="badge bg-soft-primary">中小チーム</span>
                 </div>
               </div>
             </div>
 
-            <!-- 開発者情報 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開発者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="プロジェクト管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">プロジェクトの流れ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">立ち上げから完了までの追跡を一気通貫で行い、マイルストーンと遅延アラートを自動運用します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">立ち上げ</div>
+                  <div class="small text-muted">顧客紐付け</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">タスク分解</div>
+                  <div class="small text-muted">担当者</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">進捗追跡</div>
+                  <div class="small text-muted">遅延アラート</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">マイルストーン</div>
+                  <div class="small text-muted">中間納品</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">完了</div>
+                  <div class="small opacity-75">振り返り・保管</div>
                 </div>
               </div>
-            </div>
 
-            <!-- ボタン -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>オンラインデモ
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>環境にデプロイ
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- プロジェクト管理プレビュー -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase 研発プロジェクト管理システムプレビュー" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase プロジェクト管理の独自性</h4>
-            <p class="para-desc mx-auto text-muted mb-0">プロジェクト管理方法論に適応する包括的なソリューション</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完全な研発ライフサイクル</h5>
-              <p class="text-muted mt-2">要件分析、設計開発からテスト、リリース、保守まで、研発のすべての段階を管理</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">アジャイル開発管理</h5>
-              <p class="text-muted mt-2">スクラムスプリント、カンバン、バーンダウンチャートをサポートし、反復開発と継続的デリバリーを実現</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">チーム＆品質管理</h5>
-              <p class="text-muted mt-2">開発チームを効率的に管理し、コード品質を追跡、不具合や問題を処理して製品品質を確保</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">NocoBase プラットフォーム</h5>
-              <p class="text-muted mt-2">NocoBaseのノーコード機能により、組織固有のニーズに合わせて迅速にカスタマイズ可能</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- インタラクティブデモ -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>今すぐ体験
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>環境にコピー
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">プロジェクト管理開発チュートリアル</h4>
-            <p class="para-desc mx-auto text-muted mb-0">NocoBase を使用してゼロからプロフェッショナルなプロジェクト管理システムを構築する方法を学ぶ</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">データモデル設計</h5>
-                <p class="text-muted text-center">プロジェクト、タスク、チームの基本データ構造とその関係を作成する方法を学ぶ</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">立ち上げ</td>
+                      <td class="py-3 text-muted">プロジェクト作成、顧客(納品案件)または資産(IT 案件)と関連付け、プロジェクトマネージャーを指定</td>
+                      <td class="py-3 text-muted">プロジェクト情報、顧客紐付け、担当者</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">タスク分解</td>
+                      <td class="py-3 text-muted">タスクに分解し、担当者、期間、依存関係を設定</td>
+                      <td class="py-3 text-muted">タスクテーブル、担当者、依存関係図</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">進捗追跡</td>
+                      <td class="py-3 text-muted">メンバーがタスク進捗を更新。期限超過のタスクは自動で赤色表示</td>
+                      <td class="py-3 text-muted">進捗率、遅延マーク</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">マイルストーン</td>
+                      <td class="py-3 text-muted">主要ノード(レビュー / 内部テスト / リリース)をマイルストーンに設定し、中間納品物を登録</td>
+                      <td class="py-3 text-muted">マイルストーン一覧、納品物の添付</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">完了</td>
+                      <td class="py-3 text-muted">プロジェクト完了時に保管し、工数とコストを記録</td>
+                      <td class="py-3 text-muted">完了報告、工数集計</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">ワークフロー設定</h5>
-                <p class="text-muted text-center">タスク割り当て、ステータス遷移、自動化プロジェクトワークフローを設定</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">スプリントと追跡</h5>
-                <p class="text-muted text-center">スプリント、バーンダウンチャート、進捗追跡機能を設定</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">商用プラグインで機能を強化</h4>
-            <p class="para-desc mx-auto text-muted mb-0">強力な商用プラグインでプロジェクト管理機能を拡張</p>
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">立ち上げから完了まで、軽量なプロジェクト追跡を実現します。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- 動的に生成されるプラグインカード -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_jp || plugin.name;
-          const displayDescription = plugin.description_jp || plugin.description;
-          const docsUrl = plugin.docs_jp || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">提供者: <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳細</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">生涯使用、1年アップグレード</span><br>
-                          <a href="/ja/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_1_year_jp || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">生涯使用とアップグレード</span><br>
-                          <a class="text-muted" href="/ja/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_jp || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">プロジェクト+タスクの 2 階層</h5>
+              <p class="text-muted mt-2">1 プロジェクトを複数タスクに分解し、担当者・期間・進捗を独立管理。プロジェクトボードで全タスクの状態を俯瞰できます。</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ja/plugins-commercial" class="btn btn-primary me-3">すべての商用プラグインを見る</a>
-          <a href="/ja/commercial" class="btn btn-outline-primary">価格を確認</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">マイルストーン管理</h5>
+              <p class="text-muted mt-2">主要ノード(プロトタイプレビュー、内部テスト、リリース)をマイルストーンに設定し、進捗をマイルストーン単位で可視化します。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">遅延アラート</h5>
+              <p class="text-muted mt-2">予定期限を過ぎたタスクを自動で赤色表示。遅延プロジェクト一覧はリアルタイムで更新され、リスクが一目で分かります。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">担当者と作業量</h5>
+              <p class="text-muted mt-2">担当者ごとにタスク数と作業量を集計。誰が忙しく、誰が余裕があり、遅延が多いのかを一目で把握できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">プロジェクトステータスボード</h5>
+              <p class="text-muted mt-2">プロジェクトタイプ・ステータス・担当者ごとに KPI を集計。進行中、完了、遅延プロジェクトを分類して表示します。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">顧客・資産との連携</h5>
+              <p class="text-muted mt-2">プロジェクトを顧客(納品案件)や資産(IT 案件)と関連付け。顧客詳細画面から関連プロジェクトの履歴を確認できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">機能拡張中</h5>
+              <p class="text-muted small mt-2 mb-0">予定:タスク依存グラフ、工数記録とコスト、成果物アーカイブ、ガントチャート表示</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">どのように使用しますか？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">3つのステップでプロジェクト管理機能を持つ NocoBase CRM システムを環境にデプロイ</p>
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>NocoBase システムをインストール</h5>
-                <p class="text-muted mt-2">インストールドキュメントに従って NocoBase システムをサーバーにデプロイ</p>
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">インストールガイドを見る</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>CRM システムテンプレートをダウンロード</h5>
-                <p class="text-muted mt-2">プロジェクト管理機能を取得するための完全な CRM テンプレートをダウンロード</p>
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">SQL ファイルをダウンロード</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">バックアップファイル (.nbdata) をダウンロード</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>システムで復元</h5>
-                <p class="text-muted mt-2">CRM テンプレートファイルを NocoBase システムにインポートして、CRM とプロジェクト管理機能を取得</p>
-              </div>
-              <div class="mt-3">
-                <a href="/ja/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">復元チュートリアル</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- プロジェクト管理機能の説明 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">ヒント</h6>
-                <p class="mb-0 text-muted">プロジェクト管理システムは包括的なモジュールとして CRM テンプレートに完全に統合されています。デプロイ後、CRM システム内で完全なプロジェクト管理機能を直接使用でき、プロジェクトとチームの全プロセス管理を実現できます。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
   <!-- CTA Start -->
-  <section class="section bg-primary">
+  <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 col-md-10">
-          <div class="text-center">
-            <h3 class="title mb-4 text-white">研発管理の変革準備はできていますか？</h3>
-            <p class="para-desc mx-auto text-white-50 mb-0">
-              NocoBase 研発プロジェクト管理システムで、チームコラボレーションを強化し、製品デリバリー品質を向上させましょう。今すぐ体験して、開発チームの効率を最大化してください。
-            </p>
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-light me-3">
-                <i class="uil uil-play me-1"></i>今すぐ体験
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-light">
-                <i class="uil uil-copy me-1"></i>環境にデプロイ
-              </a>
-            </div>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・販売管理・ヘルプデスク・固定資産管理・HR と連携しても利用できます。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
+        </div>
+      </div>
+    </div>
+  </section>
   <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseJA>
 
 <style>
-/* プロジェクト管理システムスタイル - チケットページスタイルを参照 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* プラグインカードスタイル */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/ja/solutions/sales-management.astro
+++ b/src/pages/ja/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseJA from "../../../layouts/BaseJA.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseJA
+  title="販売管理 — オープンソースの受注・売掛管理 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースの販売管理。見積、受注、請求、入金までの一連の流れに対応し、承認ワークフロー、多通貨、売掛 KPI、滞留分析を標準装備しています。"
+  keywords="販売管理, 受注管理, 見積, 請求管理, 売掛管理, 入金管理, 販売プロセス, 販売承認, オープンソース 販売管理, 多通貨見積, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">販売管理モジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">販売管理</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。<strong>見積 → 受注 → 請求 → 入金</strong> までの一連の流れを網羅し、販売承認ワークフロー、多通貨見積、売掛 KPI、滞留分析を標準搭載しています。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">多通貨見積</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">受注承認フロー</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">売掛 KPI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">B2B 営業</span>
+                  <span class="badge bg-soft-primary me-2">貿易の受注</span>
+                  <span class="badge bg-soft-primary me-2">機器販売</span>
+                  <span class="badge bg-soft-primary">売掛管理</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="販売管理システム画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">販売プロセス</h4>
+            <p class="para-desc mx-auto text-muted mb-0">見積から入金までの一連の流れと、承認・売掛 KPI を一気通貫で連携します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">見積</div>
+                  <div class="small text-muted">多通貨</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">受注</div>
+                  <div class="small text-muted">承認フロー</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">出荷</div>
+                  <div class="small text-muted">物流追跡</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">請求</div>
+                  <div class="small text-muted">情報自動入力</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">入金</div>
+                  <div class="small opacity-75">売掛 KPI</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">見積</td>
+                      <td class="py-3 text-muted">顧客 / 製品を選択し、多通貨対応の見積書を作成。値引き、税率、有効期限を設定可能</td>
+                      <td class="py-3 text-muted">見積書、製品明細、PDF 出力</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">受注</td>
+                      <td class="py-3 text-muted">見積から受注へ変換。値引き超過や高額受注は承認をトリガー</td>
+                      <td class="py-3 text-muted">受注、承認フロー、明細</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">出荷</td>
+                      <td class="py-3 text-muted">受注確定後に出荷伝票を作成し、配送番号と関連付け</td>
+                      <td class="py-3 text-muted">出荷伝票、配送番号、ステータス遷移</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">請求</td>
+                      <td class="py-3 text-muted">受注または出荷後に請求書を発行。顧客情報の税番号 / 住所を自動入力</td>
+                      <td class="py-3 text-muted">請求書、発行ステータス</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入金</td>
+                      <td class="py-3 text-muted">分割入金を登録し、エイジングごとに売掛 KPI を集計</td>
+                      <td class="py-3 text-muted">入金記録、売掛残高、エイジング</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">見積、受注、請求、入金の一気通貫と、承認・売掛分析を一通り提供します。</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">見積書管理</h5>
+              <p class="text-muted mt-2">多通貨対応の見積書に対応し、値引き、税率、有効期限を設定可能。PDF 出力でそのまま顧客に送付でき、受注への変換もワンクリックです。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">受注管理</h5>
+              <p class="text-muted mt-2">受注ステータス(下書き / 審査中 / 確定 / 出荷済 / 完了)で遷移管理。顧客と製品を関連付け、明細は行単位で編集可能です。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">受注承認ワークフロー</h5>
+              <p class="text-muted mt-2">値引き超過、高額受注、特殊条件など、承認のトリガーを部門 / 役職 / 金額閾値で柔軟に設定できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">請求管理</h5>
+              <p class="text-muted mt-2">受注から請求書を生成し、発行状況を追跡。顧客情報の税番号、住所、備考が自動入力され、手入力ミスを減らせます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">入金記録</h5>
+              <p class="text-muted mt-2">分割入金や部分入金に対応し、売掛残高を自動計算。顧客別・受注別に支払い状況を集計できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">売掛 KPI</h5>
+              <p class="text-muted mt-2">延滞債権一覧、エイジング分析(30 / 60 / 90 日のレンジ)を提供。顧客別・営業担当別に集計し、回収状況を可視化します。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">多通貨と為替レート</h5>
+              <p class="text-muted mt-2">USD / EUR / CNY / JPY など多通貨での見積・受注に対応。為替レート表は手動更新やインポートに対応し、基準通貨換算も自動です。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">出荷と物流</h5>
+              <p class="text-muted mt-2">出荷伝票を受注と配送番号に関連付け。複数回出荷や部分出荷にも対応し、ステータスは自動で受注へ反映されます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">販売ダッシュボード</h5>
+              <p class="text-muted mt-2">営業担当・地域・製品別に売上、受注数、回収率を集計。月次・四半期のトレンドも一目で把握できます。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・ヘルプデスク・プロジェクト管理・固定資産管理・HR と連携しても利用できます。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseJA>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/ja/solutions/sales-management.astro
+++ b/src/pages/ja/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">売掛 KPI</h5>
-              <p class="text-muted mt-2">延滞債権一覧、エイジング分析(30 / 60 / 90 日のレンジ)を提供。顧客別・営業担当別に集計し、回収状況を可視化します。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">多通貨と為替レート</h5>
-              <p class="text-muted mt-2">USD / EUR / CNY / JPY など多通貨での見積・受注に対応。為替レート表は手動更新やインポートに対応し、基準通貨換算も自動です。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">出荷と物流</h5>
-              <p class="text-muted mt-2">出荷伝票を受注と配送番号に関連付け。複数回出荷や部分出荷にも対応し、ステータスは自動で受注へ反映されます。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">販売ダッシュボード</h5>

--- a/src/pages/ja/solutions/ticketing-v2.astro
+++ b/src/pages/ja/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseJA from "../../../layouts/BaseJA.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI駆動のインテリジェントチケットシステム - NocoBase"
-  description="NocoBase AI駆動のインテリジェントチケットシステム。T型データアーキテクチャで複数のビジネスシナリオをサポート。AIエージェントチームが自動分類、スマート返信、ナレッジ推奨を実行。SLA完全監視でチケットライフサイクル全体を管理。"
-  keywords="NocoBase チケットシステム, AIチケット, インテリジェントカスタマーサービス, SLA管理, ナレッジベース, チケット分類"
+<BaseJA
+  title="ヘルプデスク(チケット)— オープンソースのカスタマーサポート管理 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースのヘルプデスク。顧客からの問い合わせ受付、スマートな振り分け、SLA 計測、優先度、AI 自動分類、満足度評価、サポート作業画面を標準装備。中小規模のカスタマーサポートチームやアフターサポート部門に適しています。"
+  keywords="ヘルプデスク, カスタマーサポート, オープンソース ヘルプデスク, help desk, ticketing, チケット管理, SLA 管理, アフターサポート, カスタマーサービス, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,336 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI駆動の<br/>インテリジェントチケット</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">ヘルプデスクモジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">ヘルプデスク(チケット)</h1>
             <p class="para-desc text-muted">
-              サポートチームが複雑なワークフローではなく、問題解決に集中できるように。NocoBaseローコードプラットフォーム上に構築し、T型データアーキテクチャで複数ビジネスを統合管理。AIエージェントチームがチケット作成からクローズまでのライフサイクル全体をサポートします。
+              NocoBase ノーコードプラットフォーム上に構築。<strong>顧客の問い合わせ → スマート振り分け → 対応 → 満足度評価</strong> までの一連の流れを網羅し、SLA 計測、優先度管理、AI 自動分類、サポート作業画面を標準搭載しています。
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">マルチソース受付</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AIスマート振り分け</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">SLA完全監視</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">ナレッジ自動蓄積</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自動計測</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 段階の優先度</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 自動分類</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">ユースケース：</span>
-                  <span class="badge bg-soft-primary me-2">設備修理</span>
-                  <span class="badge bg-soft-primary me-2">ITサポート</span>
-                  <span class="badge bg-soft-primary me-2">顧客クレーム</span>
-                  <span class="badge bg-soft-primary">お問い合わせ</span>
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">カスタマーサポート</span>
+                  <span class="badge bg-soft-primary me-2">IT サービスデスク</span>
+                  <span class="badge bg-soft-primary me-2">機器保守</span>
+                  <span class="badge bg-soft-primary">SaaS サポート</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>使い方
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha版公開中。ぜひお試しください。継続的に改善しています。
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="インテリジェントチケットシステム画面"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="ヘルプデスク(チケット)画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">このような課題はありませんか？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">企業は多様なサービスリクエストに直面し、ソースは分散、ワークフローは多様、統一管理が困難です</p>
+            <h4 class="title mb-4">チケット対応プロセス</h4>
+            <p class="para-desc mx-auto text-muted mb-0">顧客の問い合わせから完了・評価まで、SLA を全工程で計測します。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">高コスト、カスタマイズが遅い</h5>
-              </div>
-              <p class="text-muted mb-0">SaaSチケットシステムは高額。カスタム開発は長期化し、コスト予測が困難。ビジネスニーズの変化に適応しづらい。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">システム分断、データサイロ</h5>
-              </div>
-              <p class="text-muted mb-0">設備修理、ITサポート、顧客クレームが別々のシステムに分散。統一的な分析や意思決定が困難。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">対応が遅い、透明性がない</h5>
-              </div>
-              <p class="text-muted mb-0">リクエストがシステム間で非効率的に流れる。顧客は進捗を追跡できず、頻繁な問い合わせがサポートの負担に。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">品質保証が困難</h5>
-              </div>
-              <p class="text-muted mb-0">SLA監視メカニズムがない。タイムアウトやネガティブフィードバックを適時に警告できず、サービス品質にばらつき。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">ナレッジが蓄積されない</h5>
-              </div>
-              <p class="text-muted mb-0">解決策が散在。新人の立ち上がりが遅い。同じ問題を繰り返し解決し、効率が低い。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">AI機能の欠如</h5>
-              </div>
-              <p class="text-muted mb-0">従来のシステムにはAI支援がない。手動分類は時間がかかる。スマート推奨や自動返信ができない。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">私たちのソリューション</h4>
-            <p class="para-desc mx-auto text-muted mb-0">NocoBaseローコードで構築した汎用チケットプラットフォーム：統一受付、スマート配布、マルチビジネス対応、クローズドループフィードバック</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">マルチソース受付</h5>
-              <p class="text-muted mt-2">公開フォーム、顧客ポータル、メール解析、API/Webhook。全チャネルを統合し自動重複チェック</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AIスマート振り分け</h5>
-              <p class="text-muted mt-2">自動インテント認識、感情分析、緊急度評価。スキルマッチングと負荷分散でスマートに割り当て</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">SLA完全監視</h5>
-              <p class="text-muted mt-2">P0-P3の4段階優先度。応答/解決時間の自動追跡。タイムアウト警告とエスカレーション</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">クローズドループフィードバック</h5>
-              <p class="text-muted mt-2">多次元満足度評価、NPSスコア、ネガティブフィードバック警告とフォローアップで継続改善</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">コア設計</span>
-            <h4 class="title mb-4">T型データアーキテクチャ</h4>
-            <p class="para-desc mx-auto text-muted mb-0">全チケットがメインテーブルを共有し統一ワークフロー。業務固有フィールドは拡張テーブルに。新業務タイプはテーブル追加のみで対応</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>チケットメインテーブル (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">チケット# | タイトル | ステータス | 優先度 | 担当者 | SLA | AI分析</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">設備修理</strong>
-                  <div class="small text-muted mt-2">シリアル番号 | 故障コード<br/>部品リスト | 現場写真</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">ITサポート</strong>
-                  <div class="small text-muted mt-2">資産ID | OSバージョン<br/>リモートURL | エラーコード</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">顧客クレーム</strong>
-                  <div class="small text-muted mt-2">注文ID | 重要度<br/>補償方案 | 根本原因</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">その他業務...</strong>
-                  <div class="small text-muted mt-2">必要に応じて拡張<br/>コアフロー変更なし</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">統一レポート</h6>
-                  <p class="text-muted small mb-0">1つのテーブルで全チケット統計</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">ワークフロー再利用</h6>
-                  <p class="text-muted small mb-0">コアフローは1箇所で変更</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">柔軟な拡張</h6>
-                  <p class="text-muted small mb-0">新業務 = 新テーブル</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AIネイティブ</span>
-            <h4 class="title mb-4">AIエージェントチーム</h4>
-            <p class="para-desc mx-auto text-muted mb-0">「AIボタンを追加」するだけでなく、AIエージェントが全ステップに組み込まれています。各AIには明確な役割、責任、性格があります</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">サービスデスクリーダー</span>
-              <p class="text-muted mt-2 small">チケット振り分け、優先度評価、エスカレーション判断、SLAリスク特定</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">トリガー：チケット作成時に自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">カスタマーサクセス専門家</span>
-              <p class="text-muted mt-2 small">返信生成、トーン調整、クレーム対応、EQファイアウォール</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">トリガー：「AI返信」クリック時</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">ナレッジアシスタント</span>
-              <p class="text-muted mt-2 small">類似ケース、ナレッジ推奨、ソリューション統合、ナレッジ生成</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">トリガー：チケット詳細ページで自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻訳担当</span>
-              <p class="text-muted mt-2 small">多言語翻訳、品質レビュー、機密情報遮断</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">トリガー：外国語検出時に自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />GraceのEQファイアウォール</h5>
-              <p class="text-muted mb-3">サポート返信のネガティブな表現を自動検出・最適化し、二次クレームを防止</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">元の文</span>
-                    <p class="mb-0 small">「それは弊社の問題ではありません、設定ミスです」</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">最適化後</span>
-                    <p class="mb-0 small">「調査の結果、設定に問題がありました。正常に動作するよう、一緒に設定を調整させてください」</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">ナレッジ管理</span>
-            <h4 class="title mb-4">ナレッジ自己循環システム</h4>
-            <p class="para-desc mx-auto text-muted mb-0">解決済みチケットが自動的にナレッジに。類似問題にはAIがナレッジを推奨し、ナレッジ蓄積-活用のループを形成</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">チケット解決</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI価値評価</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">記事生成</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">人間レビュー</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">ナレッジベース</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">類似チケット</div>
+                  <div class="small fw-medium">作成</div>
+                  <div class="small text-muted">複数チャネル</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI推奨</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">自動分類</div>
+                  <div class="small text-muted">AI 判定</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">迅速解決</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">振り分け</div>
+                  <div class="small text-muted">ルール</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">対応</div>
+                  <div class="small text-muted">SLA 計測</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">評価</div>
+                  <div class="small opacity-75">完了・保管</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">作成</td>
+                      <td class="py-3 text-muted">メール、フォーム、IM など複数チャネルから受付。顧客と製品を関連付け</td>
+                      <td class="py-3 text-muted">チケット番号、流入元、顧客情報</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">自動分類</td>
+                      <td class="py-3 text-muted">AI が問題カテゴリ(アカウント / 機能 / バグ)を判定し、優先度を自動設定</td>
+                      <td class="py-3 text-muted">カテゴリタグ、優先度、信頼度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">振り分け</td>
+                      <td class="py-3 text-muted">ルールに従って担当チーム / 担当者へ割り当て。緊急チケットは当番に自動通知</td>
+                      <td class="py-3 text-muted">担当者、振り分け履歴、チームキュー</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">対応</td>
+                      <td class="py-3 text-muted">サポート担当が顧客とやり取り。SLA を計測し、超過前に自動警告</td>
+                      <td class="py-3 text-muted">対応ログ、SLA ステータス、待機理由</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評価</td>
+                      <td class="py-3 text-muted">完了後に顧客評価(1〜5 星 + コメント)を送信し、担当者 / 製品別に集計</td>
+                      <td class="py-3 text-muted">満足度記録、保管チケット、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">説明が完全</h6>
-                  <p class="text-muted small mb-0">説明 >= 200文字</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">十分な議論</h6>
-                  <p class="text-muted small mb-0">コメント >= 2件</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">品質基準</h6>
-                  <p class="text-muted small mb-0">AIスコア >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLAサービスレベル管理</h4>
-            <p class="para-desc mx-auto text-muted mb-0">優先度別に応答・解決時間を設定。自動監視、アラート、エスカレーション。保留中はSLAが一時停止</p>
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">受付から完了までのカスタマーサポート業務を一通りカバーします。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">優先度</th>
-                  <th class="border-0 py-3">応答時間</th>
-                  <th class="border-0 py-3">解決時間</th>
-                  <th class="border-0 py-3">典型的なシナリオ</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 緊急</span></td>
-                  <td class="py-3">15分</td>
-                  <td class="py-3">2時間</td>
-                  <td class="py-3 text-muted small">システムダウン、生産停止</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 高</span></td>
-                  <td class="py-3">1時間</td>
-                  <td class="py-3">8時間</td>
-                  <td class="py-3 text-muted small">主要機能障害、影響大</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 中</span></td>
-                  <td class="py-3">4時間</td>
-                  <td class="py-3">24時間</td>
-                  <td class="py-3 text-muted small">一般的な問題、回避策あり</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 低</span></td>
-                  <td class="py-3">8時間</td>
-                  <td class="py-3">72時間</td>
-                  <td class="py-3 text-muted small">提案、機能に関する問い合わせ</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">事前警告</h6>
-                  <p class="text-muted small mb-0">残り時間 &lt; 20%で担当者に通知</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">タイムアウト警告</h6>
-                  <p class="text-muted small mb-0">タイムアウト時に担当者+上司に通知</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">自動エスカレーション</h6>
-                  <p class="text-muted small mb-0">1時間超過後にマネージャーに通知</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 計測とアラート</h5>
+              <p class="text-muted mt-2">優先度ごとに応答 / 解決時間を自動計算。超過前にアラートを発し、超過チケットは赤色表示。SLA 達成率はダッシュボードで確認できます。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 段階の優先度</h5>
+              <p class="text-muted mt-2">緊急、高、中、低の 4 段階で異なる応答時間を設定。緊急チケットは自動で上位表示され、当番に通知されます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 自動分類</h5>
+              <p class="text-muted mt-2">新規チケットを AI が自動でカテゴリ判定(アカウント問題 / 機能相談 / バグ報告など)し、ルールに従って担当チームへ振り分けます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">待機理由の細分化</h5>
+              <p class="text-muted mt-2">「顧客回答待ち」「第三者待ち」「要件レビュー待ち」など、待機中のチケットは SLA の超過カウントから除外され、公平に運用できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">サポート作業画面</h5>
+              <p class="text-muted mt-2">サポート担当はログイン後に自分宛のチケットを即確認。期限順に並び、未着手 / 対応中 / 期限間近を 1 画面で把握できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">チケットダッシュボード</h5>
+              <p class="text-muted mt-2">本日の新規 / 完了 / 未着手 / 超過の分布を表示。担当者・顧客・製品ライン別に集計し、マネージャーが全体を俯瞰できます。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">機能拡張中</h5>
+              <p class="text-muted small mt-2 mb-0">予定:満足度評価、転送・エスカレーションフロー、定型返信テンプレート、ナレッジベース連携</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">AIがもたらす価値</h4>
-            <p class="para-desc mx-auto text-muted mb-0">人間とAIの協働、AIが人間を置き換えるのではなく。AIに反復作業を任せ、人間は価値創造に集中</p>
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">振り分け効率向上</h5>
-              <p class="text-muted small mb-0">AI自動分類で手動振り分け時間を削減</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">二次クレーム減少</h5>
-              <p class="text-muted small mb-0">EQファイアウォールが返信トーンを最適化</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">タイムアウト率低下</h5>
-              <p class="text-muted small mb-0">SLA警告で早期介入を可能に</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">初回解決率向上</h5>
-              <p class="text-muted small mb-0">ナレッジ推奨で解決を加速</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">なぜ私たちを選ぶのか？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">従来のSaaSチケットシステムやカスタム開発との比較</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">比較項目</th>
-                  <th class="border-0 py-3">SaaSチケット</th>
-                  <th class="border-0 py-3">カスタム開発</th>
-                  <th class="border-0 py-3 text-primary">NocoBaseソリューション</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">導入までの時間</td>
-                  <td class="py-3 text-muted">すぐに使える</td>
-                  <td class="py-3 text-muted">数ヶ月の開発</td>
-                  <td class="py-3 text-primary">設定ですぐに開始</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">カスタマイズ</td>
-                  <td class="py-3 text-muted">制限あり</td>
-                  <td class="py-3 text-muted">完全制御</td>
-                  <td class="py-3 text-primary">ローコードで柔軟に</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">データセキュリティ</td>
-                  <td class="py-3 text-muted">クラウドホスト</td>
-                  <td class="py-3 text-muted">セルフホスト</td>
-                  <td class="py-3 text-primary">セルフホスト、完全制御</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI統合</td>
-                  <td class="py-3 text-muted">限定的/追加費用</td>
-                  <td class="py-3 text-muted">自社開発が必要</td>
-                  <td class="py-3 text-primary">AIネイティブ、深く統合</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">拡張性</td>
-                  <td class="py-3 text-muted">機能固定</td>
-                  <td class="py-3 text-muted">コード変更が必要</td>
-                  <td class="py-3 text-primary">T型、オンデマンドで拡張</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">総コスト</td>
-                  <td class="py-3 text-muted">高いサブスク費用</td>
-                  <td class="py-3 text-muted">高い開発コスト</td>
-                  <td class="py-3 text-primary">一度購入、永続利用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">使い方</h4>
-            <p class="para-desc mx-auto text-muted mb-0">3つのステップでインテリジェントチケットシステムをデプロイ</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>NocoBaseをインストール</h5>
-                <p class="text-muted mt-2">インストールガイドに従って、NocoBaseをサーバーにデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">インストールガイド</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>ソリューションを理解</h5>
-                <p class="text-muted mt-2">ソリューション概要を読んで、機能、アーキテクチャ、ユースケースを理解</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">ソリューション概要</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>システムに復元</h5>
-                <p class="text-muted mt-2">復元チュートリアルに従って、NocoBase環境にチケットシステムをデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">復元チュートリアル</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">AIでチケット管理を再定義</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            NocoBase 2.x で構築されたAI駆動のインテリジェントチケットシステム。カスタムニーズがある方、詳細を知りたい方は、お気軽にお問い合わせください。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・販売管理・プロジェクト管理・固定資産管理・HR と連携しても利用できます。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/ja/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>お問い合わせ
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseJA>
 
 <style>
-/* チケット2.0ページスタイル */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AIアバタースタイル */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/ja/solutions/ticketing.astro
+++ b/src/pages/ja/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseJA from "../../../layouts/BaseJA.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// 交互演示データをインポート
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-ja.json";
-
-// プラグインデータを取得
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// チケットシステムで使用するプラグイン名を定義
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// 名前でプラグインデータをマッチング
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// チケットシステム関連プラグインを取得
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// デバッグ情報
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="効率的で便利なチケット管理システム"
-  description="NocoBase チケット管理システムは CRM の重要な補完として、顧客連絡先作成からチケット割り当て、処理まで、完全なチケットライフサイクル管理を提供し、全プロセスデジタル管理を実現します。"
-  keywords="NocoBase チケットシステム, チケット管理, カスタマーサービスシステム, アフターサービス, チケット割り当て"
+<BaseJA
+  title="ヘルプデスク(チケット)— オープンソースのカスタマーサポート管理 | NocoBase"
+  description="NocoBase ノーコードプラットフォームをベースにしたオープンソースのヘルプデスク。顧客からの問い合わせ受付、スマートな振り分け、SLA 計測、優先度、AI 自動分類、満足度評価、サポート作業画面を標準装備。中小規模のカスタマーサポートチームやアフターサポート部門に適しています。"
+  keywords="ヘルプデスク, カスタマーサポート, オープンソース ヘルプデスク, help desk, ticketing, チケット管理, SLA 管理, アフターサポート, カスタマーサービス, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,336 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">効率的で便利な<br/>チケット管理システム</h1>
-            <p class="para-desc text-muted">NocoBase チケット管理システムは CRM の重要な補完として、完全なチケットライフサイクル管理を提供します。顧客連絡先作成からチケット入力、割り当て、処理、追跡まで、アフターサービスの全プロセスデジタル管理を実現します。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> NocoBase 1.x で構築（2.0 開発中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ja/solutions/all-in-one" class="text-muted small text-decoration-none">一体型業務管理システム</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">ヘルプデスクモジュール</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">ヘルプデスク(チケット)</h1>
+            <p class="para-desc text-muted">
+              NocoBase ノーコードプラットフォーム上に構築。<strong>顧客の問い合わせ → スマート振り分け → 対応 → 満足度評価</strong> までの一連の流れを網羅し、SLA 計測、優先度管理、AI 自動分類、サポート作業画面を標準搭載しています。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自動計測</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 段階の優先度</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 自動分類</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">オープンソース無料</span></div></div>
             </div>
 
-            <!-- タグ -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">適用シナリオ：</span>
-                  <span class="badge bg-soft-primary me-2">カスタマーサービス</span>
-                  <span class="badge bg-soft-primary">アフターサポート</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">想定シーン:</span>
+                  <span class="badge bg-soft-primary me-2">カスタマーサポート</span>
+                  <span class="badge bg-soft-primary me-2">IT サービスデスク</span>
+                  <span class="badge bg-soft-primary me-2">機器保守</span>
+                  <span class="badge bg-soft-primary">SaaS サポート</span>
                 </div>
               </div>
             </div>
 
-            <!-- 開発者情報 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開発者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- ボタン -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>ライブデモ
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>自分の環境にコピー
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+              <a href="/ja/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>全体ソリューションを見る</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- チケットシステムプレビュー -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase チケット管理システムプレビュー" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="ヘルプデスク(チケット)画面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase チケット管理システムの機能特性</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM システムの重要な補完として、プロフェッショナルなカスタマーサービスとアフターサポート管理を提供</p>
+            <h4 class="title mb-4">チケット対応プロセス</h4>
+            <p class="para-desc mx-auto text-muted mb-0">顧客の問い合わせから完了・評価まで、SLA を全工程で計測します。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完全なチケットライフサイクル</h5>
-              <p class="text-muted mt-2">チケット作成、割り当て、処理からクローズまで、全プロセス管理により全てのチケットが適切に処理されます</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">スマート割り当てと追跡</h5>
-              <p class="text-muted mt-2">チケットタイプとチームメンバーのスキルに基づいて自動的にタスクを割り当て、処理進捗と状態をリアルタイムで追跡</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">マルチチャネルコミュニケーション記録</h5>
-              <p class="text-muted mt-2">API を通じてメール、電話、オンラインチャットなど複数のコミュニケーションチャネルを同期し、顧客とのやり取り記録を統一管理</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">オープンソース、完全なデータ制御</h5>
-              <p class="text-muted mt-2">オープンソースコード、プライベートデータデプロイメント、企業データセキュリティと自律制御を保証</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- 拡張機能インタラクティブデモを使用 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>今すぐ体験
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>自分の環境にコピー
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">チケットシステム開発チュートリアル</h4>
-            <p class="para-desc mx-auto text-muted mb-0">NocoBase を使用してプロフェッショナルなチケット管理システムをゼロから構築する方法を学習</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">データモデル設計</h5>
-                <p class="text-muted text-center">チケット、顧客、カテゴリーなどの基本的なデータ構造と関係を作成する方法を学習</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">ワークフロー設定</h5>
-                <p class="text-muted text-center">チケット割り当て、ステータス遷移、自動化処理ワークフローを設定</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">通知とリマインダー</h5>
-                <p class="text-muted text-center">メールとシステム通知を設定し、チケットの適時処理を確保</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">近日公開</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">チケットシステムで使用されている商用プラグイン紹介</h4>
-            <p class="para-desc mx-auto text-muted mb-0">商用プラグインを通じてより強力な機能を獲得し、チケットシステムの専門性と使いやすさを向上させる方法を学習</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 動的プラグインカード -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_ja || plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description_ja || plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs_ja || plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳細</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用、1年間アップグレード</span><br>
-                          <a href="/ja/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_1_year_jp || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用とアップグレード</span><br>
-                          <a class="text-muted" href="/ja/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_jp || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">作成</div>
+                  <div class="small text-muted">複数チャネル</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">自動分類</div>
+                  <div class="small text-muted">AI 判定</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">振り分け</div>
+                  <div class="small text-muted">ルール</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">対応</div>
+                  <div class="small text-muted">SLA 計測</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">評価</div>
+                  <div class="small opacity-75">完了・保管</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- レイアウト用プレースホルダーカード -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">より多くのプラグインが近日公開</h6>
-                  <p class="text-muted small">より多くの便利な商用プラグインを開発中です、お楽しみに</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">ステージ</th>
+                      <th class="border-0 py-3">主な操作</th>
+                      <th class="border-0 py-3">システム記録</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">作成</td>
+                      <td class="py-3 text-muted">メール、フォーム、IM など複数チャネルから受付。顧客と製品を関連付け</td>
+                      <td class="py-3 text-muted">チケット番号、流入元、顧客情報</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">自動分類</td>
+                      <td class="py-3 text-muted">AI が問題カテゴリ(アカウント / 機能 / バグ)を判定し、優先度を自動設定</td>
+                      <td class="py-3 text-muted">カテゴリタグ、優先度、信頼度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">振り分け</td>
+                      <td class="py-3 text-muted">ルールに従って担当チーム / 担当者へ割り当て。緊急チケットは当番に自動通知</td>
+                      <td class="py-3 text-muted">担当者、振り分け履歴、チームキュー</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">対応</td>
+                      <td class="py-3 text-muted">サポート担当が顧客とやり取り。SLA を計測し、超過前に自動警告</td>
+                      <td class="py-3 text-muted">対応ログ、SLA ステータス、待機理由</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評価</td>
+                      <td class="py-3 text-muted">完了後に顧客評価(1〜5 星 + コメント)を送信し、担当者 / 製品別に集計</td>
+                      <td class="py-3 text-muted">満足度記録、保管チケット、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ja/plugins-commercial" class="btn btn-primary me-3">すべての商用プラグインを見る</a>
-          <a href="/ja/commercial" class="btn btn-outline-primary">価格詳細を了解</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">使用方法は？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">3つのステップでチケット管理機能を含む NocoBase CRM システムを環境に迅速にデプロイ</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>NocoBase システムをインストール</h5>
-                <p class="text-muted mt-2">インストールドキュメントに従って、サーバーに NocoBase システムをデプロイ</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">インストールドキュメントを見る</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>CRM システムテンプレートファイルをダウンロード</h5>
-                <p class="text-muted mt-2">完全な CRM テンプレートをダウンロードしてチケット管理機能を獲得</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">SQL ファイルをダウンロード</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">バックアップファイルをダウンロード (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>システム内で復元</h5>
-                <p class="text-muted mt-2">CRM テンプレートファイルを NocoBase システムにインポートし、CRM とチケット管理機能の両方を同時に獲得</p>
-              </div>
-              <div class="mt-3">
-                <a href="/ja/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">復元チュートリアル</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- チケット機能説明 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">ヒント</h6>
-                <p class="mb-0 text-muted">チケット管理システムは CRM の重要な補完モジュールとして、CRM テンプレートに完全に統合されています。デプロイメント完了後、CRM システム内で完全なチケット管理機能を直接使用でき、顧客サービスの全プロセス管理を実現できます。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">拡張方法は？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">ビジネス要件に応じてチケット管理システムをさらに拡張とカスタマイズ</p>
+            <h4 class="title mb-4">主な機能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">受付から完了までのカスタマーサポート業務を一通りカバーします。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">チケットタイプと分類管理</h5>
-                  <p class="text-muted mb-3">ビジネス要件に応じて異なるチケット分類と処理ルールを作成</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">近日公開</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 計測とアラート</h5>
+              <p class="text-muted mt-2">優先度ごとに応答 / 解決時間を自動計算。超過前にアラートを発し、超過チケットは赤色表示。SLA 達成率はダッシュボードで確認できます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">チーム協業機能</h5>
-                  <p class="text-muted mb-3">チームロール、権限、協業ワークフローを設定</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">近日公開</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 段階の優先度</h5>
+              <p class="text-muted mt-2">緊急、高、中、低の 4 段階で異なる応答時間を設定。緊急チケットは自動で上位表示され、当番に通知されます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">統計レポート分析</h5>
-                  <p class="text-muted mt-2">チケット処理状況と効率分析レポートを構築</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">近日公開</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 自動分類</h5>
+              <p class="text-muted mt-2">新規チケットを AI が自動でカテゴリ判定(アカウント問題 / 機能相談 / バグ報告など)し、ルールに従って担当チームへ振り分けます。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM システム統合</h5>
-                  <p class="text-muted mb-3">既存の CRM システムとシームレスに統合し、データ共有を実現</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">近日公開</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">待機理由の細分化</h5>
+              <p class="text-muted mt-2">「顧客回答待ち」「第三者待ち」「要件レビュー待ち」など、待機中のチケットは SLA の超過カウントから除外され、公平に運用できます。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">サポート作業画面</h5>
+              <p class="text-muted mt-2">サポート担当はログイン後に自分宛のチケットを即確認。期限順に並び、未着手 / 対応中 / 期限間近を 1 画面で把握できます。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">チケットダッシュボード</h5>
+              <p class="text-muted mt-2">本日の新規 / 完了 / 未着手 / 超過の分布を表示。担当者・顧客・製品ライン別に集計し、マネージャーが全体を俯瞰できます。</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">機能拡張中</h5>
+              <p class="text-muted small mt-2 mb-0">予定:満足度評価、転送・エスカレーションフロー、定型返信テンプレート、ナレッジベース連携</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">NocoBase チケット管理システムを使用する準備はできていますか？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1分で専用チケット管理デモをデプロイ。CRM の重要な補完として、完全な顧客サービス体系を実現し、顧客満足度とサービス効率を向上させます。
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>ライブデモ
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>自分の環境にコピー
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">ダウンロードとデプロイ</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本モジュールは一体型業務管理システムのバックアップテンプレートに含まれ、まとめてデプロイされます。</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>バックアップテンプレートをダウンロード</h5>
+                <p class="text-muted mt-2">一体型ソリューションのバックアップで、復元すると本モジュールを含む 6 モジュールすべてのプリセットデータが利用できます。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>.nbdata バックアップをダウンロード</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">または SQL ZIP をダウンロード</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>インストール手順を確認</h5>
+                <p class="text-muted mt-2">復元手順、よくある質問、注意事項の詳細は現在準備中です。</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>近日公開</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">利用を開始する</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本モジュールは <a href="/ja/solutions/all-in-one">一体型業務管理システム</a> にも組み込まれており、単独でも、CRM・販売管理・プロジェクト管理・固定資産管理・HR と連携しても利用できます。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Demo を体験</a>
+            <a href="/ja/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>お問い合わせ</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseJA>
 
 <style>
-/* チケット管理システムスタイル - CRM ページスタイルを参考 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* 商用プラグインカードスタイル */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/pt/solutions/all-in-one.astro
+++ b/src/pages/pt/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BasePT from "../../../layouts/BasePT.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BasePT
+  title="Sistema de Gestão Empresarial Integrado - CRM / Tickets / Projetos / Ativos / RH | NocoBase"
+  description="Sistema de gestão empresarial integrado e open source: CRM, Gestão de Vendas, Help Desk, Gestão de Projetos, Gestão de Ativos e Recursos Humanos — 6 módulos consolidados. Construído sobre a plataforma no-code NocoBase, pronto para uso, indicado para equipes de pequeno e médio porte."
+  keywords="sistema de gestão integrado, CRM, CRM open source, sistema de tickets, help desk, sistema de gestão de projetos, gestão de ativos, gestão de ativos de TI, RH, recursos humanos, gestão de vendas, ERP no-code, sistema all-in-one, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Sistema de Gestão<br/>Empresarial Integrado</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase, abrange seis módulos: <strong>CRM (Gestão de Clientes), Gestão de Vendas, Help Desk (Tickets), Gestão de Projetos, Gestão de Ativos e Recursos Humanos</strong>.
+              Pronto para uso, sem necessidade de seleção complexa ou integração entre múltiplos sistemas.
+            </p>
+
+            <!-- Valor central -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Consolidação de múltiplos sistemas</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Mais de 20 idiomas nativos</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Funcionários de AI + workflows</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open source e gratuito</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Cenários de aplicação -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Startups</span>
+                  <span class="badge bg-soft-primary me-2">Lojas multi-operação</span>
+                  <span class="badge bg-soft-primary me-2">Fase de exploração</span>
+                  <span class="badge bg-soft-primary">Ensino e treinamento</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Experimentar Demo
+              </a>
+              <a href="/pt/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Fale Conosco
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Sistema de Gestão Empresarial Integrado" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 módulos integrados</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, Gestão de Vendas, Help Desk, Gestão de Projetos, Gestão de Ativos e Recursos Humanos — todos os processos de negócio em um único sistema</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- CRM -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Gestão de Clientes)</h5>
+              <p class="text-muted mt-2">CRM open source: fluxo completo de leads, acompanhamento, conversão e deduplicação; visão 360° do cliente agregando histórico de pedidos, tickets, projetos e ativos.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Gestão de etapas e conversão de leads</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Visão 360° do cliente</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Ferramenta de mesclagem/deduplicação</li>
+              </ul>
+              <a href="/pt/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestão de Vendas -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de Vendas</h5>
+              <p class="text-muted mt-2">Gestão de pedidos de venda: orçamento, pedido, nota fiscal e recebimento, ponta a ponta; com fluxo de aprovação e análise de contas a receber.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Orçamento em várias moedas</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Workflow de aprovação de pedidos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI de inadimplência</li>
+              </ul>
+              <a href="/pt/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Help Desk -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Tickets)</h5>
+              <p class="text-muted mt-2">Sistema de tickets de atendimento: registro do problema, distribuição, tratamento e avaliação de satisfação; com cronômetro de SLA, gestão de prioridade e detalhamento de motivos de espera.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Cronômetro automático de SLA com alerta de prazo</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Dashboard de tickets + workspace da equipe</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 níveis de prioridade + classificação por AI</li>
+              </ul>
+              <a href="/pt/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestão de Projetos -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de Projetos</h5>
+              <p class="text-muted mt-2">Sistema leve de gestão de projetos: estrutura em dois níveis (projeto e tarefa); inclui responsável, progresso, marcos e alerta de atraso.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Painel de status dos projetos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Carga de trabalho por responsável</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Alerta de projetos atrasados</li>
+              </ul>
+              <a href="/pt/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Gestão de Ativos -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de Ativos</h5>
+              <p class="text-muted mt-2">Gestão do ciclo de vida de ativos de TI e de escritório, abrangendo aquisição, alocação, manutenção e baixa, com cadastro de fornecedores.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Alocação e devolução de ativos</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Ordens de manutenção</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Análise de fornecedores</li>
+              </ul>
+              <a href="/pt/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- RH -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Recursos Humanos</h5>
+              <p class="text-muted mt-2">Sistema de RH: cadastro de funcionários, integração, desligamento, controle de férias e período de experiência, com estrutura de cargos e departamentos.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Checklist de integração / desligamento</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Aprovação de férias</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Painel de período de experiência</li>
+              </ul>
+              <a href="/pt/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Saiba mais <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Recursos da plataforma</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Baseado no NocoBase 2.x, com AI, workflows, suporte multilíngue e multi-espaço nativos</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>Funcionários de AI</h5>
+            <p class="text-muted small">Lina (localização), Lexi (tradução), Atlas (colaboração) e outros papéis de AI nativos, acionados conforme o cenário de negócio.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Suporte multilíngue</h5>
+            <p class="text-muted small">Mais de 20 idiomas nativos: chinês, inglês, japonês, coreano, alemão, francês, entre outros, com a interface totalmente traduzida.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Motor de workflows</h5>
+            <p class="text-muted small">Aprovação, notificação, cronômetro de SLA e gatilhos agendados; orquestração visual sem código.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Isolamento multi-espaço</h5>
+            <p class="text-muted small">Um único sistema atende múltiplas equipes ou lojas, com dados isolados e permissões geridas de forma independente.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">Colaboração com AI</span>
+            <h4 class="title mb-4">Funcionários de AI nativos</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 funcionários de AI pré-configurados cobrem papéis típicos de negócio, com suporte a integração de agentes externos via protocolo MCP</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Líder de equipe — distribuição de tarefas e orquestração</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Engenheiro front-end — geração de interfaces e blocos JS</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Design visual — construção de gráficos e dashboards</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Análise e insights — identificação de tendências e leitura de KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Pesquisa — coleta de informações e elaboração de resumos</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Tratamento de dados — limpeza, mesclagem e organização em lote</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Tradução e comunicação — diálogos e e-mails multilíngues</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Engenheira de localização — textos de interface e i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Assistente de e-mail — análise de intenção e rascunho de respostas</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Funcionário de AI personalizado</h6>
+              <p class="text-muted small mb-0">Crie papéis, prompts e conjuntos de habilidades sob medida</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Conexão com agentes externos</h6>
+              <p class="text-muted small mb-0">Conecte seus próprios agentes e ferramentas via protocolo MCP</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cenários de uso</h4>
+            <p class="para-desc mx-auto text-muted mb-0">A solução integrada é particularmente adequada aos seguintes cenários</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Gestão transversal de múltiplas linhas</h5>
+                  <p class="text-muted mb-0">Operações abrangem vendas, atendimento e projetos; é necessário visualizar o todo em um único sistema, evitando alternar entre várias ferramentas isoladas.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Lojas com múltiplas linhas de negócio</h5>
+                  <p class="text-muted mb-0">A loja executa vendas, pós-venda e entrega de projetos ao mesmo tempo; muitas frentes, mas em escala limitada — soluções independentes têm alto custo de coordenação.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Fase de exploração de negócio</h5>
+                  <p class="text-muted mb-0">O negócio ainda não está consolidado e é preciso evitar comprometer-se cedo demais com uma solução específica; a plataforma integrada entra em uso e evolui conforme a necessidade.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Ensino, treinamento e POC</h5>
+                  <p class="text-muted mb-0">Exemplo completo da plataforma NocoBase, indicado para treinamento interno, demonstrações ou provas de conceito, cobrindo processos típicos de negócio.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Como usar?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Três passos para implantar o Sistema de Gestão Empresarial Integrado</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Instale o NocoBase</h5>
+                <p class="text-muted mt-2">Siga a documentação oficial para implantar o NocoBase em ambiente local ou servidor</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Ver documentação</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Consulte o guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixe o modelo de backup</h5>
+                <p class="text-muted mt-2">Após a restauração, todos os dados pré-configurados dos 6 módulos ficam disponíveis</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Comece a usar o Sistema de Gestão Empresarial Integrado</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Sistema de gestão empresarial integrado, construído sobre o NocoBase 2.x. O modelo pode ser reutilizado e estendido diretamente; para personalizações específicas, entre em contato.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Experimentar Demo
+            </a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Fale Conosco
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BasePT>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/pt/solutions/asset-management.astro
+++ b/src/pages/pt/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BasePT from "../../../layouts/BasePT.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BasePT
+  title="Gestão de Ativos — sistema open source para ativos de TI e de escritório | NocoBase"
+  description="Sistema open source de gestão de ativos baseado na plataforma no-code NocoBase: ciclo de vida completo — aquisição, alocação, manutenção e baixa — para ativos de TI e de escritório, com cadastro de fornecedores, ordens de manutenção e análise de compras."
+  keywords="gestão de ativos, gestão de ativos de TI, sistema de gestão de ativos, gestão de ativos open source, gestão de ativos de escritório, sistema patrimonial, ciclo de vida do ativo, sistema de gestão de equipamentos, inventário de ativos, gestão de fornecedores, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestão de Ativos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestão de Ativos</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Ciclo de vida completo: <strong>aquisição → alocação → manutenção → baixa</strong>, abrangendo ativos de TI e de escritório, com cadastro de fornecedores e ordens de manutenção.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Ciclo de vida completo</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Ordens de manutenção</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cadastro de fornecedores</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Ativos de TI</span>
+                  <span class="badge bg-soft-primary me-2">Ativos de escritório</span>
+                  <span class="badge bg-soft-primary me-2">Locação de equipamentos</span>
+                  <span class="badge bg-soft-primary">Inventário</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Interface do sistema de gestão de ativos" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ciclo de vida do ativo</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Da entrada no estoque à baixa, com rastreabilidade item a item</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Aquisição</div>
+                  <div class="small text-muted">Vínculo a fornecedor</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Entrada</div>
+                  <div class="small text-muted">Ficha do ativo</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Alocação</div>
+                  <div class="small text-muted">Assinatura registrada</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Manutenção</div>
+                  <div class="small text-muted">Ordens de serviço</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Baixa</div>
+                  <div class="small opacity-75">Valor residual registrado</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Aquisição</td>
+                      <td class="py-3 text-muted">Ordem de compra vinculada a fornecedor e preço; suporta múltiplas categorias e quantidades</td>
+                      <td class="py-3 text-muted">Ordem de compra, fornecedor, valor da aquisição</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Entrada</td>
+                      <td class="py-3 text-muted">A entrada gera automaticamente a ficha do ativo (código, número de série, garantia em um único cadastro)</td>
+                      <td class="py-3 text-muted">Ficha do ativo, código único, prazo de garantia</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Alocação</td>
+                      <td class="py-3 text-muted">Ativo emprestado a colaborador/cliente/departamento, com confirmação assinada</td>
+                      <td class="py-3 text-muted">Registro de alocação, usuário, datas de início e fim</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Manutenção</td>
+                      <td class="py-3 text-muted">Falhas e manutenções preventivas geram ordens vinculadas à ficha do ativo</td>
+                      <td class="py-3 text-muted">Ordens de manutenção, custo acumulado</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Baixa</td>
+                      <td class="py-3 text-muted">Registro de baixa com motivo (avaria, obsolescência, venda) e depreciação/valor residual</td>
+                      <td class="py-3 text-muted">Registro de baixa, valor residual, forma de descarte</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestão completa do ativo, da aquisição à baixa</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aquisição de ativos</h5>
+              <p class="text-muted mt-2">Ordem de compra vinculada a fornecedor e preço; a entrada gera a ficha do ativo automaticamente, com código, número de série e prazo de garantia já preenchidos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Alocação e devolução</h5>
+              <p class="text-muted mt-2">Ativo emprestado a colaborador ou cliente, com assinatura registrada; a devolução libera o ativo automaticamente e o histórico de uso fica disponível para auditoria.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ordens de manutenção</h5>
+              <p class="text-muted mt-2">Falhas e manutenções preventivas geram ordens vinculadas à ficha do ativo; o custo acumulado apoia a decisão de baixa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Baixa e venda</h5>
+              <p class="text-muted mt-2">Baixa registrada com motivo (avaria, obsolescência, venda); depreciação e valor residual ficam arquivados, alinhados ao financeiro.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cadastro de fornecedores</h5>
+              <p class="text-muted mt-2">Ficha do fornecedor + histórico de compras; valor, categorias e condições de pagamento em uma visão única, apoiando decisões de compra.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Painel de ativos</h5>
+              <p class="text-muted mt-2">Total de ativos, em uso, em manutenção e baixados; agregação por tipo, departamento e usuário, com exportação dos dados de inventário.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Mais funcionalidades em desenvolvimento</h5>
+              <p class="text-muted small mt-2 mb-0">Planejado: tarefas de inventário, cálculo de depreciação automático, leitura de QR Code, fluxo de aprovação de empréstimo de ativos</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Gestão de Vendas, Help Desk, Gestão de Projetos e RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BasePT>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/pt/solutions/crm-v2.astro
+++ b/src/pages/pt/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BasePT from "../../../layouts/BasePT.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 Sales Management System - NocoBase"
-  description="CRM 2.0 sales management system built on NocoBase no-code platform. Modular design with complete sales cycle. Supports AI-assisted lead scoring, opportunity win-rate prediction, and more."
-  keywords="NocoBase CRM, AI CRM, sales management, opportunity management, customer relationship management, lead management, no-code CRM"
+<BasePT
+  title="CRM (Gestão de Clientes) — open source e auto-hospedável | NocoBase"
+  description="CRM open source baseado na plataforma no-code NocoBase: gestão de leads, acompanhamento de clientes, conversão, mesclagem/deduplicação e visão 360° do cliente. Pronto para uso, com suporte a auto-hospedagem."
+  keywords="CRM, CRM open source, sistema de gestão de clientes, gestão de relacionamento com cliente, gestão de leads, acompanhamento de clientes, visão 360, CRM no-code, CRM auto-hospedado, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sales Management System</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestão de Clientes</h1>
             <p class="para-desc text-muted">
-              Built on NocoBase no-code platform. Modular design with complete sales cycle. Workflow automation handles routine tasks, AI assists with lead scoring, opportunity analysis, and more.
+              Construído sobre a plataforma no-code NocoBase. Cobre o fluxo completo de leads, acompanhamento, conversão e mesclagem/deduplicação; a visão 360° do cliente agrega histórico de pedidos, tickets, projetos e ativos.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Smart Lead Scoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Win-Rate Prediction</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Customer Health Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Modular Design</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestão de etapas de leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Visão 360° do cliente</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mesclagem / deduplicação</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">B2B Sales</span>
-                  <span class="badge bg-soft-primary me-2">Project Sales</span>
-                  <span class="badge bg-soft-primary me-2">Foreign Trade</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Vendas B2B</span>
+                  <span class="badge bg-soft-primary me-2">Vendas por projeto</span>
+                  <span class="badge bg-soft-primary me-2">Comércio exterior</span>
+                  <span class="badge bg-soft-primary">Equipes de pequeno e médio porte</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Sales teams face multiple challenges in daily operations</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interface do sistema de CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inconsistent Lead Quality</h5>
-              </div>
-              <p class="text-muted mb-0">Large volumes of leads with varying quality. Sales waste time on low-quality leads while high-value ones get overlooked.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Delayed Opportunity Follow-up</h5>
-              </div>
-              <p class="text-muted mb-0">Opportunities stall without progress. Sales managers struggle to track team pipeline health, missing optimal closing windows.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Scattered Customer Data</h5>
-              </div>
-              <p class="text-muted mb-0">Customer data scattered across emails, chats, and documents. No complete customer profile for targeted marketing.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inaccurate Sales Forecasts</h5>
-              </div>
-              <p class="text-muted mb-0">Forecasting based on gut feeling without data support. Large prediction gaps affect resource allocation and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High SaaS Costs</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot and other SaaS CRMs charge per seat. Custom development takes long with unpredictable costs.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Data Security Concerns</h5>
-              </div>
-              <p class="text-muted mb-0">Customer and opportunity data stored on third-party clouds, not meeting data localization and privacy compliance requirements.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 system built on NocoBase no-code platform. Workflow automation + AI assistance</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Smart Lead Scoring</h5>
-              <p class="text-muted mt-2">Auto-evaluate lead quality, prioritize high-value leads, recommend optimal contact times</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Win-Rate Prediction</h5>
-              <p class="text-muted mt-2">Predict close probability based on historical data, identify at-risk deals, provide stage progression suggestions</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Customer Health Monitoring</h5>
-              <p class="text-muted mt-2">360-degree customer profile, health scoring, churn risk alerts, proactive relationship maintenance</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Modular Design</h5>
-              <p class="text-muted mt-2">Independent module design, minimal setup requires only Customers + Opportunities, scale as needed</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">Complete Sales Cycle</h4>
-            <p class="para-desc mx-auto text-muted mb-0">From lead acquisition to customer success, unified data flow with AI assistance at every stage</p>
+            <h4 class="title mb-4">Fluxo de gestão de clientes</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Do registro do lead à visão 360°, com dados integrados de ponta a ponta</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Múltiplos canais</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Acompanhamento</div>
+                  <div class="small text-muted">Histórico registrado</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversão</div>
+                  <div class="small text-muted">Cadastro do cliente</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Visão 360°</div>
+                  <div class="small text-muted">Histórico consolidado</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Análise</div>
+                  <div class="small opacity-75">Painel de vendas</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Stage Conversion</th>
-                      <th class="border-0 py-3">Trigger</th>
-                      <th class="border-0 py-3">AI Assistance</th>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Customer</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulário, importação ou cadastro manual, com origem e responsável de vendas</td>
+                      <td class="py-3 text-muted">Pool de leads, etiquetas de origem, fluxo de etapas</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Customer → Opportunity</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">AI analyzes intent, recommends creating opportunity</td>
+                      <td class="py-3">Acompanhamento</td>
+                      <td class="py-3 text-muted">Telefone, e-mail, visita registrados, com data do próximo contato</td>
+                      <td class="py-3 text-muted">Linha do tempo de contatos, lembrete da próxima ação</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Opportunity → Quote</td>
-                      <td class="py-3 text-muted">Enters proposal stage</td>
-                      <td class="py-3 text-primary">AI pricing suggestions, competitor comparison, tiered pricing</td>
+                      <td class="py-3">Conversão</td>
+                      <td class="py-3 text-muted">Lead vira cliente; preenchimento do cadastro (setor, porte, contatos)</td>
+                      <td class="py-3 text-muted">Tabela de clientes, contatos, ligação com o lead</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Quote → Order</td>
-                      <td class="py-3 text-muted">Customer accepts quote</td>
-                      <td class="py-3 text-primary">Auto-generate order with product details and pricing</td>
+                      <td class="py-3">Visão 360°</td>
+                      <td class="py-3 text-muted">Visualização completa do cliente: pedidos, tickets, projetos, ativos</td>
+                      <td class="py-3 text-muted">Blocos embutidos e ligações entre módulos</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Análise</td>
+                      <td class="py-3 text-muted">Painel de vendas com KPI por vendedor, região e tipo</td>
+                      <td class="py-3 text-muted">Gráficos, detalhamento e exportação</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Assistance</span>
-            <h4 class="title mb-4">AI Assistance Capabilities</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Through workflow AI nodes, assist with scoring, analysis, writing, and other repetitive tasks</p>
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clientes, acompanhamentos e painéis — cobertura completa da rotina de CRM</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Workflow Node</span></h5>
-              <span class="badge bg-soft-primary mb-2">Sales Scout</span>
-              <p class="text-muted mt-2 small">Deep opportunity analysis, win-rate prediction, competitive intelligence, deal strategy suggestions</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Importação de leads</h5>
+              <p class="text-muted mt-2">Três caminhos: importação em lote via Excel, coleta por formulário e integração via API; mapeamento de campos visual e deduplicação automática em caso de conflito.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Insights Analyst</span>
-              <p class="text-muted mt-2 small">Smart lead scoring, customer health assessment, sales data analysis, pipeline forecasting</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fluxo de etapas</h5>
+              <p class="text-muted mt-2">Configuração visual das etapas do lead (novo, contatado, convertido, descartado); mudanças ficam registradas e a taxa de conversão é calculada automaticamente.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Editor Assistant</span>
-              <p class="text-muted mt-2 small">Email sentiment/intent analysis, reply drafting, communication summary</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de acompanhamento</h5>
+              <p class="text-muted mt-2">Cada visita, ligação ou e-mail fica registrado; a linha do tempo mostra todo o histórico de comunicação, facilitando a transferência de contas.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Daily Planning</span>
-              <p class="text-muted mt-2 small">Daily priorities, next action suggestions, follow-up planning</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lembrete de acompanhamento</h5>
+              <p class="text-muted mt-2">Notificação automática antes do próximo contato; clientes há muito tempo sem interação entram no painel "a reativar", evitando esquecimento.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language customer communication, content translation, foreign trade email handling</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Visão 360° do cliente</h5>
+              <p class="text-muted mt-2">Os detalhes do cliente agregam pedidos, tickets, projetos e ativos; visão completa em uma única tela, sem precisar alternar entre sistemas.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">More AI Employees</h5>
-              <span class="badge bg-soft-secondary mb-2">Expanding</span>
-              <p class="text-muted mt-2 small">More specialized AI employees can be added based on business needs</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Categorias e etiquetas</h5>
+              <p class="text-muted mt-2">Etiquetas multidimensionais por tipo, setor, porte e origem; filtragem e análise agregada por etiqueta.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Flexible Architecture</span>
-            <h4 class="title mb-4">Modular Design</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Each module designed independently, can be toggled on/off. Scale your solution to fit your needs</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Module</th>
-                  <th class="border-0 py-3">Required</th>
-                  <th class="border-0 py-3">Description</th>
-                  <th class="border-0 py-3">AI Capabilities</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Customer Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Opportunity Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Lead Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Quote Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Order Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Product Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Email Integration</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Full Suite</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Standard</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Lite</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Trade</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mesclagem e deduplicação</h5>
+              <p class="text-muted mt-2">O mesmo cliente cadastrado várias vezes é identificado automaticamente; com um clique, históricos e registros relacionados são mesclados sem perda.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Painel de vendas</h5>
+              <p class="text-muted mt-2">KPIs agregados por vendedor, região e tipo de cliente; novos clientes, taxa de conversão e distribuição de clientes ativos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissão por campo e por linha</h5>
+              <p class="text-muted mt-2">Campos visíveis configurados por papel; o vendedor enxerga apenas seus clientes, gestores visualizam tudo.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value from Automation</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Workflow automation + AI assistance reduces repetitive work, letting sales focus on customer relationships</p>
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS CRM and custom development</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimension</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">Custom Dev</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of box</td>
-                  <td class="py-3 text-muted">Months of development</td>
-                  <td class="py-3 text-primary">Configure and go, quick launch</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexible customization</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Assistance</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">Workflow AI nodes, use as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Module Flexibility</td>
-                  <td class="py-3 text-muted">Bundled features</td>
-                  <td class="py-3 text-muted">Code changes needed</td>
-                  <td class="py-3 text-primary">Modular, scale as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">Per-seat subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">One-time purchase, long-term use</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy CRM 2.0 system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/pt/solution/crm/" target="_blank" class="btn btn-outline-primary">Solution Docs</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/pt/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Restore Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com Gestão de Vendas, Help Desk, Gestão de Projetos, Gestão de Ativos e RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/pt/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BasePT>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/pt/solutions/crm.astro
+++ b/src/pages/pt/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BasePT from "../../../layouts/BasePT.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="Plataforma de CRM No-Code, Flexivel e Poderosa"
-  description="Pronta para uso desde o inicio, com personalizacao avancada e total soberania sobre os dados. Amplie campos, blocos, funcoes e paginas para adaptar o CRM ao seu negocio."
-  keywords="NocoBase CRM, CRM no-code, CRM de codigo aberto, CRM personalizado, gestao de relacionamento com clientes"
+<BasePT
+  title="CRM (Gestão de Clientes) — open source e auto-hospedável | NocoBase"
+  description="CRM open source baseado na plataforma no-code NocoBase: gestão de leads, acompanhamento de clientes, conversão, mesclagem/deduplicação e visão 360° do cliente. Pronto para uso, com suporte a auto-hospedagem."
+  keywords="CRM, CRM open source, sistema de gestão de clientes, gestão de relacionamento com cliente, gestão de leads, acompanhamento de clientes, visão 360, CRM no-code, CRM auto-hospedado, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Plataforma de CRM<br/>No-Code, Flexivel e Poderosa</h1>
-            <p class="para-desc text-muted">Pronta para uso, com capacidade real de personalizacao para atender ao seu cenario. Amplie campos, blocos e paginas para criar a solucao ideal para o seu negocio, mantendo controle total sobre os seus dados.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Desenvolvido com NocoBase 1.x (2.0 em desenvolvimento)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Gestão de Clientes</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Cobre o fluxo completo de leads, acompanhamento, conversão e mesclagem/deduplicação; a visão 360° do cliente agrega histórico de pedidos, tickets, projetos e ativos.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gestão de etapas de leads</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Visão 360° do cliente</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mesclagem / deduplicação</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Setores:</span>
-                  <span class="badge bg-soft-primary">Todos os setores</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Vendas B2B</span>
+                  <span class="badge bg-soft-primary me-2">Vendas por projeto</span>
+                  <span class="badge bg-soft-primary me-2">Comércio exterior</span>
+                  <span class="badge bg-soft-primary">Equipes de pequeno e médio porte</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Desenvolvedor:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo ao vivo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Implantar no seu ambiente
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Interface do sistema de CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">O Que Torna o NocoBase CRM Diferente</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Ao contrario de produtos SaaS e de CRMs fechados, o NocoBase CRM e flexivel e fica totalmente sob seu controle</p>
+            <h4 class="title mb-4">Fluxo de gestão de clientes</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Do registro do lead à visão 360°, com dados integrados de ponta a ponta</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Totalmente No-Code</h5>
-              <p class="text-muted mt-2">Nao exige conhecimento de programacao para personalizar o CRM</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Cobre os Principais Recursos de CRM</h5>
-              <p class="text-muted mt-2">Gestao de clientes, funil de vendas, acompanhamento de oportunidades, contatos, comunicacao por e-mail, aprovacoes e muito mais</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Facil de Adaptar e Expandir</h5>
-              <p class="text-muted mt-2">Suporta campos personalizados, processos e regras de negocio; a arquitetura flexivel facilita evolucoes adicionais</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Codigo Aberto e Controle Total dos Dados</h5>
-              <p class="text-muted mt-2">Controle completo sobre o codigo e os dados, com mais seguranca e autonomia para a empresa</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Experimente os Recursos do NocoBase CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Explore rapidamente com apenas alguns cliques</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Visualizacao de Dados no Dashboard</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Demo interativa
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Múltiplos canais</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Acompanhamento</div>
+                  <div class="small text-muted">Histórico registrado</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Conversão</div>
+                  <div class="small text-muted">Cadastro do cliente</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Visão 360°</div>
+                  <div class="small text-muted">Histórico consolidado</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Análise</div>
+                  <div class="small opacity-75">Painel de vendas</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Processo de Conversao de Leads</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Demo interativa
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/pt/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/pt/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Formulário, importação ou cadastro manual, com origem e responsável de vendas</td>
+                      <td class="py-3 text-muted">Pool de leads, etiquetas de origem, fluxo de etapas</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Acompanhamento</td>
+                      <td class="py-3 text-muted">Telefone, e-mail, visita registrados, com data do próximo contato</td>
+                      <td class="py-3 text-muted">Linha do tempo de contatos, lembrete da próxima ação</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Conversão</td>
+                      <td class="py-3 text-muted">Lead vira cliente; preenchimento do cadastro (setor, porte, contatos)</td>
+                      <td class="py-3 text-muted">Tabela de clientes, contatos, ligação com o lead</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Visão 360°</td>
+                      <td class="py-3 text-muted">Visualização completa do cliente: pedidos, tickets, projetos, ativos</td>
+                      <td class="py-3 text-muted">Blocos embutidos e ligações entre módulos</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Análise</td>
+                      <td class="py-3 text-muted">Painel de vendas com KPI por vendedor, região e tipo</td>
+                      <td class="py-3 text-muted">Gráficos, detalhamento e exportação</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/pt/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/pt/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Leads, clientes, acompanhamentos e painéis — cobertura completa da rotina de CRM</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Importação de leads</h5>
+              <p class="text-muted mt-2">Três caminhos: importação em lote via Excel, coleta por formulário e integração via API; mapeamento de campos visual e deduplicação automática em caso de conflito.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Fluxo de etapas</h5>
+              <p class="text-muted mt-2">Configuração visual das etapas do lead (novo, contatado, convertido, descartado); mudanças ficam registradas e a taxa de conversão é calculada automaticamente.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/pt/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de acompanhamento</h5>
+              <p class="text-muted mt-2">Cada visita, ligação ou e-mail fica registrado; a linha do tempo mostra todo o histórico de comunicação, facilitando a transferência de contas.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Lembrete de acompanhamento</h5>
+              <p class="text-muted mt-2">Notificação automática antes do próximo contato; clientes há muito tempo sem interação entram no painel "a reativar", evitando esquecimento.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Visão 360° do cliente</h5>
+              <p class="text-muted mt-2">Os detalhes do cliente agregam pedidos, tickets, projetos e ativos; visão completa em uma única tela, sem precisar alternar entre sistemas.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Categorias e etiquetas</h5>
+              <p class="text-muted mt-2">Etiquetas multidimensionais por tipo, setor, porte e origem; filtragem e análise agregada por etiqueta.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mesclagem e deduplicação</h5>
+              <p class="text-muted mt-2">O mesmo cliente cadastrado várias vezes é identificado automaticamente; com um clique, históricos e registros relacionados são mesclados sem perda.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Painel de vendas</h5>
+              <p class="text-muted mt-2">KPIs agregados por vendedor, região e tipo de cliente; novos clientes, taxa de conversão e distribuição de clientes ativos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissão por campo e por linha</h5>
+              <p class="text-muted mt-2">Campos visíveis configurados por papel; o vendedor enxerga apenas seus clientes, gestores visualizam tudo.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com Gestão de Vendas, Help Desk, Gestão de Projetos, Gestão de Ativos e RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BasePT>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/pt/solutions/hr-management.astro
+++ b/src/pages/pt/solutions/hr-management.astro
@@ -1,0 +1,350 @@
+---
+import BasePT from "../../../layouts/BasePT.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BasePT
+  title="Recursos Humanos — sistema open source de RH | NocoBase"
+  description="Sistema open source de RH baseado na plataforma no-code NocoBase: cadastro de funcionários, integração, desligamento, controle de férias, período de experiência, cargos e estrutura departamental. Leve e auto-hospedável, indicado para equipes de RH de pequeno e médio porte."
+  keywords="sistema de RH, recursos humanos, RH open source, sistema de gestão de funcionários, gestão de admissão, gestão de desligamento, aprovação de férias, período de experiência, estrutura organizacional, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Recursos Humanos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Recursos Humanos</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Cadastro de funcionários e acompanhamento de <strong>admissão, desligamento, férias e período de experiência</strong>, com estrutura de cargos e departamentos.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Checklist de admissão / desligamento</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Aprovação de férias</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Painel de período de experiência</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Pequenas e médias empresas</span>
+                  <span class="badge bg-soft-primary me-2">Redes de lojas</span>
+                  <span class="badge bg-soft-primary me-2">RH setorial</span>
+                  <span class="badge bg-soft-primary">Colaboração entre departamentos</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Interface do sistema de RH" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ciclo de vida do colaborador</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Da seleção ao desligamento, com gestão de RH ponta a ponta</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Recrutamento</div>
+                  <div class="small text-muted">Candidatos</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Admissão</div>
+                  <div class="small text-muted">Checklist</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Gestão em atividade</div>
+                  <div class="small text-muted">Frequência e férias</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Avaliação</div>
+                  <div class="small text-muted">Efetivação / mudança de cargo</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Desligamento</div>
+                  <div class="small opacity-75">Transição e arquivamento</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Recrutamento</td>
+                      <td class="py-3 text-muted">Cadastro de candidatos e avaliação de entrevistas; aprovados viram funcionários</td>
+                      <td class="py-3 text-muted">Tabela de candidatos, notas de entrevista</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Admissão</td>
+                      <td class="py-3 text-muted">Checklist de admissão (contrato, crachá, equipamento, contas)</td>
+                      <td class="py-3 text-muted">Checklist de admissão, arquivo do contrato</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Gestão em atividade</td>
+                      <td class="py-3 text-muted">Rotina de frequência, férias, banco de horas e horas extras</td>
+                      <td class="py-3 text-muted">Registros de férias, saldo disponível</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Avaliação</td>
+                      <td class="py-3 text-muted">Avaliação do período de experiência, efetivação, mudança de cargo e promoção</td>
+                      <td class="py-3 text-muted">Formulário de avaliação, alteração de cargo</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Desligamento</td>
+                      <td class="py-3 text-muted">Checklist de desligamento: transição, devolução de ativos, encerramento de contas, formalidades</td>
+                      <td class="py-3 text-muted">Registro do desligamento, liberação de ativos</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Gestão completa de RH, da admissão ao desligamento</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de funcionários</h5>
+              <p class="text-muted mt-2">Perfil de funcionários com número, data de admissão, cargo, departamento — registros unificados, busca multidimensional.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ciclo de vida do funcionário</h5>
+              <p class="text-muted mt-2">Pré-onboarding → período de experiência → ativo → offboarding → inativo: 5 status percorrendo o registro do funcionário; filtre por status num relance.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Estrutura departamental</h5>
+              <p class="text-muted mt-2">Organograma em árvore: departamento → subdepartamento, baseado no plugin nativo departments do NocoBase, vinculado a permissões.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Catálogo de cargos</h5>
+              <p class="text-muted mt-2">Definições de cargos com nível (júnior / pleno / sênior / especialista); funcionários vinculados a cargos para gestão de carreira e permissões.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Aprovação de licenças</h5>
+              <p class="text-muted mt-2">8 tipos de licença (anual / atestado / pessoal / banco de horas / casamento / parental / luto / outro); fluxo de aprovação configurável por departamento / supervisor direto.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Permissões de campo</h5>
+              <p class="text-muted mt-2">RH vê campos salariais; gestores veem informações básicas do time — configuração flexível via permissões de função do NocoBase.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Mais funcionalidades em desenvolvimento</h5>
+              <p class="text-muted small mt-2 mb-0">Planejado: checklists de admissão/desligamento, avaliação de período de experiência, gestão de contratos e previdência social, candidatos de recrutamento, registros de transferência/promoção</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Gestão de Vendas, Help Desk, Gestão de Projetos e Gestão de Ativos.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BasePT>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/pt/solutions/project-management.astro
+++ b/src/pages/pt/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BasePT from "../../../layouts/BasePT.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BasePT
+  title="Gestão de Projetos — sistema open source de colaboração leve | NocoBase"
+  description="Sistema de gestão de projetos open source baseado na plataforma no-code NocoBase: dois níveis (projetos e tarefas), responsáveis, progresso, marcos, alerta de atraso e distribuição da carga de trabalho. Leve e auto-hospedável, indicado para equipes de pequeno e médio porte e colaboração entre departamentos."
+  keywords="sistema de gestão de projetos, software de gestão de projetos, gestão de tarefas, gestão de projetos open source, gestão de projetos leve, colaboração em projetos, acompanhamento de projetos, gestão de marcos, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,337 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestão de Projetos</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestão de Projetos</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Estrutura em dois níveis: <strong>projeto + tarefa</strong>, com responsáveis, progresso, marcos, alerta de atraso e distribuição de carga de trabalho. Leve e auto-hospedável.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Dois níveis: projeto + tarefa</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Alerta de atraso</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Controle de marcos</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Projetos de entrega</span>
+                  <span class="badge bg-soft-primary me-2">TI interna</span>
+                  <span class="badge bg-soft-primary me-2">Colaboração entre departamentos</span>
+                  <span class="badge bg-soft-primary">Equipes de pequeno e médio porte</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Interface do sistema de gestão de projetos" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ciclo do projeto</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Da abertura ao encerramento, com marcos e alerta de atraso automáticos</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Abertura</div>
+                  <div class="small text-muted">Vínculo com cliente</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Decomposição</div>
+                  <div class="small text-muted">Responsáveis</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Acompanhamento</div>
+                  <div class="small text-muted">Alerta de atraso</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Marcos</div>
+                  <div class="small text-muted">Entrega por fase</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Encerramento</div>
+                  <div class="small opacity-75">Retrospectiva e arquivo</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Abertura</td>
+                      <td class="py-3 text-muted">Criar o projeto, vincular cliente (projeto de entrega) ou ativo (projeto de TI) e definir o gestor</td>
+                      <td class="py-3 text-muted">Cadastro do projeto, vínculo com cliente, responsável</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Decomposição</td>
+                      <td class="py-3 text-muted">Quebrar em tarefas, com responsáveis, datas de início/fim e dependências</td>
+                      <td class="py-3 text-muted">Tabela de tarefas, responsáveis, grafo de dependências</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Acompanhamento</td>
+                      <td class="py-3 text-muted">Os membros atualizam o progresso; tarefas atrasadas ficam destacadas em vermelho</td>
+                      <td class="py-3 text-muted">Percentual de conclusão, marcação de atraso</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Marcos</td>
+                      <td class="py-3 text-muted">Pontos críticos definidos como marcos (revisão, beta, go-live); registro de entregáveis</td>
+                      <td class="py-3 text-muted">Lista de marcos, anexos de entregáveis</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Encerramento</td>
+                      <td class="py-3 text-muted">Projeto concluído e arquivado, com registro de horas e custos</td>
+                      <td class="py-3 text-muted">Relatório de encerramento, resumo de horas</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Acompanhamento leve do projeto, da abertura ao encerramento</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/pt/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/pt/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Projeto + tarefa em dois níveis</h5>
+              <p class="text-muted mt-2">Cada projeto é dividido em várias tarefas, cada uma com responsável, datas e progresso próprios; o painel do projeto consolida o status de todas elas.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/pt/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/pt/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de marcos</h5>
+              <p class="text-muted mt-2">Pontos críticos definidos como marcos (revisão de protótipo, beta, go-live); o progresso é apresentado seguindo essa cadência.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Alerta de atraso</h5>
+              <p class="text-muted mt-2">Tarefas que passam do prazo ficam em vermelho automaticamente; a lista de projetos atrasados é atualizada em tempo real, expondo os riscos.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Responsável e carga de trabalho</h5>
+              <p class="text-muted mt-2">Tarefas e carga agregadas por responsável; o gestor enxerga quem está sobrecarregado, quem está ocioso e quem mais atrasa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Painel de status</h5>
+              <p class="text-muted mt-2">KPIs agregados por tipo de projeto, status e responsável; em andamento, encerrados e atrasados ficam separados na visualização.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vínculo com clientes e ativos</h5>
+              <p class="text-muted mt-2">O projeto pode ser ligado a clientes (entrega) ou ativos (TI); no detalhe do cliente é possível ver o histórico de projetos relacionados.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Mais funcionalidades em desenvolvimento</h5>
+              <p class="text-muted small mt-2 mb-0">Planejado: grafo de dependências de tarefas, registro de horas e custos, arquivo de entregáveis, visão Gantt</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/pt/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Gestão de Vendas, Help Desk, Gestão de Ativos e RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BasePT>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/pt/solutions/project-management.astro
+++ b/src/pages/pt/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Marcos</div>
                   <div class="small text-muted">Entrega por fase</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Gestão de marcos</h5>
               <p class="text-muted mt-2">Pontos críticos definidos como marcos (revisão de protótipo, beta, go-live); o progresso é apresentado seguindo essa cadência.</p>

--- a/src/pages/pt/solutions/sales-management.astro
+++ b/src/pages/pt/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BasePT from "../../../layouts/BasePT.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BasePT
+  title="Gestão de Vendas — sistema open source de pedidos e contas a receber | NocoBase"
+  description="Sistema de gestão de vendas open source baseado na plataforma no-code NocoBase: orçamentos, pedidos de venda, notas fiscais e recebimentos de ponta a ponta, com workflow de aprovação, múltiplas moedas, KPIs de contas a receber e análise de inadimplência."
+  keywords="sistema de gestão de vendas, gestão de pedidos de venda, orçamento, gestão de notas fiscais, contas a receber, gestão de recebimentos, fluxo de vendas, aprovação de vendas, gestão de vendas open source, orçamento multimoeda, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Gestão de Vendas</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Gestão de Vendas</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Fluxo completo: <strong>orçamento → pedido → nota fiscal → recebimento</strong>, com workflow de aprovação de vendas, orçamento em múltiplas moedas, KPIs de contas a receber e análise de inadimplência.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Orçamento multimoeda</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Workflow de aprovação de pedidos</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI de contas a receber</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Vendas B2B</span>
+                  <span class="badge bg-soft-primary me-2">Pedidos de comércio exterior</span>
+                  <span class="badge bg-soft-primary me-2">Venda de equipamentos</span>
+                  <span class="badge bg-soft-primary">Contas a receber</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Interface do sistema de gestão de vendas" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Fluxo de vendas</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Do orçamento ao recebimento, com aprovações e KPIs de contas a receber integrados</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Orçamento</div>
+                  <div class="small text-muted">Multimoeda</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Pedido</div>
+                  <div class="small text-muted">Workflow de aprovação</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Expedição</div>
+                  <div class="small text-muted">Rastreamento logístico</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Nota fiscal</div>
+                  <div class="small text-muted">Preenchimento automático</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Recebimento</div>
+                  <div class="small opacity-75">KPI de recebíveis</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Orçamento</td>
+                      <td class="py-3 text-muted">Seleção de cliente/produto, geração de orçamento multimoeda com descontos, impostos e validade</td>
+                      <td class="py-3 text-muted">Orçamento, itens de produto, exportação em PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Pedido</td>
+                      <td class="py-3 text-muted">Conversão do orçamento em pedido; descontos acima do limite e valores altos disparam aprovação</td>
+                      <td class="py-3 text-muted">Pedido de venda, workflow de aprovação, itens</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Expedição</td>
+                      <td class="py-3 text-muted">Após a confirmação do pedido, é registrada a guia de remessa com o número de rastreio</td>
+                      <td class="py-3 text-muted">Guia de remessa, código de rastreio, status</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Nota fiscal</td>
+                      <td class="py-3 text-muted">Emissão a partir do pedido ou da remessa; CNPJ e endereço do cliente preenchidos automaticamente</td>
+                      <td class="py-3 text-muted">Registro de notas fiscais, status de emissão</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Recebimento</td>
+                      <td class="py-3 text-muted">Lançamento de recebimentos parciais; KPI de contas a receber por aging</td>
+                      <td class="py-3 text-muted">Recebimentos, saldo a receber, faixas de aging</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Orçamento, pedido, nota fiscal e recebimento de ponta a ponta, com aprovações e análise de recebíveis</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de orçamentos</h5>
+              <p class="text-muted mt-2">Orçamento em múltiplas moedas, com descontos, impostos e validade; exportação em PDF com um clique e conversão direta em pedido de venda.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Pedido de venda</h5>
+              <p class="text-muted mt-2">Fluxo de status do pedido (rascunho, em aprovação, confirmado, enviado, encerrado), vínculo a cliente e produto, e itens editáveis por linha.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workflow de aprovação</h5>
+              <p class="text-muted mt-2">Descontos acima do limite, pedidos de alto valor e cláusulas especiais disparam aprovação; nós configuráveis por departamento, cargo e faixa de valor.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gestão de notas fiscais</h5>
+              <p class="text-muted mt-2">Geração de notas a partir do pedido, com controle de emissão; CNPJ, endereço e observações do cliente são preenchidos automaticamente, reduzindo erros.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Registro de recebimentos</h5>
+              <p class="text-muted mt-2">Recebimentos parciais e em parcelas; cálculo automático do saldo a receber e consolidação do status por cliente e por pedido.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI de contas a receber</h5>
+              <p class="text-muted mt-2">Lista de inadimplência e aging (faixas de 30/60/90 dias); agregação por cliente e por vendedor, facilitando a cobrança.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Multimoeda e câmbio</h5>
+              <p class="text-muted mt-2">Orçamentos e pedidos em USD, EUR, BRL e outras moedas; tabela de câmbio mantida manualmente ou por importação; consolidação automática na moeda local.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Expedição e logística</h5>
+              <p class="text-muted mt-2">Guia de remessa vinculada ao pedido e ao código de rastreio; suporte a remessas múltiplas ou parciais; o status do pedido é sincronizado automaticamente.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Painel de vendas</h5>
+              <p class="text-muted mt-2">Faturamento, quantidade de pedidos e taxa de recebimento agregados por vendedor, região e produto; tendência mensal e trimestral em uma única visão.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Help Desk, Gestão de Projetos, Gestão de Ativos e RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BasePT>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/pt/solutions/sales-management.astro
+++ b/src/pages/pt/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI de contas a receber</h5>
-              <p class="text-muted mt-2">Lista de inadimplência e aging (faixas de 30/60/90 dias); agregação por cliente e por vendedor, facilitando a cobrança.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multimoeda e câmbio</h5>
-              <p class="text-muted mt-2">Orçamentos e pedidos em USD, EUR, BRL e outras moedas; tabela de câmbio mantida manualmente ou por importação; consolidação automática na moeda local.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Expedição e logística</h5>
-              <p class="text-muted mt-2">Guia de remessa vinculada ao pedido e ao código de rastreio; suporte a remessas múltiplas ou parciais; o status do pedido é sincronizado automaticamente.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Painel de vendas</h5>

--- a/src/pages/pt/solutions/ticketing-v2.astro
+++ b/src/pages/pt/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BasePT from "../../../layouts/BasePT.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI-Powered Intelligent Ticketing System - NocoBase"
-  description="NocoBase AI-powered intelligent ticketing system with T-shaped data architecture supporting multiple business scenarios. AI employee team for auto-classification, smart replies, and knowledge recommendations. Full SLA monitoring for complete ticket lifecycle management."
-  keywords="NocoBase ticketing system, AI ticketing, intelligent customer service, SLA management, knowledge base, ticket classification"
+<BasePT
+  title="Help Desk (Tickets) — sistema open source de atendimento ao cliente | NocoBase"
+  description="Sistema de tickets open source baseado na plataforma no-code NocoBase: registro de problemas, distribuição inteligente, cronômetro de SLA, prioridade, classificação por AI, avaliação de satisfação e workspace de atendimento. Pronto para uso, indicado para equipes de pequeno e médio porte."
+  keywords="sistema de tickets, help desk, sistema de chamados, ticketing open source, gestão de SLA, sistema de pós-venda, sistema de atendimento ao cliente, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,337 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI-Powered<br/>Intelligent Ticketing</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
             <p class="para-desc text-muted">
-              Let support teams focus on solving problems, not navigating complex workflows. Built on NocoBase no-code platform with T-shaped data architecture for unified multi-business management. AI employee team powers the entire ticket lifecycle from creation to closure.
+              Construído sobre a plataforma no-code NocoBase. Fluxo completo: <strong>registro do problema → distribuição inteligente → tratamento → avaliação de satisfação</strong>, com cronômetro de SLA, gestão de prioridade, classificação por AI e workspace de atendimento.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Multi-source Intake</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI Smart Routing</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Full SLA Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Auto Knowledge Capture</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cronômetro automático de SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 níveis de prioridade</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Classificação por AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Equipment Repair</span>
-                  <span class="badge bg-soft-primary me-2">IT Support</span>
-                  <span class="badge bg-soft-primary me-2">Customer Complaints</span>
-                  <span class="badge bg-soft-primary">Inquiries</span>
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Atendimento e pós-venda</span>
+                  <span class="badge bg-soft-primary me-2">Service desk de TI</span>
+                  <span class="badge bg-soft-primary me-2">Manutenção de equipamentos</span>
+                  <span class="badge bg-soft-primary">Atendimento de SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha version is now live. Try it out - we're actively improving.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interface do sistema de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Enterprises face diverse service requests with scattered sources, varying workflows, and lack of unified management</p>
+            <h4 class="title mb-4">Fluxo de tratamento de tickets</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Do registro pelo cliente à avaliação final, com SLA monitorado de ponta a ponta</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High Cost, Slow Customization</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Fragmented Systems, Data Silos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Slow Response, No Transparency</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Quality Hard to Ensure</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Knowledge Can't Accumulate</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Missing AI Capabilities</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Universal ticketing platform built on NocoBase no-code: unified intake, smart distribution, multi-business support, closed-loop feedback</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-source Intake</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI Smart Routing</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Full SLA Monitoring</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">T-Shaped Data Architecture</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Equipment Repair</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT Support</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">AI Employee Team</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Abertura</div>
+                  <div class="small text-muted">Múltiplos canais</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classificação</div>
+                  <div class="small text-muted">Identificação por AI</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Distribuição</div>
+                  <div class="small text-muted">Regras por equipe</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tratamento</div>
+                  <div class="small text-muted">Cronômetro de SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Avaliação</div>
+                  <div class="small opacity-75">Encerramento e arquivamento</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Abertura</td>
+                      <td class="py-3 text-muted">Envio do cliente por e-mail, formulário ou IM; com vínculo a cliente e produto</td>
+                      <td class="py-3 text-muted">Número do ticket, origem e cadastro do cliente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classificação</td>
+                      <td class="py-3 text-muted">AI identifica a categoria (conta, funcionalidade, bug) e define a prioridade</td>
+                      <td class="py-3 text-muted">Etiqueta de categoria, prioridade, índice de confiança</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Distribuição</td>
+                      <td class="py-3 text-muted">Encaminhamento por regras à equipe/atendente correspondente; urgentes notificam plantão</td>
+                      <td class="py-3 text-muted">Responsável, registro de distribuição, fila da equipe</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tratamento</td>
+                      <td class="py-3 text-muted">Atendente resolve e dialoga com o cliente; o SLA é monitorado, com alerta antes do estouro</td>
+                      <td class="py-3 text-muted">Log do atendimento, status do SLA, motivo da espera</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Avaliação</td>
+                      <td class="py-3 text-muted">No encerramento, o cliente avalia (1 a 5 estrelas + texto); resultados agregados por atendente/produto</td>
+                      <td class="py-3 text-muted">Registro de satisfação, tickets arquivados, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Rotina completa do recebimento ao encerramento dos tickets de atendimento</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cronômetro de SLA e alertas</h5>
+              <p class="text-muted mt-2">Cálculo automático dos prazos de resposta e resolução conforme a prioridade; alerta antes do estouro, ticket atrasado em vermelho, taxa de cumprimento no painel.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 níveis de prioridade</h5>
+              <p class="text-muted mt-2">Urgente, alta, média e baixa, com tempos de resposta distintos; tickets urgentes vão automaticamente para o topo e notificam o plantão.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Classificação por AI</h5>
+              <p class="text-muted mt-2">Ao abrir o ticket, a AI identifica automaticamente a categoria (problema de conta, dúvida de funcionalidade, bug etc.) e o encaminha para a equipe correta.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Motivos de espera detalhados</h5>
+              <p class="text-muted mt-2">"Aguardando cliente", "Aguardando terceiro" e "Em análise de requisitos" — tickets em espera não contam para o estouro de SLA, mantendo a métrica justa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workspace do atendente</h5>
+              <p class="text-muted mt-2">Ao entrar, o atendente vê os tickets atribuídos a ele, ordenados por prazo; em uma única tela: pendentes, em andamento e próximos do estouro.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard de tickets</h5>
+              <p class="text-muted mt-2">Novos do dia, encerrados, pendentes e em atraso; agregação por atendente, cliente e linha de produto, dando ao gestor uma visão completa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Mais funcionalidades em desenvolvimento</h5>
+              <p class="text-muted small mt-2 mb-0">Planejado: avaliação de satisfação, fluxo de transferência e escalonamento, modelos de resposta, integração com base de conhecimento</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Gestão de Vendas, Gestão de Projetos, Gestão de Ativos e RH.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/pt/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BasePT>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/pt/solutions/ticketing.astro
+++ b/src/pages/pt/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BasePT from "../../../layouts/BasePT.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BasePT
+  title="Help Desk (Tickets) — sistema open source de atendimento ao cliente | NocoBase"
+  description="Sistema de tickets open source baseado na plataforma no-code NocoBase: registro de problemas, distribuição inteligente, cronômetro de SLA, prioridade, classificação por AI, avaliação de satisfação e workspace de atendimento. Pronto para uso, indicado para equipes de pequeno e médio porte."
+  keywords="sistema de tickets, help desk, sistema de chamados, ticketing open source, gestão de SLA, sistema de pós-venda, sistema de atendimento ao cliente, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,337 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/pt/solutions/all-in-one" class="text-muted small text-decoration-none">Sistema de Gestão Empresarial Integrado</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">módulo Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Tickets)</h1>
+            <p class="para-desc text-muted">
+              Construído sobre a plataforma no-code NocoBase. Fluxo completo: <strong>registro do problema → distribuição inteligente → tratamento → avaliação de satisfação</strong>, com cronômetro de SLA, gestão de prioridade, classificação por AI e workspace de atendimento.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cronômetro automático de SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 níveis de prioridade</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Classificação por AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source e gratuito</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Cenários de uso:</span>
+                  <span class="badge bg-soft-primary me-2">Atendimento e pós-venda</span>
+                  <span class="badge bg-soft-primary me-2">Service desk de TI</span>
+                  <span class="badge bg-soft-primary me-2">Manutenção de equipamentos</span>
+                  <span class="badge bg-soft-primary">Atendimento de SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+              <a href="/pt/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Ver solução completa</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Interface do sistema de tickets" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Fluxo de tratamento de tickets</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Do registro pelo cliente à avaliação final, com SLA monitorado de ponta a ponta</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/pt/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/pt/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Abertura</div>
+                  <div class="small text-muted">Múltiplos canais</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Classificação</div>
+                  <div class="small text-muted">Identificação por AI</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Distribuição</div>
+                  <div class="small text-muted">Regras por equipe</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tratamento</div>
+                  <div class="small text-muted">Cronômetro de SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Avaliação</div>
+                  <div class="small opacity-75">Encerramento e arquivamento</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Etapa</th>
+                      <th class="border-0 py-3">Ação-chave</th>
+                      <th class="border-0 py-3">Registro no sistema</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Abertura</td>
+                      <td class="py-3 text-muted">Envio do cliente por e-mail, formulário ou IM; com vínculo a cliente e produto</td>
+                      <td class="py-3 text-muted">Número do ticket, origem e cadastro do cliente</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Classificação</td>
+                      <td class="py-3 text-muted">AI identifica a categoria (conta, funcionalidade, bug) e define a prioridade</td>
+                      <td class="py-3 text-muted">Etiqueta de categoria, prioridade, índice de confiança</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Distribuição</td>
+                      <td class="py-3 text-muted">Encaminhamento por regras à equipe/atendente correspondente; urgentes notificam plantão</td>
+                      <td class="py-3 text-muted">Responsável, registro de distribuição, fila da equipe</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Tratamento</td>
+                      <td class="py-3 text-muted">Atendente resolve e dialoga com o cliente; o SLA é monitorado, com alerta antes do estouro</td>
+                      <td class="py-3 text-muted">Log do atendimento, status do SLA, motivo da espera</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Avaliação</td>
+                      <td class="py-3 text-muted">No encerramento, o cliente avalia (1 a 5 estrelas + texto); resultados agregados por atendente/produto</td>
+                      <td class="py-3 text-muted">Registro de satisfação, tickets arquivados, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/pt/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/pt/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/pt/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Funcionalidades principais</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Rotina completa do recebimento ao encerramento dos tickets de atendimento</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cronômetro de SLA e alertas</h5>
+              <p class="text-muted mt-2">Cálculo automático dos prazos de resposta e resolução conforme a prioridade; alerta antes do estouro, ticket atrasado em vermelho, taxa de cumprimento no painel.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 níveis de prioridade</h5>
+              <p class="text-muted mt-2">Urgente, alta, média e baixa, com tempos de resposta distintos; tickets urgentes vão automaticamente para o topo e notificam o plantão.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Classificação por AI</h5>
+              <p class="text-muted mt-2">Ao abrir o ticket, a AI identifica automaticamente a categoria (problema de conta, dúvida de funcionalidade, bug etc.) e o encaminha para a equipe correta.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Motivos de espera detalhados</h5>
+              <p class="text-muted mt-2">"Aguardando cliente", "Aguardando terceiro" e "Em análise de requisitos" — tickets em espera não contam para o estouro de SLA, mantendo a métrica justa.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workspace do atendente</h5>
+              <p class="text-muted mt-2">Ao entrar, o atendente vê os tickets atribuídos a ele, ordenados por prazo; em uma única tela: pendentes, em andamento e próximos do estouro.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard de tickets</h5>
+              <p class="text-muted mt-2">Novos do dia, encerrados, pendentes e em atraso; agregação por atendente, cliente e linha de produto, dando ao gestor uma visão completa.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Mais funcionalidades em desenvolvimento</h5>
+              <p class="text-muted small mt-2 mb-0">Planejado: avaliação de satisfação, fluxo de transferência e escalonamento, modelos de resposta, integração com base de conhecimento</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Download e implantação</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Este módulo está incluído no modelo de backup do Sistema de Gestão Empresarial Integrado, com implantação unificada</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Baixar o modelo de backup</h5>
+                <p class="text-muted mt-2">Backup da solução integrada; após a restauração inclui dados pré-configurados deste módulo e dos demais 5</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Baixar backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">ou baixar o pacote SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Guia de instalação</h5>
+                <p class="text-muted mt-2">Passos detalhados de restauração, perguntas frequentes e observações estão em preparação</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Em breve</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Comece a usar</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Este módulo também faz parte do <a href="/pt/solutions/all-in-one">Sistema de Gestão Empresarial Integrado</a>. Pode ser usado isoladamente ou em conjunto com CRM, Gestão de Vendas, Gestão de Projetos, Gestão de Ativos e RH.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Experimentar Demo</a>
+            <a href="/pt/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Fale Conosco</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BasePT>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/ru/solutions/all-in-one.astro
+++ b/src/pages/ru/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseRU
+  title="Единая система управления бизнесом — CRM / Help Desk / Управление проектами / Активы / HR | NocoBase"
+  description="Открытая единая система управления бизнесом: CRM, управление продажами, тикет-система, управление проектами, управление активами и HR — шесть модулей в едином решении. Построена на NocoBase no-code платформе, готова к использованию, подходит для небольших и средних команд."
+  keywords="Единая система управления бизнесом, CRM, открытая CRM, тикет-система, help desk, управление проектами, управление активами, IT активы, HR система, управление персоналом, управление продажами, no-code ERP, всё в одном, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Единая система<br/>управления бизнесом</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Охватывает <strong>CRM, управление продажами, тикет-систему, управление проектами, управление активами и HR</strong> — шесть модулей.
+              Готово к использованию, без сложного подбора и интеграции отдельных систем.
+            </p>
+
+            <!-- Ключевые преимущества -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Единая платформа вместо набора систем</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Поддержка 20+ языков</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI-сотрудники и рабочие процессы</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Open source, бесплатно</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Сценарии применения -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">Стартапы</span>
+                  <span class="badge bg-soft-primary me-2">Многопрофильные точки</span>
+                  <span class="badge bg-soft-primary me-2">Этап поиска бизнес-модели</span>
+                  <span class="badge bg-soft-primary">Обучение и тренинги</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Попробовать Demo
+              </a>
+              <a href="/ru/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Связаться с нами
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Единая система управления бизнесом" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Шесть модулей в связке</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, управление продажами, тикет-система, управление проектами, управление активами и HR — все бизнес-процессы замкнуты в одной системе</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- CRM -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Управление клиентами)</h5>
+              <p class="text-muted mt-2">Открытая CRM: полный цикл от лида до сделки, объединение и дедупликация записей; представление «Клиент 360» агрегирует заказы, заявки, проекты и активы.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Управление этапами лида и конверсия</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Карточка «Клиент 360»</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Инструменты объединения и дедупликации</li>
+              </ul>
+              <a href="/ru/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Управление продажами -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление продажами</h5>
+              <p class="text-muted mt-2">Управление заказами: коммерческие предложения, заказы, счета и оплаты в едином потоке; встроенные процессы согласования и анализ дебиторской задолженности.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Коммерческие предложения в нескольких валютах</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Процесс согласования заказов</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI по просроченной дебиторке</li>
+              </ul>
+              <a href="/ru/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Тикет-система -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Тикеты)</h5>
+              <p class="text-muted mt-2">Help Desk для клиентского сервиса: регистрация обращений, распределение, обработка и оценка удовлетворённости; учёт SLA, приоритеты и детализация причин ожидания.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Автоматический учёт SLA и уведомления о просрочке</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Дашборд тикетов и рабочее место команды</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 уровня приоритета и AI-классификация</li>
+              </ul>
+              <a href="/ru/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Управление проектами -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление проектами</h5>
+              <p class="text-muted mt-2">Лёгкая система управления проектами: двухуровневая модель «проект — задача»; ответственные, прогресс, контрольные точки и предупреждения о просрочке.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Доска статусов проектов</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Загрузка ответственных за задачи</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Уведомления о просроченных проектах</li>
+              </ul>
+              <a href="/ru/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Управление активами -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление активами</h5>
+              <p class="text-muted mt-2">Полный жизненный цикл IT- и офисных активов: закупка, выдача, обслуживание, списание, а также реестр поставщиков.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Выдача и возврат активов</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Заявки на обслуживание</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Аналитика по поставщикам</li>
+              </ul>
+              <a href="/ru/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR / Управление персоналом</h5>
+              <p class="text-muted mt-2">HR-система: реестр сотрудников, оформление приёма, увольнение, отпуска, контроль испытательного срока, а также должности и оргструктура.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Чек-листы приёма и увольнения</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Согласование отпусков</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Доска по сотрудникам на испытательном сроке</li>
+              </ul>
+              <a href="/ru/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Подробнее <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Возможности платформы</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Построено на NocoBase 2.x: встроенные AI, рабочие процессы, многоязычность и изоляция нескольких рабочих пространств</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI-сотрудники</h5>
+            <p class="text-muted small">Lina (локализация), Lexi (перевод), Atlas (координация) и другие встроенные AI-роли, доступные под конкретные задачи.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Поддержка нескольких языков</h5>
+            <p class="text-muted small">Встроенная поддержка 20+ языков (русский, английский, китайский, японский, корейский, немецкий, французский и другие), весь UI переведён.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Движок рабочих процессов</h5>
+            <p class="text-muted small">Согласования, уведомления, учёт SLA, запуск по расписанию; визуальное проектирование правил без программирования.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Изоляция рабочих пространств</h5>
+            <p class="text-muted small">Одна установка обслуживает несколько команд или точек: данные изолированы, права настраиваются независимо.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI-совместная работа</span>
+            <h4 class="title mb-4">Встроенные AI-сотрудники</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 предустановленных AI-сотрудников охватывают типовые бизнес-роли; через протокол MCP можно подключать внешних агентов и расширять возможности</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Руководитель команды — постановка задач и координация</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Frontend-инженер — интерфейсы и генерация JS-блоков</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Визуализация — графики и дашборды</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Аналитика — выявление трендов и интерпретация KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Исследования — сбор информации и подготовка выжимок</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Подготовка данных — очистка, объединение и пакетная обработка</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Переводы и коммуникация — переписка с клиентами на разных языках</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Инженер по локализации — тексты интерфейса и i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Почтовый ассистент — разбор намерений и черновики ответов</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Свой AI-сотрудник</h6>
+              <p class="text-muted small mb-0">Собственные роли, промпты и наборы навыков под вашу задачу</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Подключение внешних агентов</h6>
+              <p class="text-muted small mb-0">Через протокол MCP подключите свои агенты и инструменты</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Сценарии применения</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Решение особенно полезно в следующих случаях</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Управление несколькими направлениями</h5>
+                  <p class="text-muted mb-0">Бизнес охватывает продажи, сервис и проектную работу — нужен единый интерфейс, без переключения между разрозненными инструментами.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Многопрофильные точки</h5>
+                  <p class="text-muted mb-0">Точка одновременно занимается продажами, постпродажным обслуживанием и проектной работой: направлений много, масштаб умеренный, отдельные системы давали бы лишние издержки на интеграцию.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Этап поиска бизнес-модели</h5>
+                  <p class="text-muted mb-0">Бизнес ещё не сформировался — нет смысла рано фиксироваться на конкретной системе. Единое решение можно использовать сразу, а потом постепенно дорабатывать под реальные потребности.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Обучение, тренинги и PoC</h5>
+                  <p class="text-muted mb-0">Полноценный пример возможностей платформы NocoBase: подходит для внутреннего обучения, демонстраций и проверки концепции на типовых бизнес-процессах.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Как развернуть?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Три шага — и единая система управления бизнесом готова к работе</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Установить NocoBase</h5>
+                <p class="text-muted mt-2">Разверните NocoBase локально или на сервере, следуя официальной инструкции по установке</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">Открыть инструкцию</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">После восстановления вы получите полный набор предзаполненных данных по всем шести модулям</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Начните работу с единой системой управления бизнесом</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Комплексная бизнес-система на базе NocoBase 2.x. Шаблон можно использовать как есть или расширять. Если вам нужна глубокая адаптация под конкретный процесс — напишите нам.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Попробовать Demo
+            </a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Связаться с нами
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/ru/solutions/asset-management.astro
+++ b/src/pages/ru/solutions/asset-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseRU
+  title="Управление активами — открытая система учёта IT- и офисных активов | NocoBase"
+  description="Открытая система управления активами на базе NocoBase no-code платформы: полный жизненный цикл — закупка, выдача, обслуживание, списание — для IT- и офисных активов; реестр поставщиков, заявки на обслуживание и аналитика закупок."
+  keywords="Управление активами, управление IT активами, система учёта активов, открытое управление активами, управление офисными активами, жизненный цикл активов, управление оборудованием, инвентаризация активов, управление поставщиками, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль «Управление активами»</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Управление активами</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный жизненный цикл <strong>Закупка → Выдача → Обслуживание → Списание</strong> для IT- и офисных активов, дополненный реестром поставщиков и заявками на обслуживание.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Полный жизненный цикл</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Заявки на обслуживание</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Реестр поставщиков</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">IT-активы</span>
+                  <span class="badge bg-soft-primary me-2">Офисные активы</span>
+                  <span class="badge bg-soft-primary me-2">Аренда оборудования</span>
+                  <span class="badge bg-soft-primary">Инвентаризация активов</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Интерфейс системы управления активами" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Жизненный цикл актива</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл от закупки до списания — история каждого актива прослеживается полностью</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Закупка</div>
+                  <div class="small text-muted">Связь с поставщиком</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Постановка на учёт</div>
+                  <div class="small text-muted">Карточка актива</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Выдача</div>
+                  <div class="small text-muted">Подпись получателя</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Обслуживание</div>
+                  <div class="small text-muted">Связь с заявкой</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Списание</div>
+                  <div class="small opacity-75">Учёт остаточной стоимости</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Закупка</td>
+                      <td class="py-3 text-muted">Заявка на закупку со связью с поставщиком и ценой; поддерживаются несколько категорий и количеств</td>
+                      <td class="py-3 text-muted">Заявка на закупку, поставщик, сумма</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Постановка на учёт</td>
+                      <td class="py-3 text-muted">При постановке на учёт автоматически создаётся карточка актива (инвентарный номер, серийный номер, срок гарантии — за один ввод)</td>
+                      <td class="py-3 text-muted">Карточка актива, уникальный номер, срок гарантии</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Выдача</td>
+                      <td class="py-3 text-muted">Актив передаётся сотруднику, клиенту или подразделению с подтверждением подписи</td>
+                      <td class="py-3 text-muted">Запись выдачи, пользователь, период использования</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Обслуживание</td>
+                      <td class="py-3 text-muted">При поломке или плановом ТО создаётся заявка на обслуживание со связью с карточкой актива</td>
+                      <td class="py-3 text-muted">Заявка на обслуживание, накопленные расходы</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Списание</td>
+                      <td class="py-3 text-muted">При списании фиксируется причина (поломка / устаревание / продажа), регистрируется амортизация и остаточная стоимость</td>
+                      <td class="py-3 text-muted">Запись списания, остаточная стоимость, способ выбытия</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный охват учёта активов — от закупки до списания</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Закупка активов</h5>
+              <p class="text-muted mt-2">Заявка на закупку связана с поставщиком и ценой; при постановке на учёт создаётся карточка актива — инвентарный и серийный номера, срок гарантии регистрируются за один шаг.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Выдача и возврат</h5>
+              <p class="text-muted mt-2">Передача актива сотруднику или клиенту с подписью; при возврате актив автоматически освобождается; история использования каждого актива прослеживается полностью.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Заявки на обслуживание</h5>
+              <p class="text-muted mt-2">Поломка или плановое ТО регистрируются заявкой со связью с карточкой актива; накопленные затраты помогают принимать решения о списании.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Списание и продажа</h5>
+              <p class="text-muted mt-2">При списании указывается причина (поломка / устаревание / продажа); амортизация и остаточная стоимость учитываются и согласуются с финансовым учётом.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Реестр поставщиков</h5>
+              <p class="text-muted mt-2">Карточка поставщика и история закупок: сумма, категории и условия оплаты — данные для решений по выбору контрагентов.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд активов</h5>
+              <p class="text-muted mt-2">Общее количество, в эксплуатации, на обслуживании, списанные; агрегация по типу, подразделению и пользователю; данные инвентаризации экспортируются в один клик.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Дополнительные функции в разработке</h5>
+              <p class="text-muted small mt-2 mb-0">Запланировано: задачи инвентаризации, автоматический расчёт амортизации, сканирование QR-кодов, согласование заявок на актив</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Управление продажами», «Help Desk», «Управление проектами» и «HR».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/ru/solutions/crm-v2.astro
+++ b/src/pages/ru/solutions/crm-v2.astro
@@ -1,0 +1,366 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseRU
+  title="CRM (Управление клиентами) — открытая, разворачивается на своём сервере | NocoBase"
+  description="Открытая CRM на базе NocoBase no-code платформы: управление лидами, ведение клиентов, конверсия, объединение и дедупликация, карточка «Клиент 360». Готова к использованию, разворачивается на своих серверах."
+  keywords="CRM, открытая CRM, система управления клиентами, управление клиентами, управление лидами, ведение клиентов, Клиент 360, no-code CRM, self-hosted CRM, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>(Управление клиентами)</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный цикл от лида до сделки: ведение, конверсия, объединение и дедупликация; карточка «Клиент 360» агрегирует историю заказов, заявок, проектов и активов.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Управление этапами лида</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Карточка «Клиент 360»</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Объединение и дедупликация</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-продажи</span>
+                  <span class="badge bg-soft-primary me-2">Проектные продажи</span>
+                  <span class="badge bg-soft-primary me-2">ВЭД</span>
+                  <span class="badge bg-soft-primary">Небольшие и средние команды</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Интерфейс CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Процесс ведения клиентов</h4>
+            <p class="para-desc mx-auto text-muted mb-0">От получения лида до карточки «Клиент 360» — данные связаны на каждом этапе</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Лид</div>
+                  <div class="small text-muted">Разные каналы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Контакт и ведение</div>
+                  <div class="small text-muted">Фиксация истории</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Конверсия в клиента</div>
+                  <div class="small text-muted">Заведение карточки</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">«Клиент 360»</div>
+                  <div class="small text-muted">Полная картина</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Накопление данных</div>
+                  <div class="small opacity-75">Дашборд продаж</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Лид</td>
+                      <td class="py-3 text-muted">Форма, импорт или ручной ввод; помечается источник и ответственный менеджер</td>
+                      <td class="py-3 text-muted">Пул лидов, метки источников, движение по этапам</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Контакт и ведение</td>
+                      <td class="py-3 text-muted">Звонки, письма, встречи; назначается дата следующего контакта</td>
+                      <td class="py-3 text-muted">Лента взаимодействий, напоминание о следующем шаге</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Конверсия в клиента</td>
+                      <td class="py-3 text-muted">Лид переводится в клиента, заполняется карточка (отрасль, размер, контакты)</td>
+                      <td class="py-3 text-muted">Таблица клиентов, контактные лица, связи с лидом</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">«Клиент 360»</td>
+                      <td class="py-3 text-muted">Полная картина клиента: заказы, заявки, проекты, активы</td>
+                      <td class="py-3 text-muted">Встроенные блоки, межмодульные связи</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Накопление данных</td>
+                      <td class="py-3 text-muted">Дашборд продаж агрегирует KPI по менеджерам, регионам и сегментам</td>
+                      <td class="py-3 text-muted">Графики, детализация, экспорт</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Лиды, клиенты, ведение, дашборды — полный охват ежедневной работы CRM</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Импорт лидов</h5>
+              <p class="text-muted mt-2">Загрузка из Excel, сбор через форму, приём по API; визуальная настройка маппинга полей и автоматическая дедупликация при импорте.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Движение по этапам</h5>
+              <p class="text-muted mt-2">Этапы лида (новый / в работе / сконвертирован / отказ) настраиваются визуально; смена этапа фиксируется автоматически, расчёт конверсии идёт сам.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">История взаимодействий</h5>
+              <p class="text-muted mt-2">Каждый звонок, письмо и встреча сохраняются; вся история коммуникаций видна на единой ленте — передача дел проходит без потерь.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Напоминания о следующем шаге</h5>
+              <p class="text-muted mt-2">Автоматические уведомления до наступления даты следующего контакта; клиенты, с которыми давно не общались, попадают в доску «требуют реактивации».</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Карточка «Клиент 360»</h5>
+              <p class="text-muted mt-2">Карточка клиента собирает заказы, заявки, проекты и активы — вся картина в одном окне, без переключения между системами.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Категории и метки</h5>
+              <p class="text-muted mt-2">Многомерные метки: тип клиента, отрасль, размер, источник; поддерживается фильтрация и агрегированная аналитика по меткам.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Объединение и дедупликация</h5>
+              <p class="text-muted mt-2">Повторные записи одного клиента распознаются автоматически; объединение в один клик — история ведения и связи переносятся без потерь.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд продаж</h5>
+              <p class="text-muted mt-2">Агрегация KPI по менеджерам, регионам и типам клиентов: число новых клиентов, конверсия, распределение активных клиентов.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Права на уровне полей и строк</h5>
+              <p class="text-muted mt-2">Видимые поля настраиваются ролью; менеджер видит только своих клиентов, руководитель — всё.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями «Управление продажами», «Help Desk», «Управление проектами», «Управление активами» и «HR».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/ru/solutions/crm.astro
+++ b/src/pages/ru/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseRU from "../../../layouts/BaseRU.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-ru.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-ru.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-ru.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-ru.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="no-code, гибкая и мощная CRM платформа"
-  description="Готова к использованию из коробки. Обеспечивает максимальные возможности настройки при полном контроле над данными. Вы можете расширять поля, блоки, функции и страницы на этой основе, чтобы полностью удовлетворить потребности вашего бизнеса."
-  keywords="NocoBase CRM, управление отношениями с клиентами, No-code CRM, открытая CRM, настраиваемая CRM"
+<BaseRU
+  title="CRM (Управление клиентами) — открытая, разворачивается на своём сервере | NocoBase"
+  description="Открытая CRM на базе NocoBase no-code платформы: управление лидами, ведение клиентов, конверсия, объединение и дедупликация, карточка «Клиент 360». Готова к использованию, разворачивается на своих серверах."
+  keywords="CRM, открытая CRM, система управления клиентами, управление клиентами, управление лидами, ведение клиентов, Клиент 360, no-code CRM, self-hosted CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">no-code, гибкая и мощная<br/>CRM платформа</h1>
-            <p class="para-desc text-muted">Готова к использованию из коробки с мощными возможностями настройки под ваши уникальные потребности. Расширяйте поля, блоки и страницы для создания идеального решения для вашего бизнеса — при полном контроле над данными.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Создано на NocoBase 1.x (2.0 в разработке)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>(Управление клиентами)</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный цикл от лида до сделки: ведение, конверсия, объединение и дедупликация; карточка «Клиент 360» агрегирует историю заказов, заявок, проектов и активов.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Управление этапами лида</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Карточка «Клиент 360»</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Объединение и дедупликация</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Отрасли:</span>
-                  <span class="badge bg-soft-primary">Все отрасли</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-продажи</span>
+                  <span class="badge bg-soft-primary me-2">Проектные продажи</span>
+                  <span class="badge bg-soft-primary me-2">ВЭД</span>
+                  <span class="badge bg-soft-primary">Небольшие и средние команды</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Разработчик:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Демо
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Развернуть на своем сервере
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Ваш браузер не поддерживает HTML5 видео.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Интерфейс CRM" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Что делает NocoBase CRM уникальной</h4>
-            <p class="para-desc mx-auto text-muted mb-0">В отличие от SaaS и других CRM систем, NocoBase CRM гибкая и полностью контролируемая</p>
+            <h4 class="title mb-4">Процесс ведения клиентов</h4>
+            <p class="para-desc mx-auto text-muted mb-0">От получения лида до карточки «Клиент 360» — данные связаны на каждом этапе</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Полностью no-code</h5>
-              <p class="text-muted mt-2">Не требуются навыки программирования для настройки CRM</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Охватывает общие функции CRM</h5>
-              <p class="text-muted mt-2">Управление клиентами, воронка продаж, отслеживание возможностей, управление контактами, email-коммуникация, процессы одобрения и многое другое</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Легко модифицируется и расширяется</h5>
-              <p class="text-muted mt-2">Поддерживает пользовательские поля, процессы и бизнес-логику, гибкая архитектура делает "вторичную разработку" простой</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Открытый код, полный контроль данных</h5>
-              <p class="text-muted mt-2">Полный контроль над кодом системы и данными, обеспечивая безопасность корпоративных данных</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Попробуйте функции NocoBase CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Быстрый опыт всего несколькими кликами</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Визуализация данных</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Интерактивное демо
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Лид</div>
+                  <div class="small text-muted">Разные каналы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Контакт и ведение</div>
+                  <div class="small text-muted">Фиксация истории</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Конверсия в клиента</div>
+                  <div class="small text-muted">Заведение карточки</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">«Клиент 360»</div>
+                  <div class="small text-muted">Полная картина</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Накопление данных</div>
+                  <div class="small opacity-75">Дашборд продаж</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Процесс конвертации лидов</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Интерактивное демо
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">От возможности к заказу</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Интерактивное демо
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Попробовать сейчас
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Скопировать на свой сервер
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Учебник по разработке и расширению CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Узнайте, как использовать NocoBase для создания и расширения профессиональных CRM систем</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Базовая настройка и кастомизация</h5>
-                <p class="text-muted text-center">Научитесь создавать модели данных, настраивать связи полей, конфигурировать разрешения и макеты интерфейса</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Анализ данных и визуализация</h5>
-                <p class="text-muted text-center">Создавайте дашборды анализа данных продаж для мониторинга производительности и визуализации данных</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Автоматизация процессов</h5>
-                <p class="text-muted text-center">Настройте рабочие процессы для автоматизации процессов продаж, рабочих процессов одобрения и бизнес-правил</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Интеграция и расширение системы</h5>
-                <p class="text-muted text-center">Интегрируйте сторонние системы, мобильную адаптацию и другие продвинутые функции расширения</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Коммерческие плагины используемые в CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Ядро CRM работает на версии с открытым исходным кодом, коммерческие плагины добавляют функциональность</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_ru || plugin.name;
-          const displayDescription = plugin.description_ru || plugin.description;
-          const docsUrl = plugin.docs_ru || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">От <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Подробности</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Навсегда + 1 год обновлений</span><br>
-                          <a href="/ru/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted" style="font-size: 0.85rem;"> {plugin.price_1_year_rub ? plugin.price_1_year_rub.toLocaleString('ru-RU') : '?'} ₽ </span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Навсегда + обновления навсегда</span><br>
-                          <a class="text-muted" href="/ru/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted" style="font-size: 0.85rem;">{plugin.price_rub ? plugin.price_rub.toLocaleString('ru-RU') : '?'} ₽</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">Больше плагинов скоро</h6>
-                  <p class="text-muted small">Мы разрабатываем больше полезных коммерческих плагинов, следите за обновлениями</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Лид</td>
+                      <td class="py-3 text-muted">Форма, импорт или ручной ввод; помечается источник и ответственный менеджер</td>
+                      <td class="py-3 text-muted">Пул лидов, метки источников, движение по этапам</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Контакт и ведение</td>
+                      <td class="py-3 text-muted">Звонки, письма, встречи; назначается дата следующего контакта</td>
+                      <td class="py-3 text-muted">Лента взаимодействий, напоминание о следующем шаге</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Конверсия в клиента</td>
+                      <td class="py-3 text-muted">Лид переводится в клиента, заполняется карточка (отрасль, размер, контакты)</td>
+                      <td class="py-3 text-muted">Таблица клиентов, контактные лица, связи с лидом</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">«Клиент 360»</td>
+                      <td class="py-3 text-muted">Полная картина клиента: заказы, заявки, проекты, активы</td>
+                      <td class="py-3 text-muted">Встроенные блоки, межмодульные связи</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Накопление данных</td>
+                      <td class="py-3 text-muted">Дашборд продаж агрегирует KPI по менеджерам, регионам и сегментам</td>
+                      <td class="py-3 text-muted">Графики, детализация, экспорт</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ru/plugins-commercial" class="btn btn-primary me-3">Все коммерческие плагины</a>
-          <a href="/ru/commercial" class="btn btn-outline-primary">Цены</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Как использовать?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Три шага для быстрого развертывания NocoBase CRM в вашей среде</p>
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Лиды, клиенты, ведение, дашборды — полный охват ежедневной работы CRM</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Установить NocoBase</h5>
-                                  <p class="text-muted mt-2">Следуйте нашей документации по установке для развертывания NocoBase на вашем сервере</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Посмотреть документацию по установке</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Импорт лидов</h5>
+              <p class="text-muted mt-2">Загрузка из Excel, сбор через форму, приём по API; визуальная настройка маппинга полей и автоматическая дедупликация при импорте.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Скачать файл шаблона CRM</h5>
-                <p class="text-muted mt-2">Получите полный файл шаблона для системы NocoBase CRM, поддерживающий два формата</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Скачать SQL файл</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Скачать файл резервной копии (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Движение по этапам</h5>
+              <p class="text-muted mt-2">Этапы лида (новый / в работе / сконвертирован / отказ) настраиваются визуально; смена этапа фиксируется автоматически, расчёт конверсии идёт сам.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Восстановить в системе</h5>
-                <p class="text-muted mt-2">Импортируйте файл шаблона в вашу систему NocoBase для завершения развертывания</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/ru/solution/crm/v1" class="btn btn-outline-primary">Учебник по восстановлению</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">История взаимодействий</h5>
+              <p class="text-muted mt-2">Каждый звонок, письмо и встреча сохраняются; вся история коммуникаций видна на единой ленте — передача дел проходит без потерь.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Напоминания о следующем шаге</h5>
+              <p class="text-muted mt-2">Автоматические уведомления до наступления даты следующего контакта; клиенты, с которыми давно не общались, попадают в доску «требуют реактивации».</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Карточка «Клиент 360»</h5>
+              <p class="text-muted mt-2">Карточка клиента собирает заказы, заявки, проекты и активы — вся картина в одном окне, без переключения между системами.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Категории и метки</h5>
+              <p class="text-muted mt-2">Многомерные метки: тип клиента, отрасль, размер, источник; поддерживается фильтрация и агрегированная аналитика по меткам.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Объединение и дедупликация</h5>
+              <p class="text-muted mt-2">Повторные записи одного клиента распознаются автоматически; объединение в один клик — история ведения и связи переносятся без потерь.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд продаж</h5>
+              <p class="text-muted mt-2">Агрегация KPI по менеджерам, регионам и типам клиентов: число новых клиентов, конверсия, распределение активных клиентов.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Права на уровне полей и строк</h5>
+              <p class="text-muted mt-2">Видимые поля настраиваются ролью; менеджер видит только своих клиентов, руководитель — всё.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Готовы использовать NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Разверните выделенное CRM демо за 1 минуту. От настройки структур данных до макетов интерфейса и логики процессов — все это выполняется через визуальную конфигурацию NocoBase без написания ни одной строки кода.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями «Управление продажами», «Help Desk», «Управление проектами», «Управление активами» и «HR».</p>
           <div class="mt-4">
-            <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Живое демо
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Развернуть на своем сервере
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseRU>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/ru/solutions/hr-management.astro
+++ b/src/pages/ru/solutions/hr-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseRU
+  title="HR / Управление персоналом — открытая система HR | NocoBase"
+  description="Открытая HR-система на базе NocoBase no-code платформы: реестр сотрудников, оформление приёма и увольнения, отпуска, контроль испытательного срока, должности и оргструктура. Лёгкая, разворачивается на своих серверах, подходит для HR-команд небольшого и среднего бизнеса."
+  keywords="HR-система, управление персоналом, открытая HR-система, система учёта сотрудников, оформление приёма, оформление увольнения, согласование отпусков, контроль испытательного срока, оргструктура, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль HR</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR / Управление персоналом</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Реестр сотрудников, сквозной учёт <strong>приёма, увольнения, отпусков и испытательного срока</strong> со связкой с должностями и оргструктурой.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Чек-листы приёма и увольнения</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Согласование отпусков</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Доска по испытательному сроку</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">Небольшой и средний бизнес</span>
+                  <span class="badge bg-soft-primary me-2">Розничные сети</span>
+                  <span class="badge bg-soft-primary me-2">Отраслевой HR</span>
+                  <span class="badge bg-soft-primary">Межотдельная работа</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Интерфейс HR-системы" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Полный жизненный цикл сотрудника</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл HR-работы: от подбора до увольнения</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Подбор</div>
+                  <div class="small text-muted">Кандидаты</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Приём</div>
+                  <div class="small text-muted">Контроль чек-листа</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Работа в штате</div>
+                  <div class="small text-muted">Учёт и отпуска</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Оценка</div>
+                  <div class="small text-muted">Перевод в штат / смена должности</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Увольнение</div>
+                  <div class="small opacity-75">Передача дел и архив</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Подбор</td>
+                      <td class="py-3 text-muted">Регистрация кандидатов и оценка по итогам интервью; одобренные переводятся в карточку сотрудника</td>
+                      <td class="py-3 text-muted">Реестр кандидатов, оценки интервью</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Приём</td>
+                      <td class="py-3 text-muted">Чек-лист приёма (подписание договора, оформление пропуска, выдача техники, создание учётных записей)</td>
+                      <td class="py-3 text-muted">Чек-лист приёма, договоры</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Работа в штате</td>
+                      <td class="py-3 text-muted">Учёт явки, согласование отпусков, отгулов и сверхурочных</td>
+                      <td class="py-3 text-muted">Записи отпусков, остатки</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Оценка</td>
+                      <td class="py-3 text-muted">Оценка по итогам испытательного срока, перевод в штат, смена должности и повышение</td>
+                      <td class="py-3 text-muted">Оценочные формы, изменения должности</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Увольнение</td>
+                      <td class="py-3 text-muted">Чек-лист увольнения: передача дел, возврат активов, закрытие учётных записей, оформление документов</td>
+                      <td class="py-3 text-muted">Запись об увольнении, освобождение активов</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный охват HR-работы: от приёма до увольнения</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Реестр сотрудников</h5>
+              <p class="text-muted mt-2">Профили сотрудников с табельным номером, датой найма, должностью, отделом — единые записи, поиск по нескольким критериям.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Жизненный цикл сотрудника</h5>
+              <p class="text-muted mt-2">Ожидает онбординга → испытательный срок → активен → офбординг → неактивен: 5 статусов проходят через запись сотрудника; фильтрация по статусу одним взглядом.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Структура отделов</h5>
+              <p class="text-muted mt-2">Древовидная оргструктура: отдел → подотдел, на основе встроенного плагина departments NocoBase, связана с правами доступа.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Реестр должностей</h5>
+              <p class="text-muted mt-2">Определения должностей с уровнем (младший / средний / старший / эксперт); сотрудники привязаны к должностям для управления карьерой и правами.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Согласование отпусков</h5>
+              <p class="text-muted mt-2">8 типов отпусков (ежегодный / по болезни / личный / отгул / свадебный / родительский / траурный / прочие); процесс согласования настраивается по отделу / непосредственному руководителю.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Права на уровне поля</h5>
+              <p class="text-muted mt-2">HR видит поля зарплат; руководители видят базовую информацию команды — гибкая настройка через права роли NocoBase.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Дополнительные функции в разработке</h5>
+              <p class="text-muted small mt-2 mb-0">Запланировано: чек-листы онбординга/офбординга, оценка испытательного срока, управление контрактами и соцстрахом, кандидаты на рекрутинг, записи переводов/повышений</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Управление продажами», «Help Desk», «Управление проектами» и «Управление активами».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/ru/solutions/project-management.astro
+++ b/src/pages/ru/solutions/project-management.astro
@@ -1,40 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseRU from "../../../layouts/BaseRU.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-ru.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
 ---
 
-<Layout
-  title="Комплексное решение для управления R&D проектами"
-  description="Система управления R&D проектами NocoBase предоставляет полные возможности управления жизненным циклом разработки. От планирования требований, назначения задач, отслеживания прогресса до управления качеством, обеспечивая полный цифровой процесс управления и командное сотрудничество."
-  keywords="NocoBase управление R&D проектами, Управление задачами, Командное сотрудничество, Гибкая разработка, Управление качеством"
+<BaseRU
+  title="Управление проектами — открытая лёгкая система проектной работы | NocoBase"
+  description="Открытая система управления проектами на базе NocoBase no-code платформы: двухуровневая модель «проект — задача», ответственные, прогресс, контрольные точки, предупреждения о просрочке, распределение нагрузки. Лёгкая, разворачивается на своих серверах, подходит для небольших и средних команд и межотдельной проектной работы."
+  keywords="Управление проектами, система управления проектами, управление задачами, открытое управление проектами, лёгкое управление проектами, проектная работа, контроль проектов, контрольные точки, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -42,452 +14,336 @@ const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).fi
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Комплексное<br/>решение для управления R&D проектами</h1>
-            <p class="para-desc text-muted">Мощная и гибкая платформа управления R&D проектами, построенная на NocoBase. Поддерживает множество методологий разработки, включая Agile, Waterfall и гибридные подходы. Управляйте требованиями, задачами, командами, итерациями и качеством в одном месте.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Построено на NocoBase 1.x (2.0 в разработке)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль «Управление проектами»</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Управление проектами</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Двухуровневая модель <strong>«проект — задача»</strong>: ответственные, прогресс, контрольные точки, предупреждения о просрочке и распределение нагрузки. Лёгкое, разворачивается на своих серверах.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Двухуровневая модель «проект — задача»</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Предупреждения о просрочке</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Контроль контрольных точек</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Отрасли:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">Проекты внедрения</span>
+                  <span class="badge bg-soft-primary me-2">Внутренний IT</span>
+                  <span class="badge bg-soft-primary me-2">Межотдельная работа</span>
+                  <span class="badge bg-soft-primary">Небольшие и средние команды</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Разработчик:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Интерфейс системы управления проектами" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Жизненный цикл проекта</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл от инициации до закрытия — контрольные точки и предупреждения о просрочке работают автоматически</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Инициация</div>
+                  <div class="small text-muted">Связь с клиентом</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Декомпозиция задач</div>
+                  <div class="small text-muted">Ответственные</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Контроль прогресса</div>
+                  <div class="small text-muted">Предупреждения о просрочке</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Контрольные точки</div>
+                  <div class="small text-muted">Этапные сдачи</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Закрытие</div>
+                  <div class="small opacity-75">Ретроспектива и архив</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Живая демонстрация
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Развернуть в вашей среде
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="Предпросмотр системы управления R&D проектами NocoBase" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Что делает управление проектами NocoBase уникальным</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Комплексное решение, которое адаптируется к вашей методологии управления проектами</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Полный жизненный цикл проекта</h5>
-              <p class="text-muted mt-2">От инициации и планирования до выполнения, мониторинга и закрытия, управляйте каждой фазой ваших проектов</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile и традиционные методы</h5>
-              <p class="text-muted mt-2">Поддержка спринтов Scrum, досок Kanban, диаграмм Ганта, графиков сгорания и традиционных подходов Waterfall</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Командное сотрудничество и управление качеством</h5>
-              <p class="text-muted mt-2">Эффективно управляйте командами разработки, отслеживайте качество кода, обрабатывайте дефекты и проблемы, обеспечивая качество продукта</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Легко изменять и расширять</h5>
-              <p class="text-muted mt-2">На основе no-code возможностей NocoBase легко настраивайте поля, процессы и бизнес-логику с полным контролем</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Попробовать сейчас
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Скопировать в вашу среду
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Учебник по разработке системы управления проектами</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Узнайте, как создать профессиональную систему управления проектами с помощью NocoBase с нуля</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Дизайн модели данных</h5>
-                <p class="text-muted text-center">Узнайте, как создавать базовые структуры данных для проектов, задач, команд и их взаимосвязей</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Инициация</td>
+                      <td class="py-3 text-muted">Создание проекта со связью с клиентом (проекты внедрения) или активом (IT-проекты), назначение руководителя</td>
+                      <td class="py-3 text-muted">Карточка проекта, связь с клиентом, ответственный</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Декомпозиция задач</td>
+                      <td class="py-3 text-muted">Разбиение на задачи с ответственными, датами и зависимостями</td>
+                      <td class="py-3 text-muted">Таблица задач, ответственные, граф зависимостей</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Контроль прогресса</td>
+                      <td class="py-3 text-muted">Участники обновляют статус; просроченные задачи помечаются красным</td>
+                      <td class="py-3 text-muted">Процент выполнения, отметки о просрочке</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Контрольные точки</td>
+                      <td class="py-3 text-muted">Ключевые узлы оформляются как контрольные точки (ревью / бета / релиз); регистрируются артефакты сдачи</td>
+                      <td class="py-3 text-muted">Список контрольных точек, файлы артефактов</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Закрытие</td>
+                      <td class="py-3 text-muted">Проект закрывается, фиксируются трудозатраты и стоимость</td>
+                      <td class="py-3 text-muted">Отчёт о закрытии, суммарные часы</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Конфигурация рабочего процесса</h5>
-                <p class="text-muted text-center">Настройте назначение задач, переходы статусов и автоматизированные рабочие процессы проекта</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Спринт и отслеживание</h5>
-                <p class="text-muted text-center">Настройте спринты, графики сгорания и функции отслеживания прогресса</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Расширьте возможности коммерческими плагинами</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Расширьте возможности управления проектами с помощью мощных коммерческих плагинов</p>
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Лёгкий контроль проекта от инициации до закрытия</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">От <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Подробности</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Пожизненное использование, обновления на 1 год</span><br>
-                          <a href="/ru/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Пожизненное использование и обновления</span><br>
-                          <a class="text-muted" href="/ru/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Модель «проект — задача»</h5>
+              <p class="text-muted mt-2">Под проектом — набор задач, у каждой свой ответственный, сроки и прогресс; доска проекта показывает статусы всех задач сразу.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ru/plugins-commercial" class="btn btn-primary me-3">Посмотреть все коммерческие плагины</a>
-          <a href="/ru/commercial" class="btn btn-outline-primary">Узнать о ценах</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление контрольными точками</h5>
+              <p class="text-muted mt-2">Ключевые узлы оформляются как контрольные точки (ревью прототипа, бета, релиз); прогресс проекта выстраивается по их ритму.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Предупреждения о просрочке</h5>
+              <p class="text-muted mt-2">Просроченные задачи автоматически помечаются красным, список «отстающих» проектов обновляется в реальном времени — руководитель сразу видит риски.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ответственные и нагрузка</h5>
+              <p class="text-muted mt-2">Агрегация задач и трудозатрат по ответственным; видно, кто загружен, кто свободен, кто чаще других задерживает сроки.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Доска статусов проектов</h5>
+              <p class="text-muted mt-2">KPI по типу проекта, статусу и ответственному: проекты в работе, закрытые и просроченные представлены по категориям.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Связь с клиентами и активами</h5>
+              <p class="text-muted mt-2">Проект можно связать с клиентом (проекты внедрения) или активом (IT-проекты); в карточке клиента видна история всех связанных проектов.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Дополнительные функции в разработке</h5>
+              <p class="text-muted small mt-2 mb-0">Запланировано: граф зависимостей задач, учёт времени и стоимости, архив поставляемых результатов, диаграмма Ганта</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Как использовать?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Три шага для быстрого развертывания системы CRM NocoBase с функциональностью управления проектами в вашей среде</p>
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Установите систему NocoBase</h5>
-                <p class="text-muted mt-2">Разверните систему NocoBase на вашем сервере, следуя нашей документации по установке</p>
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Посмотреть руководство по установке</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Скачайте шаблон системы CRM</h5>
-                <p class="text-muted mt-2">Скачайте полный шаблон CRM для получения возможности управления проектами</p>
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Скачать SQL файл</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Скачать файл резервной копии (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Восстановите в системе</h5>
-                <p class="text-muted mt-2">Импортируйте файл шаблона CRM в вашу систему NocoBase для получения возможностей CRM и управления проектами</p>
-              </div>
-              <div class="mt-3">
-                <a href="/ru/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Учебник по восстановлению</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Совет</h6>
-                <p class="mb-0 text-muted">Система управления проектами полностью интегрирована в шаблон CRM как комплексный модуль. После развертывания вы можете напрямую использовать полную функциональность управления проектами в системе CRM для достижения полного процесса управления проектами и командой.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Готовы преобразовать ваше управление R&D?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Разверните комплексное решение для управления R&D за считанные минуты. От планирования требований до отслеживания задач и контроля качества, NocoBase адаптируется к вашему процессу разработки без написания ни одной строки кода.
-          </p>
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Управление продажами», «Help Desk», «Управление активами» и «HR».</p>
           <div class="mt-4">
-            <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Живая демонстрация
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Развернуть сейчас
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseRU>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/ru/solutions/project-management.astro
+++ b/src/pages/ru/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Контрольные точки</div>
                   <div class="small text-muted">Этапные сдачи</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Управление контрольными точками</h5>
               <p class="text-muted mt-2">Ключевые узлы оформляются как контрольные точки (ревью прототипа, бета, релиз); прогресс проекта выстраивается по их ритму.</p>

--- a/src/pages/ru/solutions/sales-management.astro
+++ b/src/pages/ru/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI по дебиторской задолженности</h5>
-              <p class="text-muted mt-2">Реестр просроченных платежей и анализ по возрасту долга (корзины 30 / 60 / 90 дней); агрегация по клиенту и менеджеру делает работу с долгами наглядной.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Мультивалютность и курсы</h5>
-              <p class="text-muted mt-2">Предложения и заказы в USD, EUR, CNY, RUB и других валютах; справочник курсов поддерживает ручное ведение или импорт; пересчёт в базовую валюту автоматический.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Отгрузка и доставка</h5>
-              <p class="text-muted mt-2">Накладная связана с заказом и транспортным номером; поддерживаются несколько отгрузок и частичная отгрузка; статус автоматически отражается в заказе.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Дашборд продаж</h5>

--- a/src/pages/ru/solutions/sales-management.astro
+++ b/src/pages/ru/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseRU
+  title="Управление продажами — открытое управление заказами и дебиторкой | NocoBase"
+  description="Открытая система управления продажами на базе NocoBase no-code платформы: коммерческие предложения, заказы, счета и оплаты в едином потоке; встроенные процессы согласования, мультивалютность, KPI по дебиторке и анализ просрочки."
+  keywords="Управление продажами, управление заказами, коммерческие предложения, управление счетами, управление дебиторской задолженностью, управление оплатами, процессы продаж, согласование продаж, открытое управление продажами, мультивалютные предложения, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль «Управление продажами»</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Управление продажами</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный цикл <strong>Коммерческое предложение → Заказ → Счёт → Оплата</strong> со встроенными процессами согласования, мультивалютными предложениями, KPI по дебиторке и анализом просрочки.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Мультивалютные предложения</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Согласование заказов</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI по дебиторке</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">B2B-продажи</span>
+                  <span class="badge bg-soft-primary me-2">Экспортные заказы</span>
+                  <span class="badge bg-soft-primary me-2">Продажа оборудования</span>
+                  <span class="badge bg-soft-primary">Управление дебиторкой</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Интерфейс системы управления продажами" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Процесс продаж</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл от коммерческого предложения до оплаты со связкой согласования и KPI по дебиторке</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Предложение</div>
+                  <div class="small text-muted">Несколько валют</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Заказ</div>
+                  <div class="small text-muted">Согласование</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Отгрузка</div>
+                  <div class="small text-muted">Отслеживание доставки</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Счёт</div>
+                  <div class="small text-muted">Автозаполнение реквизитов</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Оплата</div>
+                  <div class="small opacity-75">KPI по дебиторке</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Предложение</td>
+                      <td class="py-3 text-muted">Выбор клиента и товаров, формирование предложения в нескольких валютах со скидками, налогами и сроком действия</td>
+                      <td class="py-3 text-muted">Карточка предложения, позиции, экспорт в PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Заказ</td>
+                      <td class="py-3 text-muted">Перевод предложения в заказ; превышение скидки или крупная сумма запускают согласование</td>
+                      <td class="py-3 text-muted">Заказ, процесс согласования, позиции</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Отгрузка</td>
+                      <td class="py-3 text-muted">После подтверждения заказа формируется накладная с привязкой к транспортному номеру</td>
+                      <td class="py-3 text-muted">Накладная, номер отправления, статусы</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Счёт</td>
+                      <td class="py-3 text-muted">Счёт выставляется по заказу или отгрузке; ИНН, адрес и реквизиты из карточки клиента подставляются автоматически</td>
+                      <td class="py-3 text-muted">Запись счёта, статус выставления</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Оплата</td>
+                      <td class="py-3 text-muted">Поступления регистрируются частями; KPI по дебиторке агрегируются по срокам</td>
+                      <td class="py-3 text-muted">Записи оплат, остаток дебиторки, корзины по возрасту долга</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл «Предложение → Заказ → Счёт → Оплата» с согласованиями и анализом дебиторки</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление коммерческими предложениями</h5>
+              <p class="text-muted mt-2">Предложения в нескольких валютах со скидками, налогами и сроком действия; экспорт в PDF в один клик; перевод в заказ.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Заказы на продажу</h5>
+              <p class="text-muted mt-2">Статусная модель (черновик / на согласовании / подтверждён / отгружен / закрыт), связи с клиентом и товаром, построчное редактирование позиций.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Согласование заказов</h5>
+              <p class="text-muted mt-2">Превышение скидки, крупная сумма или особые условия запускают согласование; этапы настраиваются по подразделению, должности и порогам.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Управление счетами</h5>
+              <p class="text-muted mt-2">Счёт формируется по заказу, статус выставления отслеживается; реквизиты, адрес и комментарии из карточки клиента подставляются автоматически, без ручного ввода.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Записи оплат</h5>
+              <p class="text-muted mt-2">Поступления регистрируются частями; остаток дебиторки рассчитывается автоматически; статусы оплат агрегируются по клиенту и заказу.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI по дебиторской задолженности</h5>
+              <p class="text-muted mt-2">Реестр просроченных платежей и анализ по возрасту долга (корзины 30 / 60 / 90 дней); агрегация по клиенту и менеджеру делает работу с долгами наглядной.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Мультивалютность и курсы</h5>
+              <p class="text-muted mt-2">Предложения и заказы в USD, EUR, CNY, RUB и других валютах; справочник курсов поддерживает ручное ведение или импорт; пересчёт в базовую валюту автоматический.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Отгрузка и доставка</h5>
+              <p class="text-muted mt-2">Накладная связана с заказом и транспортным номером; поддерживаются несколько отгрузок и частичная отгрузка; статус автоматически отражается в заказе.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд продаж</h5>
+              <p class="text-muted mt-2">Выручка, число заказов и доля поступлений в разрезе менеджеров, регионов и продуктов; помесячная и поквартальная динамика наглядны.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Help Desk», «Управление проектами», «Управление активами» и «HR».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/ru/solutions/ticketing-v2.astro
+++ b/src/pages/ru/solutions/ticketing-v2.astro
@@ -1,0 +1,349 @@
+---
+import BaseRU from "../../../layouts/BaseRU.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseRU
+  title="Help Desk (Тикеты) — открытая система клиентского сервиса | NocoBase"
+  description="Открытая тикет-система на базе NocoBase no-code платформы: приём обращений клиентов, автоматическая маршрутизация, учёт SLA, приоритеты, AI-классификация, оценка удовлетворённости, рабочее место оператора. Готова к использованию, подходит для команд клиентского и постпродажного сервиса."
+  keywords="тикет-система, help desk, ticketing, открытая тикет-система, управление обращениями, управление SLA, постпродажное обслуживание, клиентский сервис, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Тикеты)</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный цикл: <strong>приём обращения → маршрутизация → обработка → оценка удовлетворённости</strong> со встроенным учётом SLA, приоритетами, AI-классификацией и рабочим местом оператора.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Автоматический учёт SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 уровня приоритета</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI-классификация</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">Клиентский и постпродажный сервис</span>
+                  <span class="badge bg-soft-primary me-2">IT Service Desk</span>
+                  <span class="badge bg-soft-primary me-2">Сервисное обслуживание оборудования</span>
+                  <span class="badge bg-soft-primary">SaaS-поддержка</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Интерфейс Help Desk" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Процесс обработки тикета</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл от обращения клиента до закрытия с оценкой — SLA отсчитывается на каждом шаге</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Создание</div>
+                  <div class="small text-muted">Разные каналы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">AI-классификация</div>
+                  <div class="small text-muted">Распознавание темы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Маршрутизация</div>
+                  <div class="small text-muted">По правилам группы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Обработка</div>
+                  <div class="small text-muted">Учёт SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Оценка</div>
+                  <div class="small opacity-75">Закрытие и архив</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Создание</td>
+                      <td class="py-3 text-muted">Обращения по электронной почте, через форму или мессенджеры; привязка к клиенту и продукту</td>
+                      <td class="py-3 text-muted">Номер тикета, источник, карточка клиента</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">AI-классификация</td>
+                      <td class="py-3 text-muted">AI определяет тип проблемы (учётная запись / функционал / ошибка) и выставляет приоритет</td>
+                      <td class="py-3 text-muted">Категории, приоритет, оценка уверенности модели</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Маршрутизация</td>
+                      <td class="py-3 text-muted">Распределение по правилам на группу или оператора; срочные тикеты уведомляют дежурную смену</td>
+                      <td class="py-3 text-muted">Ответственный, история назначений, очередь группы</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Обработка</td>
+                      <td class="py-3 text-muted">Работа оператора и переписка с клиентом; учёт SLA с предупреждением до просрочки</td>
+                      <td class="py-3 text-muted">Журнал обработки, статус SLA, причина ожидания</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Оценка</td>
+                      <td class="py-3 text-muted">После закрытия клиенту отправляется оценка (от 1 до 5 + комментарий), агрегация по оператору и продукту</td>
+                      <td class="py-3 text-muted">Оценки, архив тикетов, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный охват работы с тикетами: от приёма обращения до закрытия</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Учёт SLA и предупреждения</h5>
+              <p class="text-muted mt-2">Время реакции и решения рассчитывается по приоритету; перед просрочкой система предупреждает, просроченные тикеты помечаются красным; процент выполнения SLA выводится на дашборд.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 уровня приоритета</h5>
+              <p class="text-muted mt-2">Срочный, высокий, средний, низкий — каждому соответствует своё время реакции; срочные тикеты автоматически поднимаются вверх и оповещают дежурного.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI-классификация</h5>
+              <p class="text-muted mt-2">AI определяет тип проблемы (вопрос по учётной записи, по функционалу, отчёт об ошибке и т. д.) и направляет тикет в соответствующую группу.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Детализация причин ожидания</h5>
+              <p class="text-muted mt-2">«Ожидание ответа клиента», «Ожидание стороннего поставщика», «Требуется согласование» — пока тикет в ожидании, SLA не отсчитывается, что справедливо к команде.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Рабочее место оператора</h5>
+              <p class="text-muted mt-2">После входа оператор видит назначенные ему тикеты, отсортированные по сроку; в одном окне — в работе, в очереди и близкие к просрочке.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд тикетов</h5>
+              <p class="text-muted mt-2">Поступления за день, закрытые, в работе, просроченные; агрегация по оператору, клиенту и продукту — руководителю видна вся картина.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Дополнительные функции в разработке</h5>
+              <p class="text-muted small mt-2 mb-0">Запланировано: оценка удовлетворенности, процесс передачи и эскалации, шаблоны ответов, интеграция с базой знаний</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Управление продажами», «Управление проектами», «Управление активами» и «HR».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseRU>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/ru/solutions/ticketing.astro
+++ b/src/pages/ru/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseRU from "../../../layouts/BaseRU.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-ru.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Эффективная и удобная система управления тикетами"
-  description="Система управления тикетами NocoBase служит важным дополнением к CRM, обеспечивая полное управление жизненным циклом тикетов, от создания контакта с клиентом до назначения и обработки тикетов, достигая полного цифрового управления процессом."
-  keywords="Система тикетов NocoBase, Управление тикетами, Система обслуживания клиентов, Послепродажное обслуживание, Назначение тикетов"
+<BaseRU
+  title="Help Desk (Тикеты) — открытая система клиентского сервиса | NocoBase"
+  description="Открытая тикет-система на базе NocoBase no-code платформы: приём обращений клиентов, автоматическая маршрутизация, учёт SLA, приоритеты, AI-классификация, оценка удовлетворённости, рабочее место оператора. Готова к использованию, подходит для команд клиентского и постпродажного сервиса."
+  keywords="тикет-система, help desk, ticketing, открытая тикет-система, управление обращениями, управление SLA, постпродажное обслуживание, клиентский сервис, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,336 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Эффективная и удобная<br/>система управления тикетами</h1>
-            <p class="para-desc text-muted">Система управления тикетами NocoBase служит важным дополнением к CRM, обеспечивая полное управление жизненным циклом тикетов. От создания контакта с клиентом до ввода тикета, назначения, обработки и отслеживания, достигая полного цифрового управления послепродажным обслуживанием.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Создано на NocoBase 1.x (2.0 в разработке)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/ru/solutions/all-in-one" class="text-muted small text-decoration-none">Единая система управления бизнесом</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">модуль Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk (Тикеты)</h1>
+            <p class="para-desc text-muted">
+              Решение на базе NocoBase no-code платформы. Полный цикл: <strong>приём обращения → маршрутизация → обработка → оценка удовлетворённости</strong> со встроенным учётом SLA, приоритетами, AI-классификацией и рабочим местом оператора.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Автоматический учёт SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 уровня приоритета</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI-классификация</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Open source, бесплатно</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Применение:</span>
-                  <span class="badge bg-soft-primary me-2">Обслуживание клиентов</span>
-                  <span class="badge bg-soft-primary">Послепродажная поддержка</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Сценарии применения:</span>
+                  <span class="badge bg-soft-primary me-2">Клиентский и постпродажный сервис</span>
+                  <span class="badge bg-soft-primary me-2">IT Service Desk</span>
+                  <span class="badge bg-soft-primary me-2">Сервисное обслуживание оборудования</span>
+                  <span class="badge bg-soft-primary">SaaS-поддержка</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Разработчик:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Демо
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Развернуть на своем сервере
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+              <a href="/ru/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Перейти к полному решению</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="Предварительный просмотр системы управления тикетами NocoBase" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Интерфейс Help Desk" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Возможности системы управления тикетами NocoBase</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Как важное дополнение к системе CRM, обеспечивает профессиональное управление обслуживанием клиентов и послепродажной поддержкой</p>
+            <h4 class="title mb-4">Процесс обработки тикета</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный цикл от обращения клиента до закрытия с оценкой — SLA отсчитывается на каждом шаге</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Полный жизненный цикл тикета</h5>
-              <p class="text-muted mt-2">От создания тикета, назначения, обработки до закрытия, полное управление процессом обеспечивает правильную обработку каждого тикета</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Умное назначение и отслеживание</h5>
-              <p class="text-muted mt-2">Автоматическое назначение задач на основе типов тикетов и навыков членов команды, отслеживание в реальном времени прогресса обработки и статуса</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Многоканальные записи коммуникации</h5>
-              <p class="text-muted mt-2">Интеграция электронной почты, телефона, онлайн-чата и других каналов связи, унифицированное управление записями коммуникации с клиентами</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Открытый исходный код, полный контроль данных</h5>
-              <p class="text-muted mt-2">Открытый исходный код, приватное развертывание данных, обеспечивая безопасность корпоративных данных и автономный контроль</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Попробовать сейчас
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Развернуть на своем сервере
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Учебное пособие по разработке системы тикетов</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Узнайте, как создать профессиональную систему управления тикетами с нуля, используя NocoBase</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Дизайн модели данных</h5>
-                <p class="text-muted text-center">Узнайте, как создавать базовые структуры данных и отношения для тикетов, клиентов, категорий и т.д.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Настройка рабочего процесса</h5>
-                <p class="text-muted text-center">Настройка назначения тикетов, переходов статуса и автоматизированных рабочих процессов обработки</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Уведомления и напоминания</h5>
-                <p class="text-muted text-center">Настройка электронных и системных уведомлений для обеспечения своевременной обработки тикетов</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Скоро</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Коммерческие плагины, используемые в системе тикетов</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Узнайте, как получить более мощные функции через коммерческие плагины для повышения профессионализма и удобства использования вашей системы тикетов</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_ru || plugin.name;
-          const displayDescription = plugin.description_ru || plugin.description;
-          const docsUrl = plugin.docs_ru || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">От <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Подробности</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Навсегда + 1 год обновлений</span><br>
-                          <a href="/ru/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted" style="font-size: 0.85rem;"> {plugin.price_1_year_rub ? plugin.price_1_year_rub.toLocaleString('ru-RU') : '?'} ₽ </span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Навсегда + обновления навсегда</span><br>
-                          <a class="text-muted" href="/ru/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted" style="font-size: 0.85rem;">{plugin.price_rub ? plugin.price_rub.toLocaleString('ru-RU') : '?'} ₽</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Создание</div>
+                  <div class="small text-muted">Разные каналы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">AI-классификация</div>
+                  <div class="small text-muted">Распознавание темы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Маршрутизация</div>
+                  <div class="small text-muted">По правилам группы</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Обработка</div>
+                  <div class="small text-muted">Учёт SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Оценка</div>
+                  <div class="small opacity-75">Закрытие и архив</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">Больше плагинов скоро</h6>
-                  <p class="text-muted small">Мы разрабатываем больше полезных коммерческих плагинов, следите за обновлениями</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Этап</th>
+                      <th class="border-0 py-3">Ключевые действия</th>
+                      <th class="border-0 py-3">Что фиксирует система</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Создание</td>
+                      <td class="py-3 text-muted">Обращения по электронной почте, через форму или мессенджеры; привязка к клиенту и продукту</td>
+                      <td class="py-3 text-muted">Номер тикета, источник, карточка клиента</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">AI-классификация</td>
+                      <td class="py-3 text-muted">AI определяет тип проблемы (учётная запись / функционал / ошибка) и выставляет приоритет</td>
+                      <td class="py-3 text-muted">Категории, приоритет, оценка уверенности модели</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Маршрутизация</td>
+                      <td class="py-3 text-muted">Распределение по правилам на группу или оператора; срочные тикеты уведомляют дежурную смену</td>
+                      <td class="py-3 text-muted">Ответственный, история назначений, очередь группы</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Обработка</td>
+                      <td class="py-3 text-muted">Работа оператора и переписка с клиентом; учёт SLA с предупреждением до просрочки</td>
+                      <td class="py-3 text-muted">Журнал обработки, статус SLA, причина ожидания</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Оценка</td>
+                      <td class="py-3 text-muted">После закрытия клиенту отправляется оценка (от 1 до 5 + комментарий), агрегация по оператору и продукту</td>
+                      <td class="py-3 text-muted">Оценки, архив тикетов, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/ru/plugins-commercial" class="btn btn-primary me-3">Посмотреть все коммерческие плагины</a>
-          <a href="/ru/commercial" class="btn btn-outline-primary">Цены</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Как использовать?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Три шага для быстрого развертывания системы CRM NocoBase с функциональностью управления тикетами в вашей среде</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Установить систему NocoBase</h5>
-                <p class="text-muted mt-2">Разверните систему NocoBase на вашем сервере, следуя нашей документации по установке</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Посмотреть руководство по установке</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Скачать шаблон системы CRM</h5>
-                <p class="text-muted mt-2">Скачайте полный шаблон CRM для получения возможностей управления тикетами</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Скачать SQL файл</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Скачать файл резервной копии (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Восстановить в системе</h5>
-                <p class="text-muted mt-2">Импортируйте файл шаблона CRM в вашу систему NocoBase для получения как возможностей CRM, так и управления тикетами</p>
-              </div>
-              <div class="mt-3">
-                <a href="/ru/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Учебное пособие по восстановлению</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Совет</h6>
-                <p class="mb-0 text-muted">Система управления тикетами полностью интегрирована в шаблон CRM как важный дополнительный модуль. После развертывания вы можете напрямую использовать полную функциональность управления тикетами в системе CRM для достижения полного управления обслуживанием клиентов.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Как расширить?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Дальнейшее расширение и настройка вашей системы управления тикетами на основе бизнес-потребностей</p>
+            <h4 class="title mb-4">Ключевые возможности</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Полный охват работы с тикетами: от приёма обращения до закрытия</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Управление типами тикетов и категориями</h5>
-                  <p class="text-muted mb-3">Создание различных категорий тикетов и правил обработки на основе бизнес-потребностей</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Скоро</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Учёт SLA и предупреждения</h5>
+              <p class="text-muted mt-2">Время реакции и решения рассчитывается по приоритету; перед просрочкой система предупреждает, просроченные тикеты помечаются красным; процент выполнения SLA выводится на дашборд.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Командная работа</h5>
-                  <p class="text-muted mb-3">Настройка ролей команды, разрешений и совместных рабочих процессов</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Скоро</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 уровня приоритета</h5>
+              <p class="text-muted mt-2">Срочный, высокий, средний, низкий — каждому соответствует своё время реакции; срочные тикеты автоматически поднимаются вверх и оповещают дежурного.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Статистические отчеты и аналитика</h5>
-                  <p class="text-muted mb-3">Создание аналитических отчетов для статуса обработки тикетов и эффективности</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Скоро</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI-классификация</h5>
+              <p class="text-muted mt-2">AI определяет тип проблемы (вопрос по учётной записи, по функционалу, отчёт об ошибке и т. д.) и направляет тикет в соответствующую группу.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Интеграция с системой CRM</h5>
-                  <p class="text-muted mb-3">Безупречная интеграция с существующими системами CRM для обмена данными</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Скоро</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Детализация причин ожидания</h5>
+              <p class="text-muted mt-2">«Ожидание ответа клиента», «Ожидание стороннего поставщика», «Требуется согласование» — пока тикет в ожидании, SLA не отсчитывается, что справедливо к команде.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Рабочее место оператора</h5>
+              <p class="text-muted mt-2">После входа оператор видит назначенные ему тикеты, отсортированные по сроку; в одном окне — в работе, в очереди и близкие к просрочке.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Дашборд тикетов</h5>
+              <p class="text-muted mt-2">Поступления за день, закрытые, в работе, просроченные; агрегация по оператору, клиенту и продукту — руководителю видна вся картина.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Дополнительные функции в разработке</h5>
+              <p class="text-muted small mt-2 mb-0">Запланировано: оценка удовлетворенности, процесс передачи и эскалации, шаблоны ответов, интеграция с базой знаний</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Готовы использовать систему управления тикетами NocoBase?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Разверните выделенную демонстрацию управления тикетами за 1 минуту. Как важное дополнение к CRM, достигните полной системы обслуживания клиентов для улучшения удовлетворенности клиентов и эффективности обслуживания.
-          </p>
-          <div class="mt-4">
-            <a href="https://my.nocobase.ru/" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Демо
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Развернуть на своем сервере
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Скачивание и развёртывание</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Этот модуль входит в шаблон резервной копии единой системы управления бизнесом — разворачивается одним пакетом</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Скачать шаблон резервной копии</h5>
+                <p class="text-muted mt-2">Резервная копия единого решения: после восстановления доступны предзаполненные данные по всем шести модулям, включая этот</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Скачать .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Или скачать SQL-архив</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Изучить документацию по установке</h5>
+                <p class="text-muted mt-2">Подробные шаги восстановления, частые вопросы и важные нюансы — материал готовится</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Скоро</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Начать работу</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Модуль входит в состав <a href="/ru/solutions/all-in-one">единой системы управления бизнесом</a>: его можно использовать отдельно или совместно с модулями CRM, «Управление продажами», «Управление проектами», «Управление активами» и «HR».</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Попробовать Demo</a>
+            <a href="/ru/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Связаться с нами</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseRU>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>

--- a/src/pages/tw/solutions/all-in-one.astro
+++ b/src/pages/tw/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseTW from "../../../layouts/BaseTW.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseTW
+  title="整合式業務管理系統 - CRM / 工單 / 專案管理 / 固定資產 / HR | NocoBase"
+  description="開源整合式業務管理系統：CRM 客戶管理、銷售管理、工單系統、專案管理、固定資產管理、HR 人事管理 6 大模組全面整合。基於 NocoBase 無程式碼平台，開箱即用，適合中小團隊快速上線。"
+  keywords="整合式業務管理系統, CRM 系統, 開源 CRM, 工單系統, 客服工單系統, 專案管理系統, 固定資產管理系統, IT 資產管理, HR 系統, 人事管理系統, 銷售管理系統, 無程式碼 ERP, 多合一管理系統, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">整合式<br/>業務管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建，涵蓋 <strong>CRM 客戶管理、銷售管理、工單系統、專案管理、固定資產管理、HR 人事管理</strong> 六大模組。
+              開箱即用，無需複雜選型與多套系統整合。
+            </p>
+
+            <!-- 核心價值 -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">多系統整合</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">20+ 語系內建支援</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI 員工 + 工作流</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">開源免費</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- 適用場景標籤 -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">新創公司</span>
+                  <span class="badge bg-soft-primary me-2">多業務線門市</span>
+                  <span class="badge bg-soft-primary me-2">業務探索期</span>
+                  <span class="badge bg-soft-primary">教學與培訓</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>立即體驗 Demo
+              </a>
+              <a href="/tw/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>聯絡諮詢
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="整合式業務管理系統" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 模組協同</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM、銷售管理、工單系統、專案管理、固定資產管理、HR 人事管理，全部業務流程在同一系統內閉環</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- 客戶管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM 客戶管理</h5>
+              <p class="text-muted mt-2">開源 CRM 系統：線索、跟進、轉化、合併去重的完整流程；客戶 360 視圖彙整訂單、工單、專案、資產等歷史紀錄。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>線索階段管理與轉化</li>
+                <li><i class="uil uil-check text-primary me-1"></i>客戶 360 詳細視圖</li>
+                <li><i class="uil uil-check text-primary me-1"></i>合併／去重工具</li>
+              </ul>
+              <a href="/tw/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 銷售套件 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">銷售管理</h5>
+              <p class="text-muted mt-2">銷售訂單管理：報價、訂單、發票、收款的完整鏈路；內建簽核流程與應收帳款分析。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>多幣別報價</li>
+                <li><i class="uil uil-check text-primary me-1"></i>訂單簽核工作流</li>
+                <li><i class="uil uil-check text-primary me-1"></i>逾期帳款 KPI</li>
+              </ul>
+              <a href="/tw/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 工單系統 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工單系統</h5>
+              <p class="text-muted mt-2">客服工單系統：客戶報修、派工、處理與滿意度評價；支援 SLA 計時、優先級管理與等待原因細分。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>SLA 自動計時與逾時通知</li>
+                <li><i class="uil uil-check text-primary me-1"></i>工單儀表板 + 團隊工作台</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 級優先級 + AI 智慧分類</li>
+              </ul>
+              <a href="/tw/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 專案管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">專案管理</h5>
+              <p class="text-muted mt-2">輕量專案管理系統：專案與任務的兩級管理；涵蓋負責人、進度、里程碑與延期預警。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>專案狀態看板</li>
+                <li><i class="uil uil-check text-primary me-1"></i>任務負責人工作量</li>
+                <li><i class="uil uil-check text-primary me-1"></i>延期專案提醒</li>
+              </ul>
+              <a href="/tw/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- 資產管理 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">固定資產管理</h5>
+              <p class="text-muted mt-2">IT 資產與辦公資產的全生命週期管理，涵蓋採購、分配、維護、報廢，配套供應商台帳。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>資產分配／歸還</li>
+                <li><i class="uil uil-check text-primary me-1"></i>維護工單</li>
+                <li><i class="uil uil-check text-primary me-1"></i>採購供應商分析</li>
+              </ul>
+              <a href="/tw/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- HR 人事 -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">HR 人事管理</h5>
+              <p class="text-muted mt-2">人力資源管理系統：員工台帳，到職、離職、請假、試用期追蹤，配合職位與部門組織結構。</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>到職／離職清單</li>
+                <li><i class="uil uil-check text-primary me-1"></i>請假簽核</li>
+                <li><i class="uil uil-check text-primary me-1"></i>試用期員工看板</li>
+              </ul>
+              <a href="/tw/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">了解更多 <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">平台底座能力</h4>
+            <p class="para-desc mx-auto text-muted mb-0">基於 NocoBase 2.x，內建 AI、工作流、多語系與多空間能力</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI 員工</h5>
+            <p class="text-muted small">Lina（在地化）、Lexi（翻譯）、Atlas（協作）等內建 AI 角色，依業務場景呼叫。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>多語系支援</h5>
+            <p class="text-muted small">中、英、日、韓、德、法等 20+ 語系內建支援，全量 UI 已完成翻譯。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>工作流引擎</h5>
+            <p class="text-muted small">簽核、通知、SLA 計時、定時觸發；視覺化編排，無需編碼即可設定規則。</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>多空間隔離</h5>
+            <p class="text-muted small">一套系統服務多個團隊或門市，資料相互隔離，權限獨立管理。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">AI 協作</span>
+            <h4 class="title mb-4">內建 AI 員工</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 位預置 AI 員工涵蓋典型業務角色，支援透過 MCP 協定接入外部 Agent 擴充能力</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">團隊負責人 — 任務派發與協作編排</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">前端工程師 — 介面與 JS 區塊程式碼生成</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">視覺化設計 — 圖表與看板搭建</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">洞察分析 — 趨勢識別與 KPI 解讀</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">調研分析 — 資訊蒐集與摘要</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">資料整理 — 清洗合併與批次整理</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">翻譯溝通 — 多語系客戶對話與郵件</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">在地化工程師 — 介面文案與 i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">郵件助理 — 意圖分析與回覆草擬</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">自訂 AI 員工</h6>
+              <p class="text-muted small mb-0">依業務需求建立專屬角色／提示詞／技能組合</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/cn/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">外部 Agent 接入</h6>
+              <p class="text-muted small mb-0">MCP 協定連接你自己的 Agent／工具鏈</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">適用場景</h4>
+            <p class="para-desc mx-auto text-muted mb-0">整合方案在以下場景中尤為適用</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>跨業務線全局管理</h5>
+                  <p class="text-muted mb-0">業務橫跨銷售、客服、專案多條線，需要在統一系統中查看全局，避免在多套獨立工具間切換。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>多業務線門市</h5>
+                  <p class="text-muted mb-0">門市同時承擔銷售、售後與專案交付，業務條線繁多但規模有限，獨立方案的協同成本較高。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>業務探索階段</h5>
+                  <p class="text-muted mb-0">業務尚未定型，避免過早鎖定特定方案；整合平台可先行投入使用，再依需求迭代。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>教學／培訓／POC</h5>
+                  <p class="text-muted mb-0">作為 NocoBase 平台能力的完整示例，可用於內部培訓、方案演示或概念驗證，涵蓋典型業務流程。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">如何使用？</h4>
+            <p class="para-desc mx-auto text-muted mb-0">三步完成部署，開始使用整合式業務管理系統</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>安裝 NocoBase</h5>
+                <p class="text-muted mt-2">依官方安裝文件，將 NocoBase 部署到本機或伺服器環境</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝文件</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">還原後即可使用全套預置資料，完整 6 大模組</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">開始使用整合式業務管理系統</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            基於 NocoBase 2.x 構建的整合型業務系統。範本支援直接複用與擴充；如需面向特定業務的深度客製，歡迎與我們聯絡。
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>立即體驗 Demo
+            </a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>聯絡諮詢
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseTW>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/tw/solutions/asset-management.astro
+++ b/src/pages/tw/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseTW from "../../../layouts/BaseTW.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseTW
+  title="固定資產管理系統 — 開源 IT 資產與辦公資產管理 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源固定資產管理系統：採購、分配、維護、報廢全生命週期管理，涵蓋 IT 資產、辦公資產，內建供應商台帳、維護工單、採購分析。"
+  keywords="固定資產管理, IT 資產管理, 資產管理系統, 開源資產管理, 辦公資產管理, 固定資產管理系統, 資產生命週期, 設備管理系統, 資產盤點, 供應商管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">固定資產管理模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">固定資產管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。<strong>採購 → 分配 → 維護 → 報廢</strong> 的全生命週期管理，涵蓋 IT 資產與辦公資產，配套供應商台帳與維護工單。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">全生命週期</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">維護工單</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">供應商台帳</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">IT 資產</span>
+                  <span class="badge bg-soft-primary me-2">辦公資產</span>
+                  <span class="badge bg-soft-primary me-2">設備出租</span>
+                  <span class="badge bg-soft-primary">資產盤點</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="固定資產管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">資產生命週期</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從採購入庫到報廢註銷的完整閉環，每件資產可追溯</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">採購</div>
+                  <div class="small text-muted">關聯供應商</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">入庫</div>
+                  <div class="small text-muted">資產卡片</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">分配</div>
+                  <div class="small text-muted">簽字留痕</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">維護</div>
+                  <div class="small text-muted">工單關聯</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">報廢</div>
+                  <div class="small opacity-75">殘值留檔</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">採購</td>
+                      <td class="py-3 text-muted">採購單關聯供應商與價格；支援多品類、多數量</td>
+                      <td class="py-3 text-muted">採購單、供應商、採購金額</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">入庫</td>
+                      <td class="py-3 text-muted">入庫自動產生資產卡片（編號、序號、保固期一次鍵入）</td>
+                      <td class="py-3 text-muted">資產卡片、唯一編號、保固期</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">分配</td>
+                      <td class="py-3 text-muted">資產借給員工／客戶／部門，簽字確認</td>
+                      <td class="py-3 text-muted">分配紀錄、使用人、起迄日期</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">維護</td>
+                      <td class="py-3 text-muted">故障／保養發起維護工單，關聯資產卡片</td>
+                      <td class="py-3 text-muted">維護工單、累計成本</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">報廢</td>
+                      <td class="py-3 text-muted">報廢登記原因（損壞／淘汰／出售），紀錄折舊／殘值</td>
+                      <td class="py-3 text-muted">報廢紀錄、殘值、處置方式</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從採購到報廢的完整固定資產管理</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">資產採購</h5>
+              <p class="text-muted mt-2">採購單關聯供應商與價格；入庫自動產生資產卡片，資產編號、序號、保固期一次鍵入。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分配／歸還</h5>
+              <p class="text-muted mt-2">資產借給員工／客戶，簽字留痕；歸還登記自動釋放；每件資產的「使用歷史」完整追溯。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">維護工單</h5>
+              <p class="text-muted mt-2">資產故障／保養發起維護工單，關聯資產卡片；維護紀錄累計成本，輔助報廢決策。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">報廢／出售</h5>
+              <p class="text-muted mt-2">資產報廢登記原因（損壞／淘汰／出售）；折舊／殘值紀錄留檔，與財務對帳一致。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">供應商台帳</h5>
+              <p class="text-muted mt-2">供應商檔案 + 歷史採購紀錄；採購金額、品類、付款條件一目了然，輔助招採決策。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">資產看板</h5>
+              <p class="text-muted mt-2">資產總數、在用、維護中、報廢分布；按類型、按部門、按使用人彙整，盤點資料一鍵匯出。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">更多功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">規劃中：盤點任務、折舊自動計算、QR Code 掃碼、借用申請審核流程</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、銷售管理、工單系統、專案管理、HR 協同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseTW>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/tw/solutions/crm-v2.astro
+++ b/src/pages/tw/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
 import BaseTW from "../../../layouts/BaseTW.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
 <BaseTW
-  title="CRM 2.0 銷售管理系統 - NocoBase"
-  description="基於 NocoBase 無代碼平臺的 CRM 2.0 銷售管理系統，模塊可拆解，完整銷售閉環。支持線索評分、商機贏率預測等 AI 輔助功能。"
-  keywords="NocoBase CRM, AI CRM, 銷售管理, 商機管理, 客戶關係管理, 線索管理, 無代碼 CRM"
+  title="CRM 客戶管理系統 — 開源、可自架 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源 CRM 系統：線索管理、客戶跟進、轉化、合併去重、客戶 360 視圖。開箱即用，支援自架部署。"
+  keywords="CRM 系統, 開源 CRM, 客戶管理系統, 客戶關係管理, 線索管理, 客戶跟進, 客戶 360, 無程式碼 CRM, 自架 CRM, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>銷售管理系統</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM 模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>客戶管理系統</h1>
             <p class="para-desc text-muted">
-              基於 NocoBase 無代碼平臺構建，模塊可拆解，完整銷售閉環。工作流自動化處理日常任務，AI 輔助線索評分、商機分析等工作。
+              基於 NocoBase 無程式碼平台構建。涵蓋線索、跟進、轉化、合併去重的完整流程，客戶 360 視圖彙整訂單、工單、專案、資產歷史紀錄。
             </p>
 
-            <!-- 核心價值 -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">線索智能評分</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">商機贏率預測</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">客戶健康監控</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">模塊可拆解</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">線索階段管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">客戶 360 視圖</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">合併／去重</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
             </div>
 
-            <!-- 適用場景標籤 -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
                   <span class="text-muted me-2">適用場景：</span>
                   <span class="badge bg-soft-primary me-2">B2B 銷售</span>
-                  <span class="badge bg-soft-primary me-2">項目型銷售</span>
-                  <span class="badge bg-soft-primary me-2">外貿銷售</span>
-                  <span class="badge bg-soft-primary">全行業</span>
+                  <span class="badge bg-soft-primary me-2">專案型銷售</span>
+                  <span class="badge bg-soft-primary me-2">外貿</span>
+                  <span class="badge bg-soft-primary">中小團隊</span>
                 </div>
               </div>
             </div>
 
-            <!-- 按鈕 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>線上示範
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>如何使用
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 系統界面"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">您是否面臨這些問題？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">銷售團隊在日常運營中面臨多重挑戰</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 客戶管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">線索質量參差不齊</h5>
-              </div>
-              <p class="text-muted mb-0">市場獲取的大量線索質量不一，銷售浪費大量時間在低質量線索上，高價值線索卻被忽略。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">商機跟進不及時</h5>
-              </div>
-              <p class="text-muted mb-0">商機長時間未推進，銷售經理難以掌握團隊商機健康度，錯失最佳成交時機。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">客戶信息分散</h5>
-              </div>
-              <p class="text-muted mb-0">客戶數據散落在郵件、聊天、文檔中，無法形成完整畫像，難以進行精準營銷。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">銷售預測不準確</h5>
-              </div>
-              <p class="text-muted mb-0">憑經驗預測業績，缺乏數據支撐，預測偏差大，影響公司資源配置和決策。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">SaaS 成本高昂</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce、HubSpot 等 SaaS CRM 按人頭收費，定製開發週期長、成本難以預估。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">數據安全顧慮</h5>
-              </div>
-              <p class="text-muted mb-0">客戶信息、商機數據存儲在第三方雲端，不符合數據本地化和隱私保護的合規要求。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">我們的解決方案</h4>
-            <p class="para-desc mx-auto text-muted mb-0">基於 NocoBase 無代碼平臺構建的 CRM 2.0 系統，工作流自動化 + AI 輔助</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 核心模塊 -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">線索智能評分</h5>
-              <p class="text-muted mt-2">自動評估線索質量，優先分配高價值線索，推薦最佳聯繫時間</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">商機贏率預測</h5>
-              <p class="text-muted mt-2">基於歷史數據預測成交概率，識別風險商機，提供階段推進建議</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">客戶健康監控</h5>
-              <p class="text-muted mt-2">360 度客戶畫像，健康度評分，流失風險預警，主動維護關係</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">模塊可拆解</h5>
-              <p class="text-muted mt-2">各模塊獨立設計，最小配置僅需客戶+商機，按需裁剪成不同規模方案</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">核心設計</span>
-            <h4 class="title mb-4">完整銷售閉環流程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">從線索獲取到客戶成功，全鏈路數據貫通，AI 輔助每個環節</p>
+            <h4 class="title mb-4">客戶管理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從線索接入到客戶 360 視圖，資料全鏈路打通</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- 流程圖 -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">線索</div>
-                  <div class="small text-muted">AI 評分</div>
+                  <div class="small text-muted">多渠道接入</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">客戶</div>
-                  <div class="small text-muted">360 畫像</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">聯絡跟進</div>
+                  <div class="small text-muted">紀錄留痕</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">商機</div>
-                  <div class="small text-muted">贏率預測</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">轉化客戶</div>
+                  <div class="small text-muted">建立檔案</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">報價</div>
-                  <div class="small text-muted">多幣種</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">客戶 360</div>
+                  <div class="small text-muted">全貌彙整</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">訂單</div>
-                  <div class="small opacity-75">回款跟蹤</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">資料沉澱</div>
+                  <div class="small opacity-75">銷售看板</div>
                 </div>
               </div>
 
-              <!-- 階段說明 -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">階段轉化</th>
-                      <th class="border-0 py-3">觸發條件</th>
-                      <th class="border-0 py-3">AI 輔助</th>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">線索 → 客戶</td>
-                      <td class="py-3 text-muted">確認為有效商機</td>
-                      <td class="py-3 text-primary">AI 評分達標自動提醒轉化</td>
+                      <td class="py-3">線索</td>
+                      <td class="py-3 text-muted">表單／匯入／手動鍵入，標記來源與歸屬業務</td>
+                      <td class="py-3 text-muted">線索池、來源標籤、階段流轉</td>
                     </tr>
                     <tr>
-                      <td class="py-3">客戶 → 商機</td>
-                      <td class="py-3 text-muted">識別到明確需求</td>
-                      <td class="py-3 text-primary">AI 分析客戶意向，推薦創建商機</td>
+                      <td class="py-3">聯絡跟進</td>
+                      <td class="py-3 text-muted">電話、郵件、拜訪登記，設定下次跟進時間</td>
+                      <td class="py-3 text-muted">跟進時間軸、下次提醒</td>
                     </tr>
                     <tr>
-                      <td class="py-3">商機 → 報價</td>
-                      <td class="py-3 text-muted">進入方案報價階段</td>
-                      <td class="py-3 text-primary">AI 智能定價、競品對比、階梯報價建議</td>
+                      <td class="py-3">轉化客戶</td>
+                      <td class="py-3 text-muted">線索轉客戶，填入客戶檔案（行業／規模／聯絡人）</td>
+                      <td class="py-3 text-muted">客戶表、聯絡人表、關聯線索</td>
                     </tr>
                     <tr>
-                      <td class="py-3">報價 → 訂單</td>
-                      <td class="py-3 text-muted">客戶接受報價</td>
-                      <td class="py-3 text-primary">自動生成訂單，帶入產品明細和價格</td>
+                      <td class="py-3">客戶 360</td>
+                      <td class="py-3 text-muted">查看客戶全貌：訂單、工單、專案、資產</td>
+                      <td class="py-3 text-muted">嵌入式區塊、跨模組關聯</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">資料沉澱</td>
+                      <td class="py-3 text-muted">銷售看板按業務／地區／類型彙整 KPI</td>
+                      <td class="py-3 text-muted">圖表、明細鑽取、匯出</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI 輔助</span>
-            <h4 class="title mb-4">AI 輔助能力</h4>
-            <p class="para-desc mx-auto text-muted mb-0">通過工作流 AI 節點，輔助完成評分、分析、寫作等重複性工作</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">線索、客戶、跟進、看板，完整涵蓋客戶關係管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">工作流節點</span></h5>
-              <span class="badge bg-soft-primary mb-2">銷售偵察</span>
-              <p class="text-muted mt-2 small">商機深度分析、贏率預測、競爭情報分析、交易策略建議</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">線索匯入</h5>
+              <p class="text-muted mt-2">Excel 批次匯入、表單收集、API 接入三種方式；欄位對應視覺化設定，匯入衝突自動去重。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">洞察分析師</span>
-              <p class="text-muted mt-2 small">線索智能評分、客戶健康評估、銷售數據分析、管道預測</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">階段流轉</h5>
+              <p class="text-muted mt-2">線索階段（新建／已聯絡／已轉化／已放棄）視覺化設定；階段變更自動留痕，轉化率統計自動跑。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">編輯助手</span>
-              <p class="text-muted mt-2 small">郵件情感/意圖分析、回覆草擬、溝通記錄摘要</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟進紀錄</h5>
+              <p class="text-muted mt-2">每次拜訪、電話、郵件留下紀錄；時間軸查看完整溝通歷史，接手交接零摩擦。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">日程規劃</span>
-              <p class="text-muted mt-2 small">每日優先事項、下一步行動建議、跟進計劃制定</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟進提醒</h5>
+              <p class="text-muted mt-2">下次跟進時間到期前自動通知；長期未聯絡的客戶列入「待激活」看板，避免遺忘。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻譯官</span>
-              <p class="text-muted mt-2 small">多語言客戶溝通、內容翻譯、外貿郵件處理</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客戶 360 視圖</h5>
+              <p class="text-muted mt-2">客戶詳情彙整訂單、工單、專案、資產紀錄；一螢幕看清客戶全貌，不用切多個系統。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- 更多員工 -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">更多 AI 員工</h5>
-              <span class="badge bg-soft-secondary mb-2">持續擴展</span>
-              <p class="text-muted mt-2 small">根據業務需求，可擴展更多專業 AI 員工</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分類與標籤</h5>
+              <p class="text-muted mt-2">客戶類型、行業、規模、來源多維度標籤；支援按標籤篩選、彙整分析。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">靈活架構</span>
-            <h4 class="title mb-4">模塊可拆解設計</h4>
-            <p class="para-desc mx-auto text-muted mb-0">各模塊獨立設計，可單獨開關，企業可按需裁剪成不同規模的方案</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">模塊</th>
-                  <th class="border-0 py-3">必需</th>
-                  <th class="border-0 py-3">說明</th>
-                  <th class="border-0 py-3">AI 能力</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">客戶管理</td>
-                  <td class="py-3"><span class="badge bg-success">必需</span></td>
-                  <td class="py-3 text-muted">客戶檔案、聯繫人、客戶層級、決策鏈</td>
-                  <td class="py-3 text-primary">健康評分、流失預警</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">商機管理</td>
-                  <td class="py-3"><span class="badge bg-success">必需</span></td>
-                  <td class="py-3 text-muted">銷售漏斗、階段推進、活動記錄</td>
-                  <td class="py-3 text-primary">贏率預測、風險識別</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">線索管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可選</span></td>
-                  <td class="py-3 text-muted">線索錄入、狀態流轉、轉化跟蹤</td>
-                  <td class="py-3 text-primary">智能評分、最佳聯繫時間</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">報價管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可選</span></td>
-                  <td class="py-3 text-muted">多幣種、階梯定價、版本管理、審批流程</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">訂單管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可選</span></td>
-                  <td class="py-3 text-muted">訂單生成、回款跟蹤</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">產品管理</td>
-                  <td class="py-3"><span class="badge bg-secondary">可選</span></td>
-                  <td class="py-3 text-muted">產品目錄、分類、階梯價格</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">郵件集成</td>
-                  <td class="py-3"><span class="badge bg-secondary">可選</span></td>
-                  <td class="py-3 text-muted">郵件收發、CRM 關聯</td>
-                  <td class="py-3 text-primary">摘要生成、情感分析</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- 方案裁剪示例 -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">完整版</span>
-                  <p class="small text-muted mb-0">全部 7 個模塊<br/>流程完整的 B2B 銷售團隊</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">標準版</span>
-                  <p class="small text-muted mb-0">客戶+商機+報價+訂單<br/>中小企業銷售管理</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">輕量版</span>
-                  <p class="small text-muted mb-0">客戶+商機<br/>簡單的客戶和商機跟蹤</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">外貿版</span>
-                  <p class="small text-muted mb-0">客戶+商機+報價+郵件<br/>外貿型企業</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">合併去重</h5>
+              <p class="text-muted mt-2">同一客戶多次鍵入自動識別；一鍵合併，歷史跟進與關聯紀錄無損歸併。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">銷售看板</h5>
+              <p class="text-muted mt-2">按業務、地區、客戶類型彙整 KPI；新增客戶數、轉化率、活躍客戶分布。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">欄位與列級權限</h5>
+              <p class="text-muted mt-2">基於角色設定可見欄位；業務只看自己負責客戶，管理者看全部。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">自動化帶來的價值</h4>
-            <p class="para-desc mx-auto text-muted mb-0">工作流自動化 + AI 輔助，減少重複工作，讓銷售專注於客戶關係</p>
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">線索篩選效率提升</h5>
-              <p class="text-muted small mb-0">AI 自動評分減少人工篩選時間</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">商機跟進效率提升</h5>
-              <p class="text-muted small mb-0">贏率預測幫助聚焦高價值商機</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">客戶流失率降低</h5>
-              <p class="text-muted small mb-0">健康評估提前識別流失風險</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">銷售轉化率提升</h5>
-              <p class="text-muted small mb-0">AI 策略建議加速成交</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">為什麼選擇我們？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">與傳統 SaaS CRM 和自研系統的對比</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">對比維度</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">自研系統</th>
-                  <th class="border-0 py-3 text-primary">NocoBase 方案</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">上線速度</td>
-                  <td class="py-3 text-muted">開箱即用</td>
-                  <td class="py-3 text-muted">數月開發</td>
-                  <td class="py-3 text-primary">配置即用，快速上線</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">定製能力</td>
-                  <td class="py-3 text-muted">受限</td>
-                  <td class="py-3 text-muted">完全可控</td>
-                  <td class="py-3 text-primary">無代碼靈活定製</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">數據安全</td>
-                  <td class="py-3 text-muted">雲端託管</td>
-                  <td class="py-3 text-muted">私有部署</td>
-                  <td class="py-3 text-primary">私有部署，數據完全掌控</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI 輔助</td>
-                  <td class="py-3 text-muted">有限/加價</td>
-                  <td class="py-3 text-muted">需自行開發</td>
-                  <td class="py-3 text-primary">工作流 AI 節點，按需使用</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">模塊靈活性</td>
-                  <td class="py-3 text-muted">功能捆綁</td>
-                  <td class="py-3 text-muted">需代碼修改</td>
-                  <td class="py-3 text-primary">模塊可拆解，按需裁剪</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">總體成本</td>
-                  <td class="py-3 text-muted">按人頭訂閱</td>
-                  <td class="py-3 text-muted">開發成本高</td>
-                  <td class="py-3 text-primary">一次購買，長期使用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三個步驟快速部署 CRM 2.0 系統到你的環境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安裝 NocoBase</h5>
-                <p class="text-muted mt-2">按照我們的安裝文檔，部署 NocoBase 到你的服務器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝文檔</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>瞭解方案</h5>
-                <p class="text-muted mt-2">閱讀方案介紹文檔，瞭解系統功能、架構設計和使用場景</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/crm/" target="_blank" class="btn btn-outline-primary">方案介紹</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>還原到系統</h5>
-                <p class="text-muted mt-2">按照還原教程，將 CRM 2.0 系統部署到你的 NocoBase 環境</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/crm/installation" target="_blank" class="btn btn-outline-primary">還原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">開始使用 CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            基於 NocoBase 2.x 構建的模塊化 CRM 系統。如果您有定製需求或想了解更多細節，歡迎聯繫我們。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與銷售管理、工單系統、專案管理、固定資產管理、HR 協同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/tw/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>聯繫我們
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseTW>
 
 <style>
-/* CRM 2.0 頁面樣式 */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI 員工頭像樣式 */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/tw/solutions/crm.astro
+++ b/src/pages/tw/solutions/crm.astro
@@ -1,55 +1,13 @@
 ---
 import BaseTW from "../../../layouts/BaseTW.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// 導入交互演示數據
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-cn.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-cn.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-cn.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-cn.json";
-
-// 獲取插件數據
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定義CRM中使用的插件名稱映射
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// 根據插件名稱匹配插件數據
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 獲取CRM相關插件
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 調試信息
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseTW
-  title="無代碼、靈活且強大的 CRM 基座"
-  description="開箱即用。提供極致的定製能力，且完全保障數據主權。你可以在此基礎上任意擴展字段、區塊、功能及頁面，使其完全符合你的業務需求。"
-  keywords="NocoBase CRM, 客戶關係管理, 無代碼CRM, 開源CRM, 自定義CRM"
+  title="CRM 客戶管理系統 — 開源、可自架 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源 CRM 系統：線索管理、客戶跟進、轉化、合併去重、客戶 360 視圖。開箱即用，支援自架部署。"
+  keywords="CRM 系統, 開源 CRM, 客戶管理系統, 客戶關係管理, 線索管理, 客戶跟進, 客戶 360, 無程式碼 CRM, 自架 CRM, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -57,949 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">無代碼、靈活且強大的<br/>CRM 基座</h1>
-
-            <p class="para-desc text-muted">開箱即用。提供極致的定製能力，且完全保障數據主權。你可以在此基礎上任意擴展字段、區塊、功能及頁面，使其完全符合你的業務需求。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基於 NocoBase 1.x 搭建（2.0 準備中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">CRM 模組</span>
             </div>
-            
-            <!-- 標籤 -->
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>客戶管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。涵蓋線索、跟進、轉化、合併去重的完整流程，客戶 360 視圖彙整訂單、工單、專案、資產歷史紀錄。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">線索階段管理</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">客戶 360 視圖</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">合併／去重</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
+            </div>
+
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">適用行業：</span>
-                  <span class="badge bg-soft-primary">全行業</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">B2B 銷售</span>
+                  <span class="badge bg-soft-primary me-2">專案型銷售</span>
+                  <span class="badge bg-soft-primary me-2">外貿</span>
+                  <span class="badge bg-soft-primary">中小團隊</span>
                 </div>
               </div>
             </div>
 
-            <!-- 開發者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開發者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- 按鈕 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>線上示範
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>複製到您的環境
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM 預覽視頻 -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-cn-compress.mp4" type="video/mp4">
-                你的瀏覽器不支持 HTML5 視頻。
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="CRM 客戶管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase CRM 的獨特之處</h4>
-            <p class="para-desc mx-auto text-muted mb-0">與 SaaS 和其他 CRM 系統不同，NocoBase CRM 靈活且完全掌控</p>
+            <h4 class="title mb-4">客戶管理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從線索接入到客戶 360 視圖，資料全鏈路打通</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完全無代碼構建</h5>
-              <p class="text-muted mt-2">無需編程技能，也能對 CRM 進行個性化改造</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">涵蓋市面上 CRM 常用功能</h5>
-              <p class="text-muted mt-2">客戶管理、銷售管道、商機跟進、聯繫人管理、郵件溝通、 審批流程等功能模塊</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">可以任意修改且極易擴展</h5>
-              <p class="text-muted mt-2">支持自定義字段、流程和業務邏輯，靈活的架構設計讓"二次開發"變得簡單</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">開源，數據完全掌控</h5>
-              <p class="text-muted mt-2">對系統代碼和系統數據完全掌控，確保企業數據安全</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">試試 NocoBase CRM 的功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">幾次點擊，快速體驗</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">儀表板數據展示</h5>
-              <!-- 交互演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- 背景圖片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按鈕 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>互動演示
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">線索</div>
+                  <div class="small text-muted">多渠道接入</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">聯絡跟進</div>
+                  <div class="small text-muted">紀錄留痕</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">轉化客戶</div>
+                  <div class="small text-muted">建立檔案</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">客戶 360</div>
+                  <div class="small text-muted">全貌彙整</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">資料沉澱</div>
+                  <div class="small opacity-75">銷售看板</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">線索轉化流程</h5>
-              <!-- 線索轉化演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- 背景圖片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按鈕 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>互動演示
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">商機轉化為訂單</h5>
-              <!-- 商機轉化演示入口 -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- 背景圖片 -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- 按鈕 -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>互動演示
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Try CRM Extension Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- 使用擴展功能交互演示 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即體驗
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>複製到自己的環境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try CRM Extension End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM 開發與擴展教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">學習如何使用 NocoBase 構建和擴展專業的 CRM 系統</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">基礎搭建與自定義</h5>
-                <p class="text-muted text-center">學習創建數據模型、自定義字段關係、配置權限和界面佈局</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">數據分析與可視化</h5>
-                <p class="text-muted text-center">構建銷售數據分析儀表板，實現業績監控和數據可視化</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">流程自動化</h5>
-                <p class="text-muted text-center">設置工作流實現銷售流程、審批流程和業務規則自動化</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">系統集成與擴展</h5>
-                <p class="text-muted text-center">集成第三方系統、移動端適配和其他高級擴展功能</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM 中所用到的商業插件</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 核心開源，商業插件豐富功能</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 動態生成插件卡片 -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用, 1 年升級</span><br>
-                          <a href="/tw/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用和升級</span><br>
-                          <a class="text-muted" href="/tw/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- 佔位卡片，保持佈局整齊 -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">更多插件即將推出</h6>
-                  <p class="text-muted small">我們正在開發更多有用的商業插件，敬請期待</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">線索</td>
+                      <td class="py-3 text-muted">表單／匯入／手動鍵入，標記來源與歸屬業務</td>
+                      <td class="py-3 text-muted">線索池、來源標籤、階段流轉</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">聯絡跟進</td>
+                      <td class="py-3 text-muted">電話、郵件、拜訪登記，設定下次跟進時間</td>
+                      <td class="py-3 text-muted">跟進時間軸、下次提醒</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">轉化客戶</td>
+                      <td class="py-3 text-muted">線索轉客戶，填入客戶檔案（行業／規模／聯絡人）</td>
+                      <td class="py-3 text-muted">客戶表、聯絡人表、關聯線索</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">客戶 360</td>
+                      <td class="py-3 text-muted">查看客戶全貌：訂單、工單、專案、資產</td>
+                      <td class="py-3 text-muted">嵌入式區塊、跨模組關聯</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">資料沉澱</td>
+                      <td class="py-3 text-muted">銷售看板按業務／地區／類型彙整 KPI</td>
+                      <td class="py-3 text-muted">圖表、明細鑽取、匯出</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/tw/plugins-commercial" class="btn btn-primary me-3">查看全部商業插件</a>
-          <a href="/tw/commercial" class="btn btn-outline-primary">瞭解定價詳情</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三個步驟快速部署 NocoBase CRM 到你的環境</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">線索、客戶、跟進、看板，完整涵蓋客戶關係管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安裝 NocoBase</h5>
-                <p class="text-muted mt-2">按照我們的安裝文檔，部署 NocoBase 到你的服務器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝文檔</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">線索匯入</h5>
+              <p class="text-muted mt-2">Excel 批次匯入、表單收集、API 接入三種方式；欄位對應視覺化設定，匯入衝突自動去重。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>下載 CRM 模板文件</h5>
-                <p class="text-muted mt-2">獲取 NocoBase CRM 系統的完整模板文件，支持兩種格式</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下載 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下載備份文件 (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">階段流轉</h5>
+              <p class="text-muted mt-2">線索階段（新建／已聯絡／已轉化／已放棄）視覺化設定；階段變更自動留痕，轉化率統計自動跑。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系統內還原</h5>
-                <p class="text-muted mt-2">將模板文件導入到你的 NocoBase 系統中完成部署</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/solution/crm/v1" class="btn btn-outline-primary">還原教程</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟進紀錄</h5>
+              <p class="text-muted mt-2">每次拜訪、電話、郵件留下紀錄；時間軸查看完整溝通歷史，接手交接零摩擦。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">跟進提醒</h5>
+              <p class="text-muted mt-2">下次跟進時間到期前自動通知；長期未聯絡的客戶列入「待激活」看板，避免遺忘。</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客戶 360 視圖</h5>
+              <p class="text-muted mt-2">客戶詳情彙整訂單、工單、專案、資產紀錄；一螢幕看清客戶全貌，不用切多個系統。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">分類與標籤</h5>
+              <p class="text-muted mt-2">客戶類型、行業、規模、來源多維度標籤；支援按標籤篩選、彙整分析。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">合併去重</h5>
+              <p class="text-muted mt-2">同一客戶多次鍵入自動識別；一鍵合併，歷史跟進與關聯紀錄無損歸併。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">銷售看板</h5>
+              <p class="text-muted mt-2">按業務、地區、客戶類型彙整 KPI；新增客戶數、轉化率、活躍客戶分布。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">欄位與列級權限</h5>
+              <p class="text-muted mt-2">基於角色設定可見欄位；業務只看自己負責客戶，管理者看全部。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">準備好使用 NocoBase CRM 了嗎？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分鐘時間部署一個專屬 CRM demo。從配置數據結構，到界面佈局，再到流程邏輯，這一切都是通過 NocoBase 的可視化配置完成，無需寫一行代碼。
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與銷售管理、工單系統、專案管理、固定資產管理、HR 協同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>複製到自己的環境
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseTW>
 
 <style>
-/* CRM Demo Styles - 參考首頁樣式 */
-#crm-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-#crm-steps-wrap {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.demo_step {
-  position: absolute;
-  display: none;
-}
-
-.demo_step.demo_step_start {
-  display: block;
-}
-
-.demo_step img {
-  width: 100%;
-  border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-}
-
-.button {
-  position: absolute;
-  cursor: pointer;
-  z-index: 2;
-}
-
-.demo_tooltip {
-  position: relative;
-}
-
-/* 步驟導航樣式 */
-.steps-title {
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.steps-title:hover {
-  transform: translateY(-2px);
-}
-
-.steps-title.active {
-  background-color: #f8f9fa;
-  border-radius: 8px;
-}
-
-/* 工作流程箭頭 */
-.process-arrow:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: -45px;
-  width: 0;
-  height: 0;
-  border-left: 20px solid #e9ecef;
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.d-none-arrow:before {
-  display: none;
-}
-
-@media (max-width: 768px) {
-  .process-arrow:before {
-    display: none;
-  }
-}
-
-/* 商業插件卡片樣式 */
-.plugin-card {
-  transition: all 0.3s ease;
-}
-
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
-}
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-/* 開發者logo樣式 */
-.developer-logo {
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-}
-
-.developer-logo:hover {
-  opacity: 0.8;
-}
-
-/* 交互演示卡片樣式 */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
-}
-
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* 彈窗樣式 */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close {
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow: hidden;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* 彈窗內交互演示的基礎樣式 */
-.demo-content-wrapper {
-  margin-top: 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-/* 彈窗內圖片自適應 - 由JavaScript控制 */
-.demo-modal img {
-  max-width: 100%;
-  height: auto;
-}
-
-/* 響應式彈窗 */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
-}
-
-@media (max-height: 600px) {
-  .demo-modal-header {
-    padding: 0.5rem 1rem;
-  }
-  
-  .demo-modal-body {
-    padding: 0.5rem;
-  }
-}
-
-
 </style>
-
-<script is:inline>
-// 彈窗控制函數 - 定義在全局作用域
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待彈窗顯示後初始化交互演示
-    setTimeout(function() {
-      // 為彈窗內的演示創建獨立實例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// 線索轉化演示彈窗控制函數
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待彈窗顯示後初始化交互演示
-    setTimeout(function() {
-      // 為彈窗內的演示創建獨立實例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// 商機轉化演示彈窗控制函數
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // 等待彈窗顯示後初始化交互演示
-    setTimeout(function() {
-      // 為彈窗內的演示創建獨立實例
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // 只在初始狀態點擊大播放按鈕時觸發播放
-  playButton.addEventListener('click', function() {
-    // 添加控制欄
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // 開始播放並隱藏播放按鈕
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // 視頻結束時顯示播放按鈕，移除控制欄
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC鍵關閉彈窗
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/tw/solutions/hr-management.astro
+++ b/src/pages/tw/solutions/hr-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseTW from "../../../layouts/BaseTW.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseTW
+  title="HR 人事管理系統 — 開源人力資源管理 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源 HR 人事管理系統：員工台帳、到職、離職、請假、試用期追蹤、職位與部門組織結構。輕量、可自架，適合中小企業 HR 團隊。"
+  keywords="HR 人事管理系統, 人力資源管理系統, 開源 HR 系統, 員工管理系統, 到職管理, 離職管理, 請假簽核, 試用期管理, 組織架構管理, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">HR 人事模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">HR 人事管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。員工台帳，<strong>到職、離職、請假、試用期</strong> 全流程追蹤，配合職位與部門組織結構。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">到職／離職清單</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">請假簽核</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">試用期看板</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">中小企業</span>
+                  <span class="badge bg-soft-primary me-2">連鎖門市</span>
+                  <span class="badge bg-soft-primary me-2">行業 HR</span>
+                  <span class="badge bg-soft-primary">跨部門協作</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="HR 人事管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">員工全週期</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從招募到離職的完整人力資源管理閉環</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">招募</div>
+                  <div class="small text-muted">候選人</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">到職</div>
+                  <div class="small text-muted">清單追蹤</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">在職管理</div>
+                  <div class="small text-muted">考勤請假</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">評估</div>
+                  <div class="small text-muted">轉正／調職</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">離職</div>
+                  <div class="small opacity-75">交接歸檔</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">招募</td>
+                      <td class="py-3 text-muted">候選人鍵入、面試評估；通過後轉為員工檔案</td>
+                      <td class="py-3 text-muted">候選人表、面試評分</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">到職</td>
+                      <td class="py-3 text-muted">到職任務清單（簽合約、辦識別證、領設備、開帳號）</td>
+                      <td class="py-3 text-muted">到職清單、合約檔案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">在職管理</td>
+                      <td class="py-3 text-muted">日常考勤、請假、調休、加班簽核</td>
+                      <td class="py-3 text-muted">請假紀錄、假期餘額</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評估</td>
+                      <td class="py-3 text-muted">試用期評估、轉正、調職、晉升</td>
+                      <td class="py-3 text-muted">評估表、職位變更</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">離職</td>
+                      <td class="py-3 text-muted">離職清單：交接、歸還資產、停帳號、辦手續</td>
+                      <td class="py-3 text-muted">離職紀錄、資產釋放</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從到職到離職的完整人力資源管理</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">員工台帳</h5>
+              <p class="text-muted mt-2">員工基本資料、員工編號、入職日期、職位、部門 — 統一檔案，多維度查詢。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">員工生命週期</h5>
+              <p class="text-muted mt-2">待入職 → 試用期 → 在職 → 離職中 → 已離職：5 個狀態貫穿員工檔案；依狀態過濾一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">部門組織結構</h5>
+              <p class="text-muted mt-2">樹狀組織架構：部門→子部門，基於 NocoBase 內建 departments 外掛，與權限聯動。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">職位檔案</h5>
+              <p class="text-muted mt-2">職位定義與職等（初級／中級／高級／專家）；員工掛職位，便於晉升路徑與權限管理。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">請假審核</h5>
+              <p class="text-muted mt-2">8 種假別（特休／病假／事假／補休／婚假／育嬰假／喪假／其他）；依部門／直屬主管設定審核流程。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">欄位級權限</h5>
+              <p class="text-muted mt-2">HR 看薪資欄位，主管看團隊成員基本資料；基於 NocoBase 角色權限彈性設定。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">更多功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">規劃中：入職／離職清單、試用期評估、合約與勞健保管理、招募候選人、調職／晉升紀錄</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、銷售管理、工單系統、專案管理、固定資產管理 協同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseTW>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/tw/solutions/project-management.astro
+++ b/src/pages/tw/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
 import BaseTW from "../../../layouts/BaseTW.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-cn.json";
-
-// 獲取插件數據
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定義項目管理中使用的插件
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// 根據插件名稱匹配插件數據
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 獲取項目管理相關插件
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 調試信息
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseTW
-  title="全面的研發項目管理解決方案"
-  description="NocoBase 研發項目管理系統提供完整的研發項目生命週期管理能力。從需求規劃、任務分配、進度跟蹤到質量管理，實現研發全流程數字化管理和團隊協作。"
-  keywords="NocoBase 研發項目管理, 任務管理, 團隊協作, 敏捷開發, 質量管理"
+  title="專案管理系統 — 開源輕量專案協作 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源專案管理系統：專案 + 任務兩級管理、負責人、進度、里程碑、延期預警、工作量分布。輕量、可自架，適合中小團隊與跨部門專案協作。"
+  keywords="專案管理系統, 專案管理軟體, 任務管理系統, 開源專案管理, 輕量專案管理, 任務管理, 專案協作, 專案追蹤, 里程碑管理, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,456 +14,337 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">全面的<br/>研發項目管理解決方案</h1>
-            <p class="para-desc text-muted">基於 NocoBase 構建的強大且靈活的研發專案管理平台。支援敏捷、瀑布與混合等多種開發方法，在同一平台上統一管理需求、任務、團隊、迭代與品質。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基於 NocoBase 1.x 搭建（2.0 準備中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">專案管理模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">專案管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。<strong>專案 + 任務</strong> 兩級管理，涵蓋負責人、進度、里程碑、延期預警與工作量分布，輕量、可自架部署。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">專案 + 任務兩級</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">延期預警</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">里程碑追蹤</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
             </div>
 
-            <!-- 標籤 -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">適用行業：</span>
-                  <span class="badge bg-soft-primary">研發</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">交付專案</span>
+                  <span class="badge bg-soft-primary me-2">內部 IT</span>
+                  <span class="badge bg-soft-primary me-2">跨部門協作</span>
+                  <span class="badge bg-soft-primary">中小團隊</span>
                 </div>
               </div>
             </div>
 
-            <!-- 開發者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開發者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="專案管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">專案流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從立項到結案的完整追蹤閉環，里程碑與延期預警自動跑</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">立項</div>
+                  <div class="small text-muted">關聯客戶</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">任務拆分</div>
+                  <div class="small text-muted">負責人</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">進度追蹤</div>
+                  <div class="small text-muted">延期預警</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">里程碑</div>
+                  <div class="small text-muted">階段交付</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">結案</div>
+                  <div class="small opacity-75">復盤歸檔</div>
                 </div>
               </div>
-            </div>
 
-            <!-- 按鈕 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>線上示範
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>部署到您的環境
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- 項目管理預覽 -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase 研發項目管理系統預覽" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase 項目管理的獨特之處</h4>
-            <p class="para-desc mx-auto text-muted mb-0">適應您的項目管理方法論的綜合解決方案</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完整研發生命週期</h5>
-              <p class="text-muted mt-2">從需求分析、設計開發到測試、上線、維護，管理研發的每個階段</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">敏捷開發管理</h5>
-              <p class="text-muted mt-2">支持 Scrum 衝刺、看板、燃盡圖，實現迭代開發和持續交付</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">團隊協作與質量管理</h5>
-              <p class="text-muted mt-2">高效管理開發團隊、跟蹤代碼質量、處理缺陷和問題，確保產品質量</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">極易修改與擴展</h5>
-              <p class="text-muted mt-2">基於NocoBase的無代碼特性，輕鬆自定義字段、流程和業務邏輯，對系統完全掌控</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- 使用擴展功能交互演示 -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即體驗
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>複製到自己的環境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">項目管理開發教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">學習如何使用 NocoBase 從零開始構建專業的研發項目管理系統</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">數據模型設計</h5>
-                <p class="text-muted text-center">學習如何創建項目、任務、團隊的基礎數據結構及其關係</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">立項</td>
+                      <td class="py-3 text-muted">建立專案，關聯客戶（交付專案）或資產（IT 專案），指定專案經理</td>
+                      <td class="py-3 text-muted">專案檔案、客戶關聯、負責人</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">任務拆分</td>
+                      <td class="py-3 text-muted">拆解任務，設負責人、起迄時間、依賴關係</td>
+                      <td class="py-3 text-muted">任務表、負責人、依賴圖</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">進度追蹤</td>
+                      <td class="py-3 text-muted">成員更新任務進度；逾期任務自動標紅</td>
+                      <td class="py-3 text-muted">進度百分比、延期標記</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">里程碑</td>
+                      <td class="py-3 text-muted">關鍵節點定義為里程碑（評審／內測／上線）；階段交付物登記</td>
+                      <td class="py-3 text-muted">里程碑清單、交付物附件</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">結案</td>
+                      <td class="py-3 text-muted">專案完成結案歸檔，紀錄工時與成本</td>
+                      <td class="py-3 text-muted">結案報告、工時彙整</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">工作流配置</h5>
-                <p class="text-muted text-center">設置任務分配、狀態流轉和自動化項目工作流</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">衝刺與跟蹤</h5>
-                <p class="text-muted text-center">配置衝刺、燃盡圖和進度跟蹤功能</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">通過商業插件增強功能</h4>
-            <p class="para-desc mx-auto text-muted mb-0">使用強大的商業插件擴展您的項目管理能力</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">立項到結案的完整輕量專案追蹤</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- 動態生成的插件卡片 -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">由 <span>{plugin.developer || 'NocoBase'}</span> 提供</div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">終身使用，一年升級</span><br>
-                          <a href="/tw/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">終身使用和升級</span><br>
-                          <a class="text-muted" href="/tw/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">¥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">專案 + 任務兩級</h5>
+              <p class="text-muted mt-2">一個專案下拆分多個任務，任務負責人、起迄時間、進度獨立維護；專案看板縱覽所有任務狀態。</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/tw/plugins-commercial" class="btn btn-primary me-3">查看所有商業插件</a>
-          <a href="/tw/commercial" class="btn btn-outline-primary">瞭解定價</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">里程碑管理</h5>
+              <p class="text-muted mt-2">關鍵節點定義為里程碑（原型評審、內測、上線）；專案進度按里程碑節奏呈現。</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">延期預警</h5>
+              <p class="text-muted mt-2">任務超過預定截止日自動標紅，延期專案清單即時刷新，管理者一眼看到風險點。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">負責人與工作量</h5>
+              <p class="text-muted mt-2">按負責人彙整任務數與工作量；誰手上活多、誰閒、誰延期次數高，管理者一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">專案狀態看板</h5>
+              <p class="text-muted mt-2">按專案類型、狀態、負責人彙整 KPI；進行中、已結案、延期專案分類呈現。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">關聯客戶與資產</h5>
+              <p class="text-muted mt-2">專案可關聯客戶（交付專案）、資產（IT 專案）；客戶詳情頁可看到關聯專案歷史。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">更多功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">規劃中：任務相依圖、工時記錄與成本、交付物歸檔、甘特圖檢視</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三個步驟快速將帶有項目管理功能的 NocoBase CRM 系統部署到您的環境</p>
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>安裝 NocoBase 系統</h5>
-                <p class="text-muted mt-2">按照我們的安裝文檔將 NocoBase 系統部署到您的服務器</p>
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝指南</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>下載 CRM 系統模板</h5>
-                <p class="text-muted mt-2">下載完整的 CRM 模板以獲得項目管理功能</p>
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下載 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下載備份文件 (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系統中恢復</h5>
-                <p class="text-muted mt-2">將 CRM 模板文件導入到您的 NocoBase 系統中，獲得 CRM 和項目管理功能</p>
-              </div>
-              <div class="mt-3">
-                <a href="/tw/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">恢復教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 項目管理功能說明 -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">提示</h6>
-                <p class="mb-0 text-muted">研發項目管理系統作為綜合模塊完全集成到 CRM 模板中。部署後，您可以直接在 CRM 系統中使用完整的研發項目管理功能，實現需求、開發、測試的全流程管理。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">準備好使用 NocoBase 研發項目管理系統了嗎？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分鐘時間部署一個專屬研發管理 demo。從需求規劃到任務分配，再到進度跟蹤和質量管控，這一切都是通過 NocoBase 的可視化配置完成，無需寫一行代碼。
-          </p>
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、銷售管理、工單系統、固定資產管理、HR 協同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>複製到自己的環境
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseTW>
 
 <style>
-/* 項目管理系統樣式 - 參考 ticketing 頁面樣式 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* 插件卡片樣式 */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/tw/solutions/project-management.astro
+++ b/src/pages/tw/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">里程碑</div>
                   <div class="small text-muted">階段交付</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">里程碑管理</h5>
               <p class="text-muted mt-2">關鍵節點定義為里程碑（原型評審、內測、上線）；專案進度按里程碑節奏呈現。</p>

--- a/src/pages/tw/solutions/sales-management.astro
+++ b/src/pages/tw/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">應收帳款 KPI</h5>
-              <p class="text-muted mt-2">逾期帳款清單、帳齡分析（30／60／90 天分桶）；按客戶、按業務彙整，催收一目了然。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">多幣別與匯率</h5>
-              <p class="text-muted mt-2">USD／EUR／TWD 多幣別報價與訂單；匯率維護表支援手動或匯入；本位幣彙總自動換算。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">出貨與物流</h5>
-              <p class="text-muted mt-2">出貨單關聯訂單與物流單號；支援多次出貨、部分出貨；狀態自動同步到訂單。</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">銷售看板</h5>

--- a/src/pages/tw/solutions/sales-management.astro
+++ b/src/pages/tw/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseTW from "../../../layouts/BaseTW.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseTW
+  title="銷售管理系統 — 開源銷售訂單與應收管理 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源銷售管理系統：報價單、銷售訂單、發票、收款的完整鏈路，內建簽核流程、多幣別、應收帳款 KPI 與逾期分析。"
+  keywords="銷售管理系統, 銷售訂單管理, 報價單, 發票管理, 應收帳款管理, 收款管理, 銷售流程, 銷售簽核, 開源銷售管理, 多幣別報價, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">銷售管理模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">銷售管理系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。<strong>報價 → 訂單 → 發票 → 收款</strong> 的完整鏈路，內建銷售簽核工作流、多幣別報價、應收帳款 KPI 與逾期分析。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">多幣別報價</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">訂單簽核流</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">應收 KPI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">適用場景：</span>
+                  <span class="badge bg-soft-primary me-2">B2B 銷售</span>
+                  <span class="badge bg-soft-primary me-2">外貿訂單</span>
+                  <span class="badge bg-soft-primary me-2">設備銷售</span>
+                  <span class="badge bg-soft-primary">應收管理</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="銷售管理系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">銷售流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從報價到收款的完整閉環，簽核與應收 KPI 全鏈路打通</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">報價</div>
+                  <div class="small text-muted">多幣別</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">訂單</div>
+                  <div class="small text-muted">簽核流</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">出貨</div>
+                  <div class="small text-muted">物流追蹤</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">發票</div>
+                  <div class="small text-muted">客戶預填</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">收款</div>
+                  <div class="small opacity-75">應收 KPI</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">報價</td>
+                      <td class="py-3 text-muted">選客戶／產品，產生多幣別報價單，支援折扣、稅率、有效期</td>
+                      <td class="py-3 text-muted">報價單、產品明細、PDF 匯出</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">訂單</td>
+                      <td class="py-3 text-muted">報價轉訂單；超額折扣、大額訂單觸發簽核</td>
+                      <td class="py-3 text-muted">銷售訂單、簽核流、訂單明細</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">出貨</td>
+                      <td class="py-3 text-muted">訂單確認後登記出貨單，關聯物流單號</td>
+                      <td class="py-3 text-muted">出貨單、物流單號、狀態流轉</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">發票</td>
+                      <td class="py-3 text-muted">訂單或出貨後開票，客戶檔案稅號／地址自動預填</td>
+                      <td class="py-3 text-muted">發票紀錄、開票狀態</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">收款</td>
+                      <td class="py-3 text-muted">分筆收款登記；按帳齡彙整應收 KPI</td>
+                      <td class="py-3 text-muted">收款紀錄、應收餘額、帳齡分桶</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">報價、訂單、發票、收款全鏈路 + 簽核與應收分析</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">報價單管理</h5>
+              <p class="text-muted mt-2">多幣別報價，支援折扣、稅率、有效期；一鍵匯出 PDF 寄給客戶；支援轉化為銷售訂單。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">銷售訂單</h5>
+              <p class="text-muted mt-2">訂單狀態流轉（草稿／審核中／已確認／已出貨／已結案），客戶與產品關聯，訂單明細可分行編輯。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">訂單簽核工作流</h5>
+              <p class="text-muted mt-2">超額折扣、大額訂單、特殊條款觸發簽核；按部門、職位、金額閾值彈性設定簽核節點。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">發票管理</h5>
+              <p class="text-muted mt-2">訂單產生發票，追蹤開票狀態；客戶檔案稅號、地址、備註自動預填，減少手動輸入錯誤。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">收款紀錄</h5>
+              <p class="text-muted mt-2">分筆收款、部分到帳；自動計算應收餘額；按客戶、按訂單彙整付款狀態。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">應收帳款 KPI</h5>
+              <p class="text-muted mt-2">逾期帳款清單、帳齡分析（30／60／90 天分桶）；按客戶、按業務彙整，催收一目了然。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">多幣別與匯率</h5>
+              <p class="text-muted mt-2">USD／EUR／TWD 多幣別報價與訂單；匯率維護表支援手動或匯入；本位幣彙總自動換算。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">出貨與物流</h5>
+              <p class="text-muted mt-2">出貨單關聯訂單與物流單號；支援多次出貨、部分出貨；狀態自動同步到訂單。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">銷售看板</h5>
+              <p class="text-muted mt-2">按業務、地區、產品彙整銷售額、訂單數、回款率；月度／季度趨勢一目了然。</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、工單系統、專案管理、固定資產管理、HR 協同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseTW>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/tw/solutions/ticketing-v2.astro
+++ b/src/pages/tw/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
 import BaseTW from "../../../layouts/BaseTW.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
 <BaseTW
-  title="AI 驅動的智能工單系統 - NocoBase"
-  description="基於 NocoBase 的 AI 驅動智能工單系統，T型數據架構支持多業務場景，AI 員工團隊自動分類、智能回覆、知識推薦，SLA 全程監控，實現工單全生命週期智能化管理。"
-  keywords="NocoBase 工單系統, AI 工單, 智能客服, SLA管理, 知識庫, 工單分類"
+  title="工單系統 — 開源客服工單管理 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源工單系統：客戶報修、智慧派工、SLA 計時、優先級、AI 分類、滿意度評價、客服工作台。開箱即用，適合中小客服團隊與售後服務團隊。"
+  keywords="工單系統, 客服工單系統, 開源工單, help desk, ticketing 系統, 工單管理, SLA 管理, 售後系統, 客戶服務系統, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,337 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI 驅動的<br/>智能工單系統</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">工單系統模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">工單系統</h1>
             <p class="para-desc text-muted">
-              讓客服更專注於解決問題，而非繁瑣的流程操作。基於 NocoBase 無代碼平臺，採用 T 型數據架構統一管理多種業務場景，AI 員工團隊貫穿工單全生命週期，實現從創建到閉環的智能化管理。
+              基於 NocoBase 無程式碼平台構建。<strong>客戶報修 → 智慧派工 → 處理 → 滿意度評價</strong> 的完整鏈路，內建 SLA 計時、優先級管理、AI 智慧分類與客服工作台。
             </p>
 
-            <!-- 核心價值 -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">多源統一接入</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI 智能分流</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">SLA 全程監控</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">知識自動沉澱</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自動計時</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 級優先級</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 智慧分類</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
             </div>
 
-            <!-- 適用場景標籤 -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
                   <span class="text-muted me-2">適用場景：</span>
-                  <span class="badge bg-soft-primary me-2">設備維修</span>
-                  <span class="badge bg-soft-primary me-2">IT 支持</span>
-                  <span class="badge bg-soft-primary me-2">客戶投訴</span>
-                  <span class="badge bg-soft-primary">諮詢建議</span>
+                  <span class="badge bg-soft-primary me-2">客服售後</span>
+                  <span class="badge bg-soft-primary me-2">IT 服務台</span>
+                  <span class="badge bg-soft-primary me-2">設備維保</span>
+                  <span class="badge bg-soft-primary">SaaS 客服</span>
                 </div>
               </div>
             </div>
 
-            <!-- 按鈕 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>線上示範
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>如何使用
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha 版本已上線，歡迎體驗，功能持續更新中
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="通用工單追蹤系統界面"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="工單系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">您是否面臨這些問題？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">企業在日常運營中面臨多種服務請求，來源分散、流程各異、缺乏統一管理</p>
+            <h4 class="title mb-4">工單處理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從客戶報修到結案評價的完整閉環，SLA 全程計時</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">成本高、定製慢</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS 工單系統價格高昂，定製開發週期長、成本難以預估，業務需求變化時難以快速調整。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">系統割裂、數據孤島</h5>
-              </div>
-              <p class="text-muted mb-0">設備維修、IT支持、客戶投訴等請求分散在不同系統，難以統一分析和決策。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">響應慢、過程不透明</h5>
-              </div>
-              <p class="text-muted mb-0">請求在系統間流轉效率低，客戶無法追蹤進度，頻繁詢問增加客服壓力。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">質量難保障</h5>
-              </div>
-              <p class="text-muted mb-0">缺乏 SLA 監控機制，超時和差評無法及時預警，服務質量參差不齊。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">知識無法沉澱</h5>
-              </div>
-              <p class="text-muted mb-0">解決方案散落在各處，新人上手慢，同樣的問題反覆解決，效率低下。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">AI 能力缺失</h5>
-              </div>
-              <p class="text-muted mb-0">傳統系統缺乏 AI 輔助，人工分類耗時費力，無法實現智能推薦和自動回覆。</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">我們的解決方案</h4>
-            <p class="para-desc mx-auto text-muted mb-0">基於 NocoBase 無代碼平臺構建的通用工單中臺，實現統一入口、智能分發、多態業務、閉環反饋</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 核心模塊 -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">多源統一接入</h5>
-              <p class="text-muted mt-2">公開表單、客戶門戶、郵件解析、API/Webhook，所有渠道統一管理，自動去重檢查</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI 智能分流</h5>
-              <p class="text-muted mt-2">自動識別意圖、分析情緒、評估緊急度，結合技能匹配和負載均衡智能分派</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">SLA 全程監控</h5>
-              <p class="text-muted mt-2">P0-P3 四級優先級，響應/解決時效自動追蹤，超時預警和升級機制</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">閉環反饋</h5>
-              <p class="text-muted mt-2">多維度滿意度評價、NPS 評分、差評預警和跟進，持續提升服務質量</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T型架構 Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">核心設計</span>
-            <h4 class="title mb-4">T 型數據架構</h4>
-            <p class="para-desc mx-auto text-muted mb-0">所有工單共享主表統一流轉，業務特有字段下沉附表，新增業務類型只需添加附表</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T 型架構圖 -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>工單主表 (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">工單號 | 標題 | 狀態 | 優先級 | 處理人 | SLA | AI分析結果</div>
-                </div>
-              </div>
-
-              <!-- 連接線 -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- 業務附表 -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">設備維修</strong>
-                  <div class="small text-muted mt-2">設備序列號 | 故障碼<br/>備件清單 | 現場照片</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT 支持</strong>
-                  <div class="small text-muted mt-2">資產編號 | OS版本<br/>遠程地址 | 錯誤代碼</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">客戶投訴</strong>
-                  <div class="small text-muted mt-2">涉及訂單 | 投訴等級<br/>賠償方案 | 根本原因</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">更多業務...</strong>
-                  <div class="small text-muted mt-2">按需擴展<br/>主流程不變</div>
-                </div>
-              </div>
-
-              <!-- 優勢說明 -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">統一報表</h6>
-                  <p class="text-muted small mb-0">一張主表統計所有工單</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">流程複用</h6>
-                  <p class="text-muted small mb-0">核心流程只改一處</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">靈活擴展</h6>
-                  <p class="text-muted small mb-0">新業務只需加附表</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T型架構 End -->
-
-  <!-- AI 員工 Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI 原生</span>
-            <h4 class="title mb-4">AI 員工團隊</h4>
-            <p class="para-desc mx-auto text-muted mb-0">不是"加個 AI 按鈕"，而是 AI 員工融入每個環節。每位 AI 有明確的角色、職責、性格</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">服務檯主管</span>
-              <p class="text-muted mt-2 small">工單分流、優先級評估、升級決策、SLA風險識別</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">觸發：工單創建時自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">客戶成功專家</span>
-              <p class="text-muted mt-2 small">回覆生成、語氣調整、投訴處理、情商防火牆</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">觸發：點擊"AI回覆"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">知識助手</span>
-              <p class="text-muted mt-2 small">相似案例、知識推薦、解決方案綜合、知識生成</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">觸發：工單詳情頁自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">翻譯官</span>
-              <p class="text-muted mt-2 small">多語言翻譯、質量審核、敏感信息攔截</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">觸發：檢測到外語自動</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 情商防火牆示例 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace 的情商防火牆</h5>
-              <p class="text-muted mb-3">自動檢測並優化客服回覆中的負面表達，避免二次投訴</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">原文</span>
-                    <p class="mb-0 small">"這不是我們的問題，你自己設置錯了"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">優化後</span>
-                    <p class="mb-0 small">"經過排查，問題出在配置環節。我來幫您一起調整設置，確保正常使用"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI 員工 End -->
-
-  <!-- 知識循環 Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">知識管理</span>
-            <h4 class="title mb-4">知識自循環體系</h4>
-            <p class="para-desc mx-auto text-muted mb-0">工單解決後自動沉澱為知識，下次遇到相似問題時 AI 自動推薦，形成知識沉澱-知識應用的閉環</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- 循環流程圖 -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">工單解決</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI 評估價值</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">生成知識文章</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">人工審核發佈</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">知識庫</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">相似工單</div>
+                  <div class="small fw-medium">建立</div>
+                  <div class="small text-muted">多渠道</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI 推薦知識</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">智慧分類</div>
+                  <div class="small text-muted">AI 識別</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">快速解決</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">派工</div>
+                  <div class="small text-muted">按組規則</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">處理</div>
+                  <div class="small text-muted">SLA 計時</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">評價</div>
+                  <div class="small opacity-75">結案歸檔</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">建立</td>
+                      <td class="py-3 text-muted">客戶郵件、表單、IM 多渠道提交；關聯客戶與產品</td>
+                      <td class="py-3 text-muted">工單單號、來源、客戶檔案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">智慧分類</td>
+                      <td class="py-3 text-muted">AI 識別問題類別（帳號／功能／Bug），自動設優先級</td>
+                      <td class="py-3 text-muted">分類標籤、優先級、信賴度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">派工</td>
+                      <td class="py-3 text-muted">按規則分給對應小組／客服員，緊急工單自動通知值班</td>
+                      <td class="py-3 text-muted">負責人、派工紀錄、組佇列</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">處理</td>
+                      <td class="py-3 text-muted">客服處理、與客戶溝通；SLA 計時，逾期前自動告警</td>
+                      <td class="py-3 text-muted">處理日誌、SLA 狀態、等待原因</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評價</td>
+                      <td class="py-3 text-muted">結案推送客戶評價（1-5 星 + 文字），按客服／產品彙整</td>
+                      <td class="py-3 text-muted">滿意度紀錄、歸檔工單、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- 知識轉化條件 -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">描述完整</h6>
-                  <p class="text-muted small mb-0">描述 ≥ 200 字符</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">溝通充分</h6>
-                  <p class="text-muted small mb-0">評論 ≥ 2 條</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">質量達標</h6>
-                  <p class="text-muted small mb-0">AI 評分 ≥ 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 知識循環 End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA 服務級別管理</h4>
-            <p class="para-desc mx-auto text-muted mb-0">按優先級設置響應和解決時間，自動監控、預警、升級，掛起時 SLA 自動暫停</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從受理到結案的完整客服工單管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">優先級</th>
-                  <th class="border-0 py-3">響應時間</th>
-                  <th class="border-0 py-3">解決時間</th>
-                  <th class="border-0 py-3">典型場景</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 緊急</span></td>
-                  <td class="py-3">15 分鐘</td>
-                  <td class="py-3">2 小時</td>
-                  <td class="py-3 text-muted small">系統宕機、生產線停止</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 高</span></td>
-                  <td class="py-3">1 小時</td>
-                  <td class="py-3">8 小時</td>
-                  <td class="py-3 text-muted small">重要功能故障、影響較大</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 中</span></td>
-                  <td class="py-3">4 小時</td>
-                  <td class="py-3">24 小時</td>
-                  <td class="py-3 text-muted small">一般問題、有替代方案</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 低</span></td>
-                  <td class="py-3">8 小時</td>
-                  <td class="py-3">72 小時</td>
-                  <td class="py-3 text-muted small">優化建議、功能諮詢</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">提前預警</h6>
-                  <p class="text-muted small mb-0">剩餘時間 &lt; 20% 時通知處理人</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">超時預警</h6>
-                  <p class="text-muted small mb-0">超時後通知處理人+主管</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">自動升級</h6>
-                  <p class="text-muted small mb-0">超時 1 小時通知部門經理</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 計時與告警</h5>
+              <p class="text-muted mt-2">按優先級自動計算回應／解決時限；逾期前自動告警，逾期工單置紅色；SLA 達成率可看板呈現。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- 價值量化 Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 級優先級</h5>
+              <p class="text-muted mt-2">緊急、高、中、低四級，搭配不同回應時長；緊急工單自動置頂並通知值班人員。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 智慧分類</h5>
+              <p class="text-muted mt-2">新工單 AI 自動識別問題類別（帳號問題／功能諮詢／Bug 回報等），按規則派工給對應小組。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">等待原因細分</h5>
+              <p class="text-muted mt-2">「等待客戶回覆」「等待第三方」「需求待評審」 — 等待中的工單不計入 SLA 逾期，公平合理。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客服工作台</h5>
+              <p class="text-muted mt-2">客服登入直接看到分給自己的工單；按到期時間排序，一螢幕看待處理、處理中、即將逾期。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工單儀表板</h5>
+              <p class="text-muted mt-2">今日新增／結案／待處理／逾期分布；按客服員、客戶、產品線彙整，管理者縱覽全局。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">更多功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">規劃中：滿意度評價、轉派與升級流程、回覆範本、知識庫整合</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">AI 帶來的價值</h4>
-            <p class="para-desc mx-auto text-muted mb-0">人與 AI 協同，而非 AI 替代人。讓 AI 處理重複工作，讓人專注於創造價值</p>
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">分揀效率提升</h5>
-              <p class="text-muted small mb-0">AI 自動分類減少人工分揀時間</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">二次投訴減少</h5>
-              <p class="text-muted small mb-0">情商防火牆優化回覆語氣</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">超時率降低</h5>
-              <p class="text-muted small mb-0">SLA 預警提前干預</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">首解率提升</h5>
-              <p class="text-muted small mb-0">知識推薦加速問題解決</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 價值量化 End -->
-
-  <!-- 差異化優勢 Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">為什麼選擇我們？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">與傳統 SaaS 工單系統和自研系統的對比</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">對比維度</th>
-                  <th class="border-0 py-3">SaaS 工單</th>
-                  <th class="border-0 py-3">自研系統</th>
-                  <th class="border-0 py-3 text-primary">NocoBase 方案</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">上線速度</td>
-                  <td class="py-3 text-muted">開箱即用</td>
-                  <td class="py-3 text-muted">數月開發</td>
-                  <td class="py-3 text-primary">配置即用，快速上線</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">定製能力</td>
-                  <td class="py-3 text-muted">受限</td>
-                  <td class="py-3 text-muted">完全可控</td>
-                  <td class="py-3 text-primary">無代碼靈活定製</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">數據安全</td>
-                  <td class="py-3 text-muted">雲端託管</td>
-                  <td class="py-3 text-muted">私有部署</td>
-                  <td class="py-3 text-primary">私有部署，數據完全掌控</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI 集成</td>
-                  <td class="py-3 text-muted">有限/加價</td>
-                  <td class="py-3 text-muted">需自行開發</td>
-                  <td class="py-3 text-primary">AI 原生，深度集成</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">擴展性</td>
-                  <td class="py-3 text-muted">功能固定</td>
-                  <td class="py-3 text-muted">需代碼修改</td>
-                  <td class="py-3 text-primary">T型架構，按需擴展</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">總體成本</td>
-                  <td class="py-3 text-muted">訂閱費用高</td>
-                  <td class="py-3 text-muted">開發成本高</td>
-                  <td class="py-3 text-primary">一次購買，長期使用</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- 差異化優勢 End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三個步驟快速部署智能工單系統到你的環境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安裝 NocoBase</h5>
-                <p class="text-muted mt-2">按照我們的安裝文檔，部署 NocoBase 到你的服務器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝文檔</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>瞭解方案</h5>
-                <p class="text-muted mt-2">閱讀方案介紹文檔，瞭解系統功能、架構設計和使用場景</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">方案介紹</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>還原到系統</h5>
-                <p class="text-muted mt-2">按照還原教程，將智能工單系統部署到你的 NocoBase 環境</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">還原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">讓 AI 重新定義工單管理</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            基於 NocoBase 2.x 構建的 AI 驅動智能工單系統。如果您有定製需求或想了解更多細節，歡迎聯繫我們。
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、銷售管理、專案管理、固定資產管理、HR 協同。</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/tw/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>聯繫我們
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseTW>
 
 <style>
-/* 工單 2.0 頁面樣式 */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI 員工頭像樣式 */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/tw/solutions/ticketing.astro
+++ b/src/pages/tw/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
 import BaseTW from "../../../layouts/BaseTW.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// 導入交互演示數據
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-cn.json";
-
-// 獲取插件數據
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// 定義工單系統中使用的插件名稱映射
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// 根據插件名稱匹配插件數據
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// 獲取工單系統相關插件
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// 調試信息
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
 <BaseTW
-  title="高效便捷的工單管理系統"
-  description="NocoBase 工單管理系統作為 CRM 的重要補充，提供完整的工單生命週期管理，從客戶聯繫人創建到工單分配處理，全流程數字化管理。"
-  keywords="NocoBase 工單系統, 工單管理, 客服系統, 售後服務, 工單分配"
+  title="工單系統 — 開源客服工單管理 | NocoBase"
+  description="基於 NocoBase 無程式碼平台的開源工單系統：客戶報修、智慧派工、SLA 計時、優先級、AI 分類、滿意度評價、客服工作台。開箱即用，適合中小客服團隊與售後服務團隊。"
+  keywords="工單系統, 客服工單系統, 開源工單, help desk, ticketing 系統, 工單管理, SLA 管理, 售後系統, 客戶服務系統, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,567 +15,337 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">高效便捷的<br/>工單管理系統</h1>
-            <p class="para-desc text-muted">NocoBase 工單管理系統作為 CRM 的重要補充，提供完整的工單生命週期管理。從客戶聯繫人創建到工單錄入、分配、處理和跟蹤，實現售後服務的全流程數字化管理。</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> 基於 NocoBase 1.x 搭建（2.0 準備中）
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/tw/solutions/all-in-one" class="text-muted small text-decoration-none">整合式業務管理系統</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">工單系統模組</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">工單系統</h1>
+            <p class="para-desc text-muted">
+              基於 NocoBase 無程式碼平台構建。<strong>客戶報修 → 智慧派工 → 處理 → 滿意度評價</strong> 的完整鏈路，內建 SLA 計時、優先級管理、AI 智慧分類與客服工作台。
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">SLA 自動計時</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 級優先級</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">AI 智慧分類</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">開源免費</span></div></div>
             </div>
 
-            <!-- 標籤 -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
+                <div class="d-flex align-items-center flex-wrap">
                   <span class="text-muted me-2">適用場景：</span>
-                  <span class="badge bg-soft-primary me-2">客戶服務</span>
-                  <span class="badge bg-soft-primary">售後支持</span>
+                  <span class="badge bg-soft-primary me-2">客服售後</span>
+                  <span class="badge bg-soft-primary me-2">IT 服務台</span>
+                  <span class="badge bg-soft-primary me-2">設備維保</span>
+                  <span class="badge bg-soft-primary">SaaS 客服</span>
                 </div>
               </div>
             </div>
 
-            <!-- 開發者信息 -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">開發者：</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- 按鈕 -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>線上示範
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>複製到您的環境
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+              <a href="/tw/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>查看完整方案</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- 工單系統預覽圖 -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase 工單管理系統預覽" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="工單系統介面" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase 工單管理系統功能特點</h4>
-            <p class="para-desc mx-auto text-muted mb-0">作為 CRM 系統的重要補充，提供專業的客戶服務和售後支持管理</p>
+            <h4 class="title mb-4">工單處理流程</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從客戶報修到結案評價的完整閉環，SLA 全程計時</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">完整的工單生命週期</h5>
-              <p class="text-muted mt-2">從工單創建、分配、處理到關閉，全流程管理，確保每個工單都得到妥善處理</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">智能分配與跟蹤</h5>
-              <p class="text-muted mt-2">根據工單類型和團隊成員技能自動分配任務，實時跟蹤處理進度和狀態</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">多渠道溝通記錄</h5>
-              <p class="text-muted mt-2">通過 API 同步郵件、電話、在線聊天等多種溝通渠道，統一管理客戶交流記錄</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">開源，數據完全掌控</h5>
-              <p class="text-muted mt-2">開源代碼，數據私有部署，確保企業數據安全和自主控制</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- 使用擴展功能交互演示 -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>立即體驗
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>複製到自己的環境
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">工單系統開發教程</h4>
-            <p class="para-desc mx-auto text-muted mb-0">從零開始學習如何使用 NocoBase 構建專業的工單管理系統</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">數據模型設計</h5>
-                <p class="text-muted text-center">學習如何創建工單、客戶、分類等基礎數據結構和關係</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">工作流配置</h5>
-                <p class="text-muted text-center">設置工單分配、狀態流轉和自動化處理流程</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">通知與提醒</h5>
-                <p class="text-muted text-center">配置郵件和系統通知，確保工單及時處理</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">即將推出</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">工單系統中所使用的商業插件介紹</h4>
-            <p class="para-desc mx-auto text-muted mb-0">瞭解如何通過商業插件獲得更強大的功能，提升工單系統的專業性和易用性</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- 動態生成插件卡片 -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name_cn || plugin.name;
-          const displayDescription = plugin.description_cn || plugin.description;
-          const docsUrl = plugin.docs_cn || plugin.docs;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">詳情</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用, 1 年升級</span><br>
-                          <a href="/tw/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_1_year_cn || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">永久使用和升級</span><br>
-                          <a class="text-muted" href="/tw/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">￥{plugin.price_cny || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">建立</div>
+                  <div class="small text-muted">多渠道</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">智慧分類</div>
+                  <div class="small text-muted">AI 識別</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">派工</div>
+                  <div class="small text-muted">按組規則</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">處理</div>
+                  <div class="small text-muted">SLA 計時</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">評價</div>
+                  <div class="small opacity-75">結案歸檔</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- 佔位卡片，保持佈局整齊 -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">更多插件即將推出</h6>
-                  <p class="text-muted small">我們正在開發更多有用的商業插件，敬請期待</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">階段</th>
+                      <th class="border-0 py-3">關鍵動作</th>
+                      <th class="border-0 py-3">系統紀錄</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">建立</td>
+                      <td class="py-3 text-muted">客戶郵件、表單、IM 多渠道提交；關聯客戶與產品</td>
+                      <td class="py-3 text-muted">工單單號、來源、客戶檔案</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">智慧分類</td>
+                      <td class="py-3 text-muted">AI 識別問題類別（帳號／功能／Bug），自動設優先級</td>
+                      <td class="py-3 text-muted">分類標籤、優先級、信賴度</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">派工</td>
+                      <td class="py-3 text-muted">按規則分給對應小組／客服員，緊急工單自動通知值班</td>
+                      <td class="py-3 text-muted">負責人、派工紀錄、組佇列</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">處理</td>
+                      <td class="py-3 text-muted">客服處理、與客戶溝通；SLA 計時，逾期前自動告警</td>
+                      <td class="py-3 text-muted">處理日誌、SLA 狀態、等待原因</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">評價</td>
+                      <td class="py-3 text-muted">結案推送客戶評價（1-5 星 + 文字），按客服／產品彙整</td>
+                      <td class="py-3 text-muted">滿意度紀錄、歸檔工單、KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/tw/plugins-commercial" class="btn btn-primary me-3">查看全部商業插件</a>
-          <a href="/tw/commercial" class="btn btn-outline-primary">瞭解定價詳情</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何使用？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">三個步驟快速部署包含工單管理功能的 NocoBase CRM 系統到您的環境</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>安裝 NocoBase 系統</h5>
-                <p class="text-muted mt-2">按照我們的安裝文檔，部署 NocoBase 系統到您的服務器</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/cn/get-started/quickstart" target="_blank" class="btn btn-primary">查看安裝文檔</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>下載 CRM 系統模板文件</h5>
-                <p class="text-muted mt-2">下載完整的 CRM 模板即可獲得工單管理能力</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_250910.zip" class="text-muted small" style="text-decoration: underline !important;">下載 SQL 文件</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_cn_20250910.nbdata" class="btn btn-outline-primary">下載備份文件 (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>在系統內還原</h5>
-                <p class="text-muted mt-2">將 CRM 模板文件導入到您的 NocoBase 系統中，即可同時獲得 CRM 和工單管理功能</p>
-              </div>
-              <div class="mt-3">
-                <a href="/tw/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">還原教程</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- 工單功能說明 -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">提示</h6>
-                <p class="mb-0 text-muted">工單管理系統作為 CRM 的重要補充模塊，已完全集成在 CRM 模板中。部署完成後，您可以在 CRM 系統中直接使用完整的工單管理功能，實現客戶服務的全流程管理。</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">如何擴展？</h4>
-            <p class="para-desc mx-auto text-muted mb-0">根據業務需求進一步擴展和定製您的工單管理系統</p>
+            <h4 class="title mb-4">核心功能</h4>
+            <p class="para-desc mx-auto text-muted mb-0">從受理到結案的完整客服工單管理日常</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">工單類型與分類管理</h5>
-                  <p class="text-muted mb-3">根據業務需要創建不同類型的工單分類和處理規則</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即將推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">SLA 計時與告警</h5>
+              <p class="text-muted mt-2">按優先級自動計算回應／解決時限；逾期前自動告警，逾期工單置紅色；SLA 達成率可看板呈現。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">團隊協作功能</h5>
-                  <p class="text-muted mb-3">設置團隊角色、權限和協作工作流</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即將推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 級優先級</h5>
+              <p class="text-muted mt-2">緊急、高、中、低四級，搭配不同回應時長；緊急工單自動置頂並通知值班人員。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">統計報表分析</h5>
-                  <p class="text-muted mb-3">構建工單處理情況和效率分析報表</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即將推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">AI 智慧分類</h5>
+              <p class="text-muted mt-2">新工單 AI 自動識別問題類別（帳號問題／功能諮詢／Bug 回報等），按規則派工給對應小組。</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM 系統集成</h5>
-                  <p class="text-muted mb-3">與現有 CRM 系統無縫集成，實現數據共享</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">即將推出</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">等待原因細分</h5>
+              <p class="text-muted mt-2">「等待客戶回覆」「等待第三方」「需求待評審」 — 等待中的工單不計入 SLA 逾期，公平合理。</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">客服工作台</h5>
+              <p class="text-muted mt-2">客服登入直接看到分給自己的工單；按到期時間排序，一螢幕看待處理、處理中、即將逾期。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">工單儀表板</h5>
+              <p class="text-muted mt-2">今日新增／結案／待處理／逾期分布；按客服員、客戶、產品線彙整，管理者縱覽全局。</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">更多功能完善中</h5>
+              <p class="text-muted small mt-2 mb-0">規劃中：滿意度評價、轉派與升級流程、回覆範本、知識庫整合</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">準備好使用 NocoBase 工單管理系統了嗎？</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            1 分鐘時間部署一個專屬工單管理 demo。作為 CRM 的重要補充，實現完整的客戶服務體系，提升客戶滿意度和服務效率。
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>複製到自己的環境
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">下載與部署</h4>
+            <p class="para-desc mx-auto text-muted mb-0">本模組包含在整合式業務管理系統的備份範本中，統一部署</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>下載備份範本</h5>
+                <p class="text-muted mt-2">整合式方案備份，還原後包含本模組在內的 6 大模組全部預置資料</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>下載 .nbdata 備份</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">或下載 SQL 壓縮包</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>查看安裝文件</h5>
+                <p class="text-muted mt-2">詳細的還原步驟、常見問題與注意事項，正在準備中</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>即將推出</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">開始使用</h3>
+          <p class="text-muted para-desc mx-auto mb-0">本模組同樣整合在 <a href="/tw/solutions/all-in-one">整合式業務管理系統</a> 中，可單獨使用，也可與 CRM、銷售管理、專案管理、固定資產管理、HR 協同。</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>線上體驗 Demo</a>
+            <a href="/tw/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>聯絡諮詢</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
 </BaseTW>
 
 <style>
-/* 工單管理系統樣式 - 參考 CRM 頁面樣式 */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* 商業插件卡片樣式 */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
 </style>
-
- 

--- a/src/pages/vi/solutions/all-in-one.astro
+++ b/src/pages/vi/solutions/all-in-one.astro
@@ -1,0 +1,593 @@
+---
+import BaseVI from "../../../layouts/BaseVI.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+import AIAvatar from "../../../components/AIAvatar.astro";
+---
+
+<BaseVI
+  title="Hệ thống quản lý kinh doanh tích hợp - CRM / Help Desk / Dự án / Tài sản / Nhân sự | NocoBase"
+  description="Hệ thống quản lý kinh doanh tích hợp mã nguồn mở: tổng hợp 6 mô-đun CRM (Quản lý khách hàng), Quản lý bán hàng, Help Desk (Phiếu hỗ trợ), Quản lý dự án, Quản lý tài sản, Quản lý nhân sự. Dựa trên nền tảng no-code NocoBase, dùng được ngay, phù hợp cho các nhóm vừa và nhỏ triển khai nhanh."
+  keywords="Hệ thống quản lý kinh doanh tích hợp, CRM, CRM mã nguồn mở, Help Desk, hệ thống phiếu hỗ trợ, hệ thống quản lý dự án, hệ thống quản lý tài sản, quản lý tài sản IT, hệ thống quản lý nhân sự, hệ thống quản lý nguồn nhân lực, hệ thống quản lý bán hàng, ERP no-code, hệ thống quản lý đa-trong-một, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <h1 class="fw-bold mt-2 mb-3">Hệ thống quản lý<br/>kinh doanh tích hợp</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase, bao gồm sáu mô-đun: <strong>CRM (Quản lý khách hàng), Quản lý bán hàng, Help Desk (Phiếu hỗ trợ), Quản lý dự án, Quản lý tài sản, Quản lý nhân sự</strong>.
+              Dùng được ngay, không cần lựa chọn phức tạp và tích hợp nhiều hệ thống.
+            </p>
+
+            <!-- Giá trị cốt lõi -->
+            <div class="row mt-4 g-3">
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Tích hợp nhiều hệ thống</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Hỗ trợ tích hợp sẵn 20+ ngôn ngữ</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">AI Employee + Workflow</span>
+                </div>
+              </div>
+              <div class="col-auto">
+                <div class="d-flex align-items-center">
+                  <i class="uil uil-check-circle text-success me-2"></i>
+                  <span class="small">Mã nguồn mở miễn phí</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Nhãn tình huống áp dụng -->
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Công ty khởi nghiệp</span>
+                  <span class="badge bg-soft-primary me-2">Cửa hàng đa mảng kinh doanh</span>
+                  <span class="badge bg-soft-primary me-2">Giai đoạn thăm dò nghiệp vụ</span>
+                  <span class="badge bg-soft-primary">Giảng dạy và đào tạo</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
+                <i class="uil uil-play me-1"></i>Trải nghiệm Demo
+              </a>
+              <a href="/vi/contact" class="btn btn-outline-primary">
+                <i class="uil uil-envelope me-1"></i>Liên hệ tư vấn
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <div class="text-center">
+            <img src="https://static-docs.nocobase.com/all-in-one-cover-2026-05-20.jpg" alt="Hệ thống quản lý kinh doanh tích hợp" class="img-fluid rounded shadow" loading="eager" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- 6 Modules Overview Start -->
+  <section class="section bg-light" id="modules">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">6 mô-đun phối hợp</h4>
+            <p class="para-desc mx-auto text-muted mb-0">CRM, Quản lý bán hàng, Help Desk, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự — toàn bộ quy trình nghiệp vụ khép kín trong cùng một hệ thống</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <!-- Quản lý khách hàng -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="customers">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-users-alt rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">CRM (Quản lý khách hàng)</h5>
+              <p class="text-muted mt-2">Hệ thống CRM mã nguồn mở: quy trình hoàn chỉnh từ lead, theo dõi, chuyển đổi đến gộp/khử trùng lặp; chế độ xem khách hàng 360 tổng hợp lịch sử đơn hàng, phiếu hỗ trợ, dự án, tài sản.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Quản lý và chuyển đổi giai đoạn lead</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Chế độ xem chi tiết khách hàng 360</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Công cụ gộp/khử trùng lặp</li>
+              </ul>
+              <a href="/vi/solutions/crm-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-users-alt full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quản lý bán hàng -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="sales">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-money-bill rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý bán hàng</h5>
+              <p class="text-muted mt-2">Quản lý đơn hàng bán: chuỗi hoàn chỉnh báo giá, đơn hàng, hóa đơn, thu tiền; tích hợp sẵn quy trình phê duyệt và phân tích công nợ phải thu.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Báo giá đa tệ</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Workflow phê duyệt đơn hàng</li>
+                <li><i class="uil uil-check text-primary me-1"></i>KPI công nợ quá hạn</li>
+              </ul>
+              <a href="/vi/solutions/sales-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-money-bill full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Help Desk -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="tickets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-ticket rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Help Desk (Phiếu hỗ trợ)</h5>
+              <p class="text-muted mt-2">Hệ thống phiếu hỗ trợ khách hàng: tiếp nhận sự cố, phân công, xử lý và đánh giá hài lòng; hỗ trợ tính SLA, quản lý mức độ ưu tiên và phân loại nguyên nhân chờ.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Tự động đếm SLA và thông báo quá hạn</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Dashboard phiếu + workspace nhóm</li>
+                <li><i class="uil uil-check text-primary me-1"></i>4 mức ưu tiên + phân loại thông minh bằng AI</li>
+              </ul>
+              <a href="/vi/solutions/ticketing-v2" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-ticket full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quản lý dự án -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="projects">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-clipboard-notes rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý dự án</h5>
+              <p class="text-muted mt-2">Hệ thống quản lý dự án nhẹ: quản lý hai cấp dự án và công việc; bao gồm người phụ trách, tiến độ, mốc và cảnh báo trễ hạn.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Bảng trạng thái dự án</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Khối lượng công việc của người phụ trách</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Nhắc nhở dự án trễ hạn</li>
+              </ul>
+              <a href="/vi/solutions/project-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-clipboard-notes full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quản lý tài sản -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="assets">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-laptop rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý tài sản</h5>
+              <p class="text-muted mt-2">Quản lý toàn bộ vòng đời tài sản IT và tài sản văn phòng, bao gồm mua sắm, phân bổ, bảo trì, thanh lý, kèm sổ theo dõi nhà cung cấp.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Phân bổ / Trả lại tài sản</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Phiếu bảo trì</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Phân tích nhà cung cấp mua sắm</li>
+              </ul>
+              <a href="/vi/solutions/asset-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-laptop full-img"></i>
+            </div>
+          </div>
+        </div>
+
+        <!-- Nhân sự -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2" id="hr">
+          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
+            <div class="icons text-start">
+              <i class="uil uil-user-square rounded h3 mb-0"></i>
+            </div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý nhân sự</h5>
+              <p class="text-muted mt-2">Hệ thống quản lý nguồn nhân lực: hồ sơ nhân viên, vào việc, nghỉ việc, xin nghỉ, theo dõi thử việc, kết hợp với cấu trúc tổ chức theo vị trí và phòng ban.</p>
+              <ul class="list-unstyled text-muted mt-2 small">
+                <li><i class="uil uil-check text-primary me-1"></i>Checklist vào việc / nghỉ việc</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Phê duyệt xin nghỉ</li>
+                <li><i class="uil uil-check text-primary me-1"></i>Bảng theo dõi nhân viên thử việc</li>
+              </ul>
+              <a href="/vi/solutions/hr-management" class="text-primary small mt-2 d-inline-block position-relative" style="z-index: 1;">Tìm hiểu thêm <i class="uil uil-arrow-right"></i></a>
+              <i class="uil uil-user-square full-img"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- 6 Modules End -->
+
+  <!-- Platform Highlights Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Năng lực nền tảng</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Dựa trên NocoBase 2.x, tích hợp sẵn AI, workflow, đa ngôn ngữ và khả năng đa workspace</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-robot text-primary h2"></i>
+            </div>
+            <h5>AI Employee</h5>
+            <p class="text-muted small">Lina (bản địa hóa), Lexi (dịch thuật), Atlas (cộng tác) và các vai trò AI tích hợp khác, gọi theo từng tình huống nghiệp vụ.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-globe text-primary h2"></i>
+            </div>
+            <h5>Hỗ trợ đa ngôn ngữ</h5>
+            <p class="text-muted small">Hỗ trợ tích hợp sẵn hơn 20 ngôn ngữ như Trung, Anh, Nhật, Hàn, Đức, Pháp, toàn bộ UI đã được dịch.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-process text-primary h2"></i>
+            </div>
+            <h5>Workflow engine</h5>
+            <p class="text-muted small">Phê duyệt, thông báo, đếm SLA, kích hoạt theo lịch; cấu hình bằng giao diện trực quan, không cần lập trình.</p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 mt-4 pt-2">
+          <div class="text-center">
+            <div class="icon-circle mb-3">
+              <i class="uil uil-layer-group text-primary h2"></i>
+            </div>
+            <h5>Phân lập đa workspace</h5>
+            <p class="text-muted small">Một hệ thống phục vụ nhiều nhóm hoặc cửa hàng, dữ liệu cách ly với nhau, phân quyền độc lập.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Platform Highlights End -->
+
+  <!-- AI Employees Start -->
+  <section class="section bg-light" id="ai-employees">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <span class="badge bg-soft-primary rounded-pill mb-3">Cộng tác AI</span>
+            <h4 class="title mb-4">AI Employee tích hợp sẵn</h4>
+            <p class="para-desc mx-auto text-muted mb-0">9 AI Employee được thiết lập sẵn bao quát các vai trò nghiệp vụ điển hình, hỗ trợ kết nối Agent bên ngoài qua giao thức MCP để mở rộng năng lực</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="atlas" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Atlas</h6>
+              <p class="text-muted small mb-0">Trưởng nhóm — phân công công việc và điều phối cộng tác</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="nathan" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Nathan</h6>
+              <p class="text-muted small mb-0">Front-end engineer — tạo giao diện và code JS Block</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dara" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dara</h6>
+              <p class="text-muted small mb-0">Thiết kế trực quan — xây dựng biểu đồ và dashboard</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="viz" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Viz</h6>
+              <p class="text-muted small mb-0">Phân tích insight — nhận diện xu hướng và đọc KPI</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="vera" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Vera</h6>
+              <p class="text-muted small mb-0">Nghiên cứu — thu thập thông tin và tóm tắt</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="dex" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Dex</h6>
+              <p class="text-muted small mb-0">Sắp xếp dữ liệu — làm sạch, gộp và xử lý hàng loạt</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lexi" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lexi</h6>
+              <p class="text-muted small mb-0">Dịch thuật và giao tiếp — hội thoại và email khách hàng đa ngôn ngữ</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="lina" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Lina</h6>
+              <p class="text-muted small mb-0">Localization engineer — nội dung giao diện và i18n</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-3 overflow-hidden shadow-sm h-100">
+            <div class="text-start"><AIAvatar name="ellis" class="ai-avatar-lg" /></div>
+            <div class="card-body p-0 mt-3">
+              <h6 class="title text-dark mb-1">Ellis</h6>
+              <p class="text-muted small mb-0">Trợ lý email — phân tích ý định và soạn phản hồi</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/ai-employees/quick-start" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #fff8f0 0%, #fdecdb 100%); border: 1px dashed #f0c89a !important;">
+              <i class="uil uil-user-plus text-warning h2 mb-2"></i>
+              <h6 class="text-dark mb-1">AI Employee tùy chỉnh</h6>
+              <p class="text-muted small mb-0">Tạo vai trò / prompt / tổ hợp kỹ năng riêng theo nhu cầu nghiệp vụ</p>
+            </div>
+          </a>
+        </div>
+
+        <div class="col-lg-3 col-md-4 col-sm-6 mt-4 pt-2">
+          <a href="https://docs.nocobase.com/ai-builder" target="_blank" class="text-decoration-none">
+            <div class="card border-0 p-3 overflow-hidden shadow-sm h-100 d-flex align-items-center justify-content-center text-center" style="background: linear-gradient(135deg, #f5f7ff 0%, #eef2ff 100%); border: 1px dashed #c9d3f5 !important;">
+              <i class="uil uil-plug text-primary h2 mb-2"></i>
+              <h6 class="text-dark mb-1">Kết nối Agent bên ngoài</h6>
+              <p class="text-muted small mb-0">Dùng giao thức MCP để kết nối Agent / chuỗi công cụ của riêng bạn</p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- AI Employees End -->
+
+  <!-- Use Cases Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tình huống áp dụng</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Giải pháp tích hợp đặc biệt phù hợp với các tình huống sau</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-rocket text-primary h2 me-3"></i>
+                <div>
+                  <h5>Quản lý tổng thể đa mảng kinh doanh</h5>
+                  <p class="text-muted mb-0">Nghiệp vụ trải dài nhiều mảng như bán hàng, chăm sóc khách hàng, dự án, cần xem tổng thể trong một hệ thống thống nhất, tránh chuyển đổi giữa nhiều công cụ độc lập.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-store text-primary h2 me-3"></i>
+                <div>
+                  <h5>Cửa hàng đa mảng kinh doanh</h5>
+                  <p class="text-muted mb-0">Cửa hàng đồng thời đảm nhận bán hàng, hậu mãi và bàn giao dự án, mảng nghiệp vụ phong phú nhưng quy mô giới hạn, chi phí phối hợp của các giải pháp độc lập sẽ cao.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-search text-primary h2 me-3"></i>
+                <div>
+                  <h5>Giai đoạn thăm dò nghiệp vụ</h5>
+                  <p class="text-muted mb-0">Nghiệp vụ chưa định hình, tránh khóa vào một giải pháp cụ thể quá sớm; nền tảng tích hợp có thể đưa vào sử dụng trước, sau đó cải tiến theo nhu cầu.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 mt-4 pt-2">
+          <div class="card border-0 shadow-sm h-100">
+            <div class="card-body p-4">
+              <div class="d-flex align-items-start">
+                <i class="uil uil-graduation-cap text-primary h2 me-3"></i>
+                <div>
+                  <h5>Giảng dạy / đào tạo / POC</h5>
+                  <p class="text-muted mb-0">Là ví dụ đầy đủ về năng lực của nền tảng NocoBase, có thể dùng cho đào tạo nội bộ, demo giải pháp hoặc proof of concept, bao quát các quy trình nghiệp vụ điển hình.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Use Cases End -->
+
+  <!-- How to Use Start -->
+  <section class="section" id="how-to-use">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Cách sử dụng?</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Ba bước hoàn tất triển khai, bắt đầu sử dụng Hệ thống quản lý kinh doanh tích hợp</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-download-alt h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Cài đặt NocoBase</h5>
+                <p class="text-muted mt-2">Theo tài liệu cài đặt chính thức, triển khai NocoBase lên máy cục bộ hoặc môi trường server</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Xem tài liệu cài đặt</a>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-book-open h1 text-muted"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center">
+                <i class="uil uil-import h1 text-primary"></i>
+              </div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Sau khi khôi phục có thể sử dụng ngay toàn bộ dữ liệu mẫu, đầy đủ 6 mô-đun</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- How to Use End -->
+
+  <!-- CTA Section Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8 text-center">
+          <h3 class="title mb-4">Bắt đầu sử dụng Hệ thống quản lý kinh doanh tích hợp</h3>
+          <p class="text-muted para-desc mx-auto mb-0">
+            Hệ thống nghiệp vụ tích hợp được xây dựng trên NocoBase 2.x. Mẫu hỗ trợ sử dụng lại và mở rộng trực tiếp; nếu cần tùy chỉnh sâu cho nghiệp vụ cụ thể, hãy liên hệ với chúng tôi.
+          </p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
+              <i class="uil uil-play me-1"></i>Trải nghiệm Demo
+            </a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2">
+              <i class="uil uil-envelope me-1"></i>Liên hệ tư vấn
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA Section End -->
+
+  <ShapeFooter />
+</BaseVI>
+
+<style>
+.icon-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(47, 85, 212, 0.1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ai-avatar-lg img {
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/pages/vi/solutions/asset-management.astro
+++ b/src/pages/vi/solutions/asset-management.astro
@@ -1,0 +1,350 @@
+---
+import BaseVI from "../../../layouts/BaseVI.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseVI
+  title="Hệ thống quản lý tài sản — Quản lý tài sản IT và tài sản văn phòng mã nguồn mở | NocoBase"
+  description="Hệ thống quản lý tài sản mã nguồn mở dựa trên nền tảng no-code NocoBase: quản lý toàn bộ vòng đời mua sắm, phân bổ, bảo trì, thanh lý, bao gồm tài sản IT, tài sản văn phòng, kèm sổ theo dõi nhà cung cấp, phiếu bảo trì, phân tích mua sắm."
+  keywords="quản lý tài sản cố định, quản lý tài sản IT, hệ thống quản lý tài sản, quản lý tài sản mã nguồn mở, quản lý tài sản văn phòng, hệ thống quản lý tài sản cố định, vòng đời tài sản, hệ thống quản lý thiết bị, kiểm kê tài sản, quản lý nhà cung cấp, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Quản lý tài sản</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Hệ thống quản lý tài sản</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Quản lý toàn bộ vòng đời <strong>mua sắm → phân bổ → bảo trì → thanh lý</strong>, bao quát tài sản IT và tài sản văn phòng, kèm sổ theo dõi nhà cung cấp và phiếu bảo trì.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Toàn bộ vòng đời</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Phiếu bảo trì</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Sổ theo dõi nhà cung cấp</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Tài sản IT</span>
+                  <span class="badge bg-soft-primary me-2">Tài sản văn phòng</span>
+                  <span class="badge bg-soft-primary me-2">Cho thuê thiết bị</span>
+                  <span class="badge bg-soft-primary">Kiểm kê tài sản</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-assets-cover-260521.jpg" alt="Giao diện hệ thống quản lý tài sản" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Vòng đời tài sản</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh từ mua sắm nhập kho đến thanh lý, mọi tài sản đều có thể truy ngược</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-bag text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Mua sắm</div>
+                  <div class="small text-muted">Liên kết nhà cung cấp</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-archive text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Nhập kho</div>
+                  <div class="small text-muted">Thẻ tài sản</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-arrows text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Phân bổ</div>
+                  <div class="small text-muted">Ký xác nhận</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Bảo trì</div>
+                  <div class="small text-muted">Liên kết phiếu</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-trash-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Thanh lý</div>
+                  <div class="small opacity-75">Lưu giá trị còn lại</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Mua sắm</td>
+                      <td class="py-3 text-muted">Phiếu mua hàng liên kết nhà cung cấp và giá; hỗ trợ nhiều loại, nhiều số lượng</td>
+                      <td class="py-3 text-muted">Phiếu mua hàng, nhà cung cấp, giá trị mua sắm</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Nhập kho</td>
+                      <td class="py-3 text-muted">Nhập kho tự tạo thẻ tài sản (mã số, serial, thời hạn bảo hành nhập một lần)</td>
+                      <td class="py-3 text-muted">Thẻ tài sản, mã số duy nhất, thời hạn bảo hành</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Phân bổ</td>
+                      <td class="py-3 text-muted">Cho mượn tài sản cho nhân viên/khách hàng/phòng ban, ký xác nhận</td>
+                      <td class="py-3 text-muted">Bản ghi phân bổ, người sử dụng, ngày bắt đầu/kết thúc</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Bảo trì</td>
+                      <td class="py-3 text-muted">Khi hỏng/bảo dưỡng tạo phiếu bảo trì, liên kết thẻ tài sản</td>
+                      <td class="py-3 text-muted">Phiếu bảo trì, chi phí tích lũy</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Thanh lý</td>
+                      <td class="py-3 text-muted">Ghi nhận lý do thanh lý (hỏng/đào thải/bán), ghi nhận khấu hao/giá trị còn lại</td>
+                      <td class="py-3 text-muted">Bản ghi thanh lý, giá trị còn lại, cách xử lý</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Quản lý tài sản cố định hoàn chỉnh từ mua sắm đến thanh lý</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-bag rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Mua sắm tài sản</h5>
+              <p class="text-muted mt-2">Phiếu mua hàng liên kết nhà cung cấp và giá; nhập kho tự tạo thẻ tài sản, mã số tài sản, serial, thời hạn bảo hành nhập một lần.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-arrows rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân bổ / Trả lại</h5>
+              <p class="text-muted mt-2">Cho mượn tài sản cho nhân viên/khách hàng, ký xác nhận; trả lại ghi nhận tự giải phóng; "lịch sử sử dụng" của mỗi tài sản truy ngược đầy đủ.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-wrench rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phiếu bảo trì</h5>
+              <p class="text-muted mt-2">Khi tài sản hỏng/bảo dưỡng tạo phiếu bảo trì, liên kết thẻ tài sản; bản ghi bảo trì tích lũy chi phí, hỗ trợ quyết định thanh lý.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-trash-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Thanh lý / Bán</h5>
+              <p class="text-muted mt-2">Tài sản thanh lý ghi nhận lý do (hỏng/đào thải/bán); ghi nhận khấu hao/giá trị còn lại được lưu trữ, đối chiếu với tài chính nhất quán.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Sổ theo dõi nhà cung cấp</h5>
+              <p class="text-muted mt-2">Hồ sơ nhà cung cấp + lịch sử mua hàng; giá trị mua, loại, điều khoản thanh toán nhìn rõ, hỗ trợ quyết định mời thầu/mua sắm.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bảng tài sản</h5>
+              <p class="text-muted mt-2">Tổng số tài sản, đang dùng, đang bảo trì, đã thanh lý; tổng hợp theo loại, theo phòng ban, theo người sử dụng, dữ liệu kiểm kê xuất bằng một thao tác.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Tính năng khác đang phát triển</h5>
+              <p class="text-muted small mt-2 mb-0">Dự kiến: nhiệm vụ kiểm kê, tính khấu hao tự động, quét mã QR, quy trình phê duyệt yêu cầu mượn tài sản</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Quản lý bán hàng, Help Desk, Quản lý dự án, Quản lý nhân sự.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseVI>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/vi/solutions/crm-v2.astro
+++ b/src/pages/vi/solutions/crm-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseVI from "../../../layouts/BaseVI.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="CRM 2.0 Sales Management System - NocoBase"
-  description="CRM 2.0 sales management system built on NocoBase no-code platform. Modular design with complete sales cycle. Supports AI-assisted lead scoring, opportunity win-rate prediction, and more."
-  keywords="NocoBase CRM, AI CRM, sales management, opportunity management, customer relationship management, lead management, no-code CRM"
+<BaseVI
+  title="CRM Hệ thống quản lý khách hàng — Mã nguồn mở, tự triển khai | NocoBase"
+  description="Hệ thống CRM mã nguồn mở dựa trên nền tảng no-code NocoBase: quản lý lead, theo dõi khách hàng, chuyển đổi, gộp/khử trùng lặp, chế độ xem khách hàng 360. Dùng được ngay, hỗ trợ tự triển khai."
+  keywords="CRM, CRM mã nguồn mở, hệ thống quản lý khách hàng, quản lý quan hệ khách hàng, quản lý lead, theo dõi khách hàng, khách hàng 360, CRM no-code, CRM tự triển khai, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,792 +14,353 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">CRM 2.0<br/>Sales Management System</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Hệ thống quản lý khách hàng</h1>
             <p class="para-desc text-muted">
-              Built on NocoBase no-code platform. Modular design with complete sales cycle. Workflow automation handles routine tasks, AI assists with lead scoring, opportunity analysis, and more.
+              Được xây dựng trên nền tảng no-code NocoBase. Bao quát quy trình hoàn chỉnh từ lead, theo dõi, chuyển đổi đến gộp/khử trùng lặp; chế độ xem khách hàng 360 tổng hợp lịch sử đơn hàng, phiếu hỗ trợ, dự án, tài sản.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Smart Lead Scoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Win-Rate Prediction</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Customer Health Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Modular Design</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Quản lý giai đoạn lead</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Chế độ xem khách hàng 360</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gộp / Khử trùng lặp</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">B2B Sales</span>
-                  <span class="badge bg-soft-primary me-2">Project Sales</span>
-                  <span class="badge bg-soft-primary me-2">Foreign Trade</span>
-                  <span class="badge bg-soft-primary">All Industries</span>
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Bán hàng B2B</span>
+                  <span class="badge bg-soft-primary me-2">Bán hàng dự án</span>
+                  <span class="badge bg-soft-primary me-2">Ngoại thương</span>
+                  <span class="badge bg-soft-primary">Nhóm vừa và nhỏ</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/design-2026-02-01-02-46-56-opt.jpg"
-                alt="CRM 2.0 System Interface"
-                class="img-fluid rounded shadow"
-              />
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        </div>
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Sales teams face multiple challenges in daily operations</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Giao diện CRM Hệ thống quản lý khách hàng" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-chart-down text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inconsistent Lead Quality</h5>
-              </div>
-              <p class="text-muted mb-0">Large volumes of leads with varying quality. Sales waste time on low-quality leads while high-value ones get overlooked.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Delayed Opportunity Follow-up</h5>
-              </div>
-              <p class="text-muted mb-0">Opportunities stall without progress. Sales managers struggle to track team pipeline health, missing optimal closing windows.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Scattered Customer Data</h5>
-              </div>
-              <p class="text-muted mb-0">Customer data scattered across emails, chats, and documents. No complete customer profile for targeted marketing.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-question-circle text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Inaccurate Sales Forecasts</h5>
-              </div>
-              <p class="text-muted mb-0">Forecasting based on gut feeling without data support. Large prediction gaps affect resource allocation and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High SaaS Costs</h5>
-              </div>
-              <p class="text-muted mb-0">Salesforce, HubSpot and other SaaS CRMs charge per seat. Custom development takes long with unpredictable costs.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Data Security Concerns</h5>
-              </div>
-              <p class="text-muted mb-0">Customer and opportunity data stored on third-party clouds, not meeting data localization and privacy compliance requirements.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM 2.0 system built on NocoBase no-code platform. Workflow automation + AI assistance</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-user-plus rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Smart Lead Scoring</h5>
-              <p class="text-muted mt-2">Auto-evaluate lead quality, prioritize high-value leads, recommend optimal contact times</p>
-              <i class="uil uil-user-plus full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Win-Rate Prediction</h5>
-              <p class="text-muted mt-2">Predict close probability based on historical data, identify at-risk deals, provide stage progression suggestions</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-heart-medical rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Customer Health Monitoring</h5>
-              <p class="text-muted mt-2">360-degree customer profile, health scoring, churn risk alerts, proactive relationship maintenance</p>
-              <i class="uil uil-heart-medical full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Modular Design</h5>
-              <p class="text-muted mt-2">Independent module design, minimal setup requires only Customers + Opportunities, scale as needed</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- Sales Pipeline Start -->
+  <!-- Pipeline Start -->
   <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">Complete Sales Cycle</h4>
-            <p class="para-desc mx-auto text-muted mb-0">From lead acquisition to customer success, unified data flow with AI assistance at every stage</p>
+            <h4 class="title mb-4">Quy trình quản lý khách hàng</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Từ tiếp nhận lead đến chế độ xem khách hàng 360, dữ liệu xuyên suốt toàn chuỗi</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- Flow Chart -->
               <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
-                <div class="text-center p-3 rounded" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 100px;">
-                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Lead</div>
-                  <div class="small text-muted">AI Scoring</div>
+                  <div class="small text-muted">Đa kênh</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 100px;">
-                  <i class="uil uil-building text-warning h3 mb-2"></i>
-                  <div class="small fw-medium">Customer</div>
-                  <div class="small text-muted">360 Profile</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Liên hệ theo dõi</div>
+                  <div class="small text-muted">Ghi nhận lịch sử</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 100px;">
-                  <i class="uil uil-chart-pie-alt text-danger h3 mb-2"></i>
-                  <div class="small fw-medium">Opportunity</div>
-                  <div class="small text-muted">Win Prediction</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Chuyển đổi khách hàng</div>
+                  <div class="small text-muted">Tạo hồ sơ</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: #e8f5e9; border: 2px solid #4caf50; min-width: 100px;">
-                  <i class="uil uil-file-alt text-success h3 mb-2"></i>
-                  <div class="small fw-medium">Quote</div>
-                  <div class="small text-muted">Multi-currency</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Khách hàng 360</div>
+                  <div class="small text-muted">Tổng hợp toàn cảnh</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 100px;">
-                  <i class="uil uil-shopping-cart h3 mb-2"></i>
-                  <div class="small fw-medium">Order</div>
-                  <div class="small opacity-75">Payment Track</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Lắng đọng dữ liệu</div>
+                  <div class="small opacity-75">Bảng bán hàng</div>
                 </div>
               </div>
 
-              <!-- Stage Description -->
               <div class="table-responsive">
                 <table class="table table-hover mb-0">
                   <thead class="bg-light">
                     <tr>
-                      <th class="border-0 py-3">Stage Conversion</th>
-                      <th class="border-0 py-3">Trigger</th>
-                      <th class="border-0 py-3">AI Assistance</th>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      <td class="py-3">Lead → Customer</td>
-                      <td class="py-3 text-muted">Confirmed as valid opportunity</td>
-                      <td class="py-3 text-primary">AI score threshold triggers conversion reminder</td>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Form/import/nhập thủ công, đánh dấu nguồn và người phụ trách bán hàng</td>
+                      <td class="py-3 text-muted">Bể lead, nhãn nguồn, chuyển giai đoạn</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Customer → Opportunity</td>
-                      <td class="py-3 text-muted">Clear demand identified</td>
-                      <td class="py-3 text-primary">AI analyzes intent, recommends creating opportunity</td>
+                      <td class="py-3">Liên hệ theo dõi</td>
+                      <td class="py-3 text-muted">Ghi nhận điện thoại, email, gặp gỡ; đặt thời gian theo dõi tiếp theo</td>
+                      <td class="py-3 text-muted">Timeline theo dõi, nhắc nhở lần tới</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Opportunity → Quote</td>
-                      <td class="py-3 text-muted">Enters proposal stage</td>
-                      <td class="py-3 text-primary">AI pricing suggestions, competitor comparison, tiered pricing</td>
+                      <td class="py-3">Chuyển đổi khách hàng</td>
+                      <td class="py-3 text-muted">Lead chuyển thành khách hàng, điền hồ sơ khách hàng (ngành/quy mô/liên hệ)</td>
+                      <td class="py-3 text-muted">Bảng khách hàng, bảng liên hệ, lead liên kết</td>
                     </tr>
                     <tr>
-                      <td class="py-3">Quote → Order</td>
-                      <td class="py-3 text-muted">Customer accepts quote</td>
-                      <td class="py-3 text-primary">Auto-generate order with product details and pricing</td>
+                      <td class="py-3">Khách hàng 360</td>
+                      <td class="py-3 text-muted">Xem toàn cảnh khách hàng: đơn hàng, phiếu hỗ trợ, dự án, tài sản</td>
+                      <td class="py-3 text-muted">Block nhúng, liên kết liên mô-đun</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Lắng đọng dữ liệu</td>
+                      <td class="py-3 text-muted">Bảng bán hàng tổng hợp KPI theo nhân viên/khu vực/loại</td>
+                      <td class="py-3 text-muted">Biểu đồ, khoan sâu chi tiết, xuất dữ liệu</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Sales Pipeline End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-  <!-- AI Employee Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Assistance</span>
-            <h4 class="title mb-4">AI Assistance Capabilities</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Through workflow AI nodes, assist with scoring, analysis, writing, and other repetitive tasks</p>
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Lead, khách hàng, theo dõi, bảng điều khiển — bao quát đầy đủ công việc quản lý quan hệ khách hàng hàng ngày</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <!-- Scout -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="scout" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Scout <span class="badge bg-soft-secondary small">Workflow Node</span></h5>
-              <span class="badge bg-soft-primary mb-2">Sales Scout</span>
-              <p class="text-muted mt-2 small">Deep opportunity analysis, win-rate prediction, competitive intelligence, deal strategy suggestions</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Import lead</h5>
+              <p class="text-muted mt-2">Ba cách: import Excel hàng loạt, thu thập qua form, tiếp nhận qua API; ánh xạ trường cấu hình trực quan, tự khử trùng lặp khi xung đột.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Viz -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="viz" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Viz</h5>
-              <span class="badge bg-soft-primary mb-2">Insights Analyst</span>
-              <p class="text-muted mt-2 small">Smart lead scoring, customer health assessment, sales data analysis, pipeline forecasting</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Chuyển giai đoạn</h5>
+              <p class="text-muted mt-2">Giai đoạn lead (mới/đã liên hệ/đã chuyển đổi/đã từ bỏ) cấu hình trực quan; thay đổi giai đoạn được ghi lại, thống kê tỷ lệ chuyển đổi chạy tự động.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Ellis -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="ellis" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Ellis</h5>
-              <span class="badge bg-soft-primary mb-2">Editor Assistant</span>
-              <p class="text-muted mt-2 small">Email sentiment/intent analysis, reply drafting, communication summary</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ghi nhận theo dõi</h5>
+              <p class="text-muted mt-2">Mỗi lần gặp gỡ, điện thoại, email đều có ghi nhận; xem timeline toàn bộ lịch sử trao đổi, bàn giao không ma sát.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Dex -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="dex" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Dex</h5>
-              <span class="badge bg-soft-primary mb-2">Daily Planning</span>
-              <p class="text-muted mt-2 small">Daily priorities, next action suggestions, follow-up planning</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Nhắc nhở theo dõi</h5>
+              <p class="text-muted mt-2">Thông báo tự động trước thời điểm theo dõi tiếp theo; khách hàng lâu không liên hệ vào bảng "cần kích hoạt lại", tránh bị quên.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- Lexi -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language customer communication, content translation, foreign trade email handling</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Chế độ xem khách hàng 360</h5>
+              <p class="text-muted mt-2">Chi tiết khách hàng tổng hợp đơn hàng, phiếu hỗ trợ, dự án, tài sản; xem toàn cảnh khách hàng trên một màn hình, không phải chuyển nhiều hệ thống.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <!-- More Employees -->
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100" style="opacity: 0.7;">
-            <div class="text-start">
-              <div class="ai-avatar-placeholder" style="width: 56px; height: 56px; background: #e9ecef; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                <i class="uil uil-plus text-muted h4 mb-0"></i>
-              </div>
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-muted">More AI Employees</h5>
-              <span class="badge bg-soft-secondary mb-2">Expanding</span>
-              <p class="text-muted mt-2 small">More specialized AI employees can be added based on business needs</p>
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại và nhãn</h5>
+              <p class="text-muted mt-2">Nhãn đa chiều theo loại khách hàng, ngành, quy mô, nguồn; hỗ trợ lọc, phân tích tổng hợp theo nhãn.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employee End -->
+        </div>
 
-  <!-- Module Design Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Flexible Architecture</span>
-            <h4 class="title mb-4">Modular Design</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Each module designed independently, can be toggled on/off. Scale your solution to fit your needs</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Module</th>
-                  <th class="border-0 py-3">Required</th>
-                  <th class="border-0 py-3">Description</th>
-                  <th class="border-0 py-3">AI Capabilities</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Customer Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Customer records, contacts, tiers, decision chain</td>
-                  <td class="py-3 text-primary">Health scoring, churn alerts</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Opportunity Management</td>
-                  <td class="py-3"><span class="badge bg-success">Required</span></td>
-                  <td class="py-3 text-muted">Sales funnel, stage progression, activities</td>
-                  <td class="py-3 text-primary">Win prediction, risk identification</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Lead Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Lead capture, status workflow, conversion tracking</td>
-                  <td class="py-3 text-primary">Smart scoring, best contact time</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Quote Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Multi-currency, tiered pricing, versioning, approvals</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Order Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Order creation, payment tracking</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Product Management</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Product catalog, categories, tiered pricing</td>
-                  <td class="py-3 text-muted">-</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Email Integration</td>
-                  <td class="py-3"><span class="badge bg-secondary">Optional</span></td>
-                  <td class="py-3 text-muted">Email send/receive, CRM linking</td>
-                  <td class="py-3 text-primary">Summary, sentiment analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Solution Packages -->
-          <div class="row mt-4">
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-primary mb-2">Full Suite</span>
-                  <p class="small text-muted mb-0">All 7 modules<br/>Complete B2B sales teams</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-primary text-primary mb-2">Standard</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Order<br/>SMB sales management</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-success text-success mb-2">Lite</span>
-                  <p class="small text-muted mb-0">Customer+Opportunity<br/>Simple tracking</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6 col-lg-3 mt-3">
-              <div class="card border-0 shadow-sm h-100">
-                <div class="card-body p-3 text-center">
-                  <span class="badge bg-soft-warning text-warning mb-2">Trade</span>
-                  <p class="small text-muted mb-0">Customer+Opp+Quote+Email<br/>Foreign trade businesses</p>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gộp/khử trùng lặp</h5>
+              <p class="text-muted mt-2">Tự động nhận diện cùng một khách hàng nhập nhiều lần; gộp bằng một thao tác, lịch sử theo dõi và bản ghi liên kết được gộp không mất dữ liệu.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Module Design End -->
+        </div>
 
-  <!-- Value Proposition Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bảng bán hàng</h5>
+              <p class="text-muted mt-2">Tổng hợp KPI theo nhân viên bán hàng, khu vực, loại khách hàng; số khách hàng mới, tỷ lệ chuyển đổi, phân bố khách hàng active.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quyền cấp trường và cấp dòng</h5>
+              <p class="text-muted mt-2">Cấu hình trường hiển thị theo vai trò; nhân viên bán hàng chỉ thấy khách hàng phụ trách, quản lý xem toàn bộ.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value from Automation</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Workflow automation + AI assistance reduces repetitive work, letting sales focus on customer relationships</p>
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Lead Screening Efficiency</h5>
-              <p class="text-muted small mb-0">AI auto-scoring reduces manual screening time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Follow-up Efficiency</h5>
-              <p class="text-muted small mb-0">Win prediction helps focus on high-value deals</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Reduced Churn Rate</h5>
-              <p class="text-muted small mb-0">Health assessment identifies risks early</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">Improved Conversion</h5>
-              <p class="text-muted small mb-0">AI strategy suggestions accelerate closing</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Proposition End -->
-
-  <!-- Comparison Start -->
+  <!-- CTA Start -->
   <section class="section">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS CRM and custom development</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Dimension</th>
-                  <th class="border-0 py-3">SaaS CRM</th>
-                  <th class="border-0 py-3">Custom Dev</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of box</td>
-                  <td class="py-3 text-muted">Months of development</td>
-                  <td class="py-3 text-primary">Configure and go, quick launch</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexible customization</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full data control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Assistance</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">Workflow AI nodes, use as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Module Flexibility</td>
-                  <td class="py-3 text-muted">Bundled features</td>
-                  <td class="py-3 text-muted">Code changes needed</td>
-                  <td class="py-3 text-primary">Modular, scale as needed</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">Per-seat subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">One-time purchase, long-term use</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Comparison End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy CRM 2.0 system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution documentation to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/vi/solution/crm/" target="_blank" class="btn btn-outline-primary">Solution Docs</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restoration tutorial to deploy the CRM 2.0 system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/vi/solution/crm/installation" target="_blank" class="btn btn-outline-primary">Restore Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Start Using CRM 2.0</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Modular CRM system built on NocoBase 2.x. Contact us if you have customization needs or want to learn more.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với Quản lý bán hàng, Help Desk, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/vi/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseVI>
 
 <style>
-/* CRM 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+/* Pipeline diagram — site palette */
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
 }
 </style>

--- a/src/pages/vi/solutions/crm.astro
+++ b/src/pages/vi/solutions/crm.astro
@@ -1,57 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseVI from "../../../layouts/BaseVI.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import dashboardDemoGuides from "../../../data/crm-dashboard-demo-en.json";
-import leadConversionDemoGuides from "../../../data/crm-lead-conversion-demo-en.json";
-import opportunityDemoGuides from "../../../data/crm-opportunity-demo-en.json";
-import extensionDemoGuides from "../../../data/crm-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in CRM
-const crmPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment", 
-  "Email Manager",
-  "Workflow: Approval event",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables",
-  "Block: Tree",
-  "Template print",
-  "Workflow: JSON query node",
-  "Workflow: Custom variable",
-  "Workflow: JSON variable mapping node"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get CRM related plugins
-const crmPlugins = crmPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
-
-// Original data moved to JSON files
 ---
 
-<Layout
-  title="Nen tang CRM No-Code Linh Hoat va Manh Me"
-  description="San sang de su dung ngay, dong thoi cung cap kha nang tuy bien sau va quyen kiem soat du lieu tron ven. Mo rong field, block, function va page de CRM phu hop voi nghiep vu cua ban."
-  keywords="NocoBase CRM, CRM no-code, CRM ma nguon mo, CRM tuy chinh, quan ly quan he khach hang"
+<BaseVI
+  title="CRM Hệ thống quản lý khách hàng — Mã nguồn mở, tự triển khai | NocoBase"
+  description="Hệ thống CRM mã nguồn mở dựa trên nền tảng no-code NocoBase: quản lý lead, theo dõi khách hàng, chuyển đổi, gộp/khử trùng lặp, chế độ xem khách hàng 360. Dùng được ngay, hỗ trợ tự triển khai."
+  keywords="CRM, CRM mã nguồn mở, hệ thống quản lý khách hàng, quản lý quan hệ khách hàng, quản lý lead, theo dõi khách hàng, khách hàng 360, CRM no-code, CRM tự triển khai, NocoBase"
+  canonical="/cn/solutions/crm-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -59,803 +15,353 @@ console.log('Found plugins:', crmPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Nen tang CRM<br/>No-Code Linh Hoat va Manh Me</h1>
-            <p class="para-desc text-muted">San sang de dua vao su dung ngay, dong thoi cho phep tuy bien manh me theo nhu cau rieng. Mo rong field, block va page de xay dung giai phap phu hop nhat cho doanh nghiep, trong khi ban van giu quyen kiem soat du lieu tron ven.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Xay dung tren NocoBase 1.x (2.0 dang duoc phat trien)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun CRM</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">CRM<br/>Hệ thống quản lý khách hàng</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Bao quát quy trình hoàn chỉnh từ lead, theo dõi, chuyển đổi đến gộp/khử trùng lặp; chế độ xem khách hàng 360 tổng hợp lịch sử đơn hàng, phiếu hỗ trợ, dự án, tài sản.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Quản lý giai đoạn lead</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Chế độ xem khách hàng 360</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Gộp / Khử trùng lặp</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Nganh:</span>
-                  <span class="badge bg-soft-primary">Tat ca cac nganh</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Bán hàng B2B</span>
+                  <span class="badge bg-soft-primary me-2">Bán hàng dự án</span>
+                  <span class="badge bg-soft-primary me-2">Ngoại thương</span>
+                  <span class="badge bg-soft-primary">Nhóm vừa và nhỏ</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Nha phat trien:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Demo truc tiep
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Trien khai vao moi truong cua ban
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- CRM Preview Video -->
-            <div class="video-wrapper position-relative text-start" style="margin-top: -20px;">
-              <video 
-                id="crm-preview-video"
-                class="w-100 rounded shadow"
-                poster="https://static-docs.nocobase.com/img_v3_02o3_58bedc3b-7f22-4b56-9c74-83463ffb186g32-opt.jpeg"
-                preload="none"
-                style="cursor: pointer; max-height: 400px; object-fit: cover;"
-              >
-                <source src="https://nocobase-docs.oss-cn-beijing.aliyuncs.com/NocoBase-CRM-en-compress.mp4" type="video/mp4">
-                Your browser does not support HTML5 video.
-              </video>
-              <div id="play-button" class="position-absolute" style="top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; cursor: pointer;">
-                <i class="uil uil-play-circle" style="font-size: 84px; color: rgba(255,255,255,0.9); text-shadow: 0 2px 4px rgba(0,0,0,0.3);"></i>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-crm-cover-260521.jpg" alt="Giao diện CRM Hệ thống quản lý khách hàng" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Dieu Giup NocoBase CRM Khac Biet</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Khac voi cac san pham SaaS va CRM dong, NocoBase CRM linh hoat va nam hoan toan trong tay ban</p>
+            <h4 class="title mb-4">Quy trình quản lý khách hàng</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Từ tiếp nhận lead đến chế độ xem khách hàng 360, dữ liệu xuyên suốt toàn chuỗi</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-wrench rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Hoan Toan No-Code</h5>
-              <p class="text-muted mt-2">Khong can ky nang lap trinh de tuy chinh CRM</p>
-              <i class="uil uil-wrench full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-database rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Bao Phu Cac Tinh Nang CRM Pho Bien</h5>
-              <p class="text-muted mt-2">Quan ly khach hang, pipeline ban hang, theo doi co hoi, danh ba, email, phe duyet va nhieu hon nua</p>
-              <i class="uil uil-database full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">De Dang Dieu Chinh va Mo Rong</h5>
-              <p class="text-muted mt-2">Ho tro field tuy chinh, quy trinh va logic nghiep vu; kien truc linh hoat giup viec phat trien bo sung tro nen don gian</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Ma Nguon Mo, Kiem Soat Du Lieu Toan Dien</h5>
-              <p class="text-muted mt-2">Toan quyen kiem soat ma nguon he thong va du lieu, giup doanh nghiep chu dong hon ve bao mat</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Interactive Demo Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Thu Nhanh Cac Tinh Nang Cua NocoBase CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Trai nghiem nhanh chi voi vai thao tac</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <h5 class="mb-3">Truc Quan Hoa Du Lieu Tren Dashboard</h5>
-              <!-- Interactive Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openDashboardDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_9da41ad8-cdba-4290-aa7c-75162e16968g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-play me-2"></i>Demo tuong tac
-                  </button>
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-bullseye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Lead</div>
+                  <div class="small text-muted">Đa kênh</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-comment-alt-lines text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Liên hệ theo dõi</div>
+                  <div class="small text-muted">Ghi nhận lịch sử</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-check text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Chuyển đổi khách hàng</div>
+                  <div class="small text-muted">Tạo hồ sơ</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-user-circle text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Khách hàng 360</div>
+                  <div class="small text-muted">Tổng hợp toàn cảnh</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-chart-line h3 mb-2"></i>
+                  <div class="small fw-medium">Lắng đọng dữ liệu</div>
+                  <div class="small opacity-75">Bảng bán hàng</div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div><!--end col-->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Quy Trinh Chuyen Doi Lead</h5>
-              <!-- Lead Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openLeadDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o3_a778185b-649d-43ce-93c4-5b937fa7593g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-user-plus me-2"></i>Demo tuong tac
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4">
-              <h5 class="mb-3">Opportunity to Order</h5>
-              <!-- Opportunity Conversion Demo Entry -->
-              <div class="rounded shadow interactive-demo-card position-relative overflow-hidden" style="height: 250px; cursor: pointer;" onclick="openOpportunityDemo()">
-                <!-- Background Image -->
-                <div class="position-absolute w-100 h-100" style="background-image: url('https://static-docs.nocobase.com/img_v3_02o4_48d65d87-0214-4b1e-b426-b617add90b6g_1-opt.jpg'); background-size: cover; background-position: center;"></div>
-                <!-- Button -->
-                <div class="position-absolute w-100 d-flex justify-content-center" style="bottom: 30px;">
-                  <button class="btn btn-primary shadow">
-                    <i class="uil uil-money-bill me-2"></i>Interactive Demo
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Interactive Demo End -->
-
-  <!-- Dashboard Demo Section Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="crm-demo-wrap">
-          <!-- Using Extension Feature Interactive Demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end crm-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Dashboard Demo Section End -->
-
-  <!-- CRM Tutorial and Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">CRM Development & Extension Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to use NocoBase to build and extend professional CRM systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Basic Setup & Customization</h5>
-                <p class="text-muted text-center">Learn to create data models, customize field relationships, configure permissions and interface layouts</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-pie h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Analysis & Visualization</h5>
-                <p class="text-muted text-center">Build sales data analysis dashboards for performance monitoring and data visualization</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-setting h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Process Automation</h5>
-                <p class="text-muted text-center">Set up workflows to automate sales processes, approval workflows and business rules</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-link h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">System Integration & Extension</h5>
-                <p class="text-muted text-center">Integrate third-party systems, mobile adaptation and other advanced extension features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CRM Tutorial and Extension End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins in CRM</h4>
-            <p class="para-desc mx-auto text-muted mb-0">CRM core is open source, commercial plugins enrich functionality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {crmPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/vi/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/vi/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More plugins coming soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Lead</td>
+                      <td class="py-3 text-muted">Form/import/nhập thủ công, đánh dấu nguồn và người phụ trách bán hàng</td>
+                      <td class="py-3 text-muted">Bể lead, nhãn nguồn, chuyển giai đoạn</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Liên hệ theo dõi</td>
+                      <td class="py-3 text-muted">Ghi nhận điện thoại, email, gặp gỡ; đặt thời gian theo dõi tiếp theo</td>
+                      <td class="py-3 text-muted">Timeline theo dõi, nhắc nhở lần tới</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Chuyển đổi khách hàng</td>
+                      <td class="py-3 text-muted">Lead chuyển thành khách hàng, điền hồ sơ khách hàng (ngành/quy mô/liên hệ)</td>
+                      <td class="py-3 text-muted">Bảng khách hàng, bảng liên hệ, lead liên kết</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Khách hàng 360</td>
+                      <td class="py-3 text-muted">Xem toàn cảnh khách hàng: đơn hàng, phiếu hỗ trợ, dự án, tài sản</td>
+                      <td class="py-3 text-muted">Block nhúng, liên kết liên mô-đun</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Lắng đọng dữ liệu</td>
+                      <td class="py-3 text-muted">Bảng bán hàng tổng hợp KPI theo nhân viên/khu vực/loại</td>
+                      <td class="py-3 text-muted">Biểu đồ, khoan sâu chi tiết, xuất dữ liệu</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/vi/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/vi/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section bg-light" id="copy-tutorial">
+  <!-- Core Features Start -->
+  <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM to your environment</p>
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Lead, khách hàng, theo dõi, bảng điều khiển — bao quát đầy đủ công việc quản lý quan hệ khách hàng hàng ngày</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                                  <p class="text-muted mt-2">Follow our installation documentation to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Docs</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-import rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Import lead</h5>
+              <p class="text-muted mt-2">Ba cách: import Excel hàng loạt, thu thập qua form, tiếp nhận qua API; ánh xạ trường cấu hình trực quan, tự khử trùng lặp khi xung đột.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM Template File</h5>
-                <p class="text-muted mt-2">Get the complete template file for NocoBase CRM system, supporting two formats</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Chuyển giai đoạn</h5>
+              <p class="text-muted mt-2">Giai đoạn lead (mới/đã liên hệ/đã chuyển đổi/đã từ bỏ) cấu hình trực quan; thay đổi giai đoạn được ghi lại, thống kê tỷ lệ chuyển đổi chạy tự động.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the template file into your NocoBase system to complete deployment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://docs.nocobase.com/vi/solution/crm/v1" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-comment-alt-lines rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Ghi nhận theo dõi</h5>
+              <p class="text-muted mt-2">Mỗi lần gặp gỡ, điện thoại, email đều có ghi nhận; xem timeline toàn bộ lịch sử trao đổi, bàn giao không ma sát.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bell rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Nhắc nhở theo dõi</h5>
+              <p class="text-muted mt-2">Thông báo tự động trước thời điểm theo dõi tiếp theo; khách hàng lâu không liên hệ vào bảng "cần kích hoạt lại", tránh bị quên.</p>
+            </div>
+          </div>
+        </div>
 
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-user-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Chế độ xem khách hàng 360</h5>
+              <p class="text-muted mt-2">Chi tiết khách hàng tổng hợp đơn hàng, phiếu hỗ trợ, dự án, tài sản; xem toàn cảnh khách hàng trên một màn hình, không phải chuyển nhiều hệ thống.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-tag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại và nhãn</h5>
+              <p class="text-muted mt-2">Nhãn đa chiều theo loại khách hàng, ngành, quy mô, nguồn; hỗ trợ lọc, phân tích tổng hợp theo nhãn.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link-broken rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Gộp/khử trùng lặp</h5>
+              <p class="text-muted mt-2">Tự động nhận diện cùng một khách hàng nhập nhiều lần; gộp bằng một thao tác, lịch sử theo dõi và bản ghi liên kết được gộp không mất dữ liệu.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bảng bán hàng</h5>
+              <p class="text-muted mt-2">Tổng hợp KPI theo nhân viên bán hàng, khu vực, loại khách hàng; số khách hàng mới, tỷ lệ chuyển đổi, phân bố khách hàng active.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quyền cấp trường và cấp dòng</h5>
+              <p class="text-muted mt-2">Cấu hình trường hiển thị theo vai trò; nhân viên bán hàng chỉ thấy khách hàng phụ trách, quản lý xem toàn bộ.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase CRM?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated CRM demo in 1 minute. From configuring data structures to interface layouts to process logic, all of this is completed through NocoBase's visual configuration without writing a single line of code.
-          </p>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với Quản lý bán hàng, Help Desk, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
-
-  <!-- Dashboard Demo Modal -->
-  <div id="dashboard-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeDashboardDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{dashboardDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeDashboardDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={dashboardDemoGuides} hideHeader={true} />
         </div>
       </div>
     </div>
-  </div>
-  <!-- Dashboard Demo Modal End -->
-
-  <!-- Lead Conversion Demo Modal -->
-  <div id="lead-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeLeadDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{leadConversionDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeLeadDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={leadConversionDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Lead Conversion Demo Modal End -->
-
-  <!-- Opportunity Conversion Demo Modal -->
-  <div id="opportunity-demo-modal" class="demo-modal" style="display: none;">
-    <div class="demo-modal-overlay" onclick="closeOpportunityDemo()"></div>
-    <div class="demo-modal-content">
-      <div class="demo-modal-header">
-        <h4 class="modal-title">{opportunityDemoGuides.title}</h4>
-        <button type="button" class="demo-modal-close" onclick="closeOpportunityDemo()">
-          <i class="uil uil-times"></i>
-        </button>
-      </div>
-      <div class="demo-modal-body">
-        <div class="demo-content-wrapper">
-          <InteractiveDemo guides={opportunityDemoGuides} hideHeader={true} />
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Opportunity Conversion Demo Modal End -->
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseVI>
 
 <style>
-/* Interactive Demo Card Styles */
-.interactive-demo-card {
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.interactive-demo-card:hover {
-  transform: translateY(-2px);
-  border-color: #2f55d4;
-  box-shadow: 0 10px 30px rgba(47, 85, 212, 0.15);
-}
-
-/* Modal Styles */
-.demo-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: fadeIn 0.3s ease;
-}
-
-.demo-modal-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.demo-modal-content {
-  position: relative;
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  max-width: 95vw;
-  max-height: 90vh;
-  width: 1200px;
-  overflow: hidden;
-  animation: slideInUp 0.3s ease;
-  display: flex;
-  flex-direction: column;
-}
-
-.demo-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid #e9ecef;
-  background: #f8f9fa;
-  position: relative;
-}
-
-.demo-modal-header .modal-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
+/* Pipeline diagram — site palette */
+.pipeline-node {
   text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.demo-modal-close {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  padding: 0.5rem;
-  cursor: pointer;
-  font-size: 1.5rem;
-  color: #6c757d;
-  transition: color 0.2s ease;
+/* Hero breadcrumb */
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.demo-modal-close:hover {
-  color: #dc3545;
-}
-
-.demo-modal-body {
-  padding: 2rem;
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.demo-content-wrapper {
-  margin-top: 0;
-}
-
-/* Responsive Modal */
-@media (max-width: 768px) {
-  .demo-modal-content {
-    width: 95vw;
-    margin: 1rem;
-    max-height: 95vh;
-  }
-  
-  .demo-modal-header {
-    padding: 1rem 1.5rem;
-  }
-  
-  .demo-modal-body {
-    padding: 1rem;
-  }
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 </style>
-
-<script is:inline>
-// Modal control functions - defined in global scope
-function openDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeDashboardDemo() {
-  const modal = document.getElementById('dashboard-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Lead conversion demo modal control functions
-function openLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeLeadDemo() {
-  const modal = document.getElementById('lead-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-// Opportunity conversion demo modal control functions
-function openOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
-    
-    // Wait for modal to show then initialize interactive demo
-    setTimeout(function() {
-      // Create independent instance for modal demo
-      if (window.InteractiveDemo) {
-        new window.InteractiveDemo(modal);
-      }
-    }, 100);
-  }
-}
-
-function closeOpportunityDemo() {
-  const modal = document.getElementById('opportunity-demo-modal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = 'auto';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-  const video = document.getElementById('crm-preview-video');
-  const playButton = document.getElementById('play-button');
-  
-  if (!video || !playButton) return;
-  
-  // Only trigger play when clicking the big play button initially
-  playButton.addEventListener('click', function() {
-    // Add control bar
-    video.setAttribute('controls', '');
-    video.setAttribute('controlslist', 'nodownload');
-    
-    // Start playing and hide play button
-    video.play();
-    playButton.style.display = 'none';
-  });
-
-  // Show play button when video ends, remove control bar
-  video.addEventListener('ended', function() {
-    playButton.style.display = 'block';
-    video.removeAttribute('controls');
-  });
-
-  // ESC key to close modals
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      closeDashboardDemo();
-      closeLeadDemo();
-      closeOpportunityDemo();
-    }
-  });
-});
-</script> 

--- a/src/pages/vi/solutions/hr-management.astro
+++ b/src/pages/vi/solutions/hr-management.astro
@@ -1,0 +1,349 @@
+---
+import BaseVI from "../../../layouts/BaseVI.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseVI
+  title="Hệ thống quản lý nhân sự — Quản lý nguồn nhân lực mã nguồn mở | NocoBase"
+  description="Hệ thống quản lý nhân sự mã nguồn mở dựa trên nền tảng no-code NocoBase: hồ sơ nhân viên, vào việc, nghỉ việc, xin nghỉ, theo dõi thử việc, cấu trúc tổ chức theo vị trí và phòng ban. Nhẹ, có thể tự triển khai, phù hợp cho nhóm HR của doanh nghiệp vừa và nhỏ."
+  keywords="hệ thống quản lý nhân sự, hệ thống quản lý nguồn nhân lực, hệ thống HR mã nguồn mở, hệ thống quản lý nhân viên, quản lý vào việc, quản lý nghỉ việc, phê duyệt xin nghỉ, quản lý thử việc, quản lý cơ cấu tổ chức, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Quản lý nhân sự</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Hệ thống quản lý nhân sự</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Hồ sơ nhân viên, theo dõi toàn quy trình <strong>vào việc, nghỉ việc, xin nghỉ, thử việc</strong>, kết hợp với cấu trúc tổ chức theo vị trí và phòng ban.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Checklist vào việc / nghỉ việc</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Phê duyệt xin nghỉ</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Bảng thử việc</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Doanh nghiệp vừa và nhỏ</span>
+                  <span class="badge bg-soft-primary me-2">Chuỗi cửa hàng</span>
+                  <span class="badge bg-soft-primary me-2">HR theo ngành</span>
+                  <span class="badge bg-soft-primary">Cộng tác liên phòng ban</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-hr-cover-260521.jpg" alt="Giao diện hệ thống quản lý nhân sự" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Vòng đời nhân viên</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh quản lý nguồn nhân lực từ tuyển dụng đến nghỉ việc</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-user-plus text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tuyển dụng</div>
+                  <div class="small text-muted">Ứng viên</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-clipboard-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Vào việc</div>
+                  <div class="small text-muted">Theo dõi checklist</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-calender text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Quản lý đương chức</div>
+                  <div class="small text-muted">Chấm công, nghỉ phép</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-eye text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Đánh giá</div>
+                  <div class="small text-muted">Chính thức/chuyển vị trí</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-sign-out-alt h3 mb-2"></i>
+                  <div class="small fw-medium">Nghỉ việc</div>
+                  <div class="small opacity-75">Bàn giao, lưu trữ</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Tuyển dụng</td>
+                      <td class="py-3 text-muted">Nhập ứng viên, đánh giá phỏng vấn; sau khi đậu chuyển thành hồ sơ nhân viên</td>
+                      <td class="py-3 text-muted">Bảng ứng viên, điểm phỏng vấn</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Vào việc</td>
+                      <td class="py-3 text-muted">Checklist công việc vào việc (ký hợp đồng, làm thẻ nhân viên, nhận thiết bị, mở tài khoản)</td>
+                      <td class="py-3 text-muted">Checklist vào việc, hồ sơ hợp đồng</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Quản lý đương chức</td>
+                      <td class="py-3 text-muted">Chấm công hằng ngày, xin nghỉ, bù giờ, phê duyệt tăng ca</td>
+                      <td class="py-3 text-muted">Bản ghi xin nghỉ, số dư phép</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Đánh giá</td>
+                      <td class="py-3 text-muted">Đánh giá thử việc, lên chính thức, chuyển vị trí, thăng chức</td>
+                      <td class="py-3 text-muted">Phiếu đánh giá, thay đổi vị trí</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Nghỉ việc</td>
+                      <td class="py-3 text-muted">Checklist nghỉ việc: bàn giao, trả tài sản, khóa tài khoản, làm thủ tục</td>
+                      <td class="py-3 text-muted">Bản ghi nghỉ việc, giải phóng tài sản</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Quản lý nguồn nhân lực hoàn chỉnh từ vào việc đến nghỉ việc</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Hồ sơ nhân viên</h5>
+              <p class="text-muted mt-2">Hồ sơ nhân viên có mã, ngày vào, vị trí, phòng ban — hồ sơ thống nhất, tìm kiếm đa chiều.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Vòng đời nhân viên</h5>
+              <p class="text-muted mt-2">Chờ onboarding → thử việc → đang làm việc → đang offboarding → đã nghỉ: 5 trạng thái xuyên suốt hồ sơ; lọc theo trạng thái dễ dàng.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-sitemap rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cấu trúc phòng ban</h5>
+              <p class="text-muted mt-2">Sơ đồ tổ chức dạng cây: phòng → phòng con, dựa trên plugin departments tích hợp của NocoBase, liên kết với quyền.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-briefcase-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Hồ sơ vị trí</h5>
+              <p class="text-muted mt-2">Định nghĩa vị trí và cấp bậc (sơ cấp / trung cấp / cao cấp / chuyên gia); nhân viên gắn với vị trí, thuận lợi cho lộ trình thăng tiến và quản lý quyền.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-calender rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phê duyệt nghỉ phép</h5>
+              <p class="text-muted mt-2">8 loại nghỉ phép (năm / ốm / cá nhân / bù / cưới / con / tang / khác); quy trình phê duyệt cấu hình theo phòng / quản lý trực tiếp.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shield-check rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quyền cấp trường</h5>
+              <p class="text-muted mt-2">HR xem trường lương; quản lý xem thông tin cơ bản của đội — cấu hình linh hoạt qua quyền vai trò NocoBase.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Tính năng khác đang phát triển</h5>
+              <p class="text-muted small mt-2 mb-0">Dự kiến: checklist onboarding/offboarding, đánh giá thử việc, quản lý hợp đồng & bảo hiểm xã hội, ứng viên tuyển dụng, ghi nhận điều chuyển/thăng chức</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Quản lý bán hàng, Help Desk, Quản lý dự án, Quản lý tài sản.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseVI>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
+}
+</style>

--- a/src/pages/vi/solutions/project-management.astro
+++ b/src/pages/vi/solutions/project-management.astro
@@ -1,43 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseVI from "../../../layouts/BaseVI.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import projectDemoGuides from "../../../data/project-management-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugins used in Project Management
-const projectPluginNames = [
-  "Data Visualization: ECharts",
-  "Collection: Comment",
-  "Workflow: Custom action event"
-];
-
-// Find plugin by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get Project Management related plugins
-const projectPlugins = projectPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Comprehensive R&D Project Management Solution"
-  description="NocoBase R&D project management system provides complete development lifecycle management capabilities. From requirements planning, task assignment, progress tracking to quality management, achieving full-process digital management and team collaboration."
-  keywords="NocoBase R&D Project Management, Task Management, Team Collaboration, Agile Development, Quality Management"
+<BaseVI
+  title="Hệ thống quản lý dự án — Cộng tác dự án nhẹ mã nguồn mở | NocoBase"
+  description="Hệ thống quản lý dự án mã nguồn mở dựa trên nền tảng no-code NocoBase: quản lý hai cấp dự án + công việc, người phụ trách, tiến độ, mốc, cảnh báo trễ, phân bố khối lượng. Nhẹ, có thể tự triển khai, phù hợp cho nhóm vừa và nhỏ và cộng tác dự án liên phòng ban."
+  keywords="hệ thống quản lý dự án, phần mềm quản lý dự án, hệ thống quản lý công việc, quản lý dự án mã nguồn mở, quản lý dự án nhẹ, quản lý công việc, cộng tác dự án, theo dõi dự án, quản lý mốc, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -45,452 +14,336 @@ console.log('Found plugins:', projectPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Comprehensive<br/>R&D Project Management Solution</h1>
-            <p class="para-desc text-muted">A powerful, flexible R&D project management platform built with NocoBase. Supports multiple development methodologies including Agile, Waterfall, and hybrid approaches. Manage requirements, tasks, teams, iterations, and quality all in one place.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Quản lý dự án</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Hệ thống quản lý dự án</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Quản lý hai cấp <strong>dự án + công việc</strong>, bao gồm người phụ trách, tiến độ, mốc, cảnh báo trễ và phân bố khối lượng, nhẹ và có thể tự triển khai.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Hai cấp dự án + công việc</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Cảnh báo trễ</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Theo dõi mốc</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Industries:</span>
-                  <span class="badge bg-soft-primary">R&D</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Dự án bàn giao</span>
+                  <span class="badge bg-soft-primary me-2">IT nội bộ</span>
+                  <span class="badge bg-soft-primary me-2">Cộng tác liên phòng ban</span>
+                  <span class="badge bg-soft-primary">Nhóm vừa và nhỏ</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-pm-cover-260521.jpg" alt="Giao diện hệ thống quản lý dự án" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Quy trình dự án</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh từ khởi tạo dự án đến kết thúc, mốc và cảnh báo trễ chạy tự động</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-folder-network text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Khởi tạo dự án</div>
+                  <div class="small text-muted">Liên kết khách hàng</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-sitemap text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Chia nhỏ công việc</div>
+                  <div class="small text-muted">Người phụ trách</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-chart-line text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Theo dõi tiến độ</div>
+                  <div class="small text-muted">Cảnh báo trễ</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Mốc</div>
+                  <div class="small text-muted">Bàn giao giai đoạn</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-check-circle h3 mb-2"></i>
+                  <div class="small fw-medium">Kết thúc</div>
+                  <div class="small opacity-75">Tổng kết và lưu trữ</div>
                 </div>
               </div>
-            </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Project Management Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/screenshot-20250909-151855-1.png" 
-                alt="NocoBase R&D Project Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
-
-  <!-- Features Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">What Makes NocoBase Project Management Unique</h4>
-            <p class="para-desc mx-auto text-muted mb-0">A comprehensive solution that adapts to your project management methodology</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-layers rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Project Lifecycle</h5>
-              <p class="text-muted mt-2">From initiation and planning to execution, monitoring, closure, manage every phase of your projects</p>
-              <i class="uil uil-layers full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-chart-line rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Agile & Traditional Methods</h5>
-              <p class="text-muted mt-2">Support for Scrum sprints, Kanban boards, Gantt charts, burndown charts, and traditional waterfall approaches</p>
-              <i class="uil uil-chart-line full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Team Collaboration & Quality Management</h5>
-              <p class="text-muted mt-2">Efficiently manage development teams, track code quality, handle defects and issues, ensuring product quality</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-cube rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Easy to Modify & Extend</h5>
-              <p class="text-muted mt-2">Based on NocoBase's no-code capabilities, easily customize fields, processes and business logic with complete control</p>
-              <i class="uil uil-cube full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-
-  <!-- Try Project Management Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Interactive Demo -->
-          <InteractiveDemo guides={projectDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try It Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Copy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Project Management Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Project Management Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional project management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-database h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures for projects, tasks, teams, and their relationships</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Khởi tạo dự án</td>
+                      <td class="py-3 text-muted">Tạo dự án, liên kết khách hàng (dự án bàn giao) hoặc tài sản (dự án IT), chỉ định project manager</td>
+                      <td class="py-3 text-muted">Hồ sơ dự án, liên kết khách hàng, người phụ trách</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Chia nhỏ công việc</td>
+                      <td class="py-3 text-muted">Phân rã công việc, đặt người phụ trách, thời gian bắt đầu/kết thúc, quan hệ phụ thuộc</td>
+                      <td class="py-3 text-muted">Bảng công việc, người phụ trách, sơ đồ phụ thuộc</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Theo dõi tiến độ</td>
+                      <td class="py-3 text-muted">Thành viên cập nhật tiến độ công việc; công việc quá hạn tự đánh dấu đỏ</td>
+                      <td class="py-3 text-muted">% tiến độ, đánh dấu trễ</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Mốc</td>
+                      <td class="py-3 text-muted">Đặt các điểm chính làm mốc (review/internal test/go live); ghi nhận sản phẩm bàn giao theo giai đoạn</td>
+                      <td class="py-3 text-muted">Danh sách mốc, file đính kèm sản phẩm bàn giao</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Kết thúc</td>
+                      <td class="py-3 text-muted">Hoàn tất và lưu trữ dự án, ghi nhận thời gian làm việc và chi phí</td>
+                      <td class="py-3 text-muted">Báo cáo kết thúc, tổng hợp giờ làm</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-sitemap h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up task assignment, status transitions and automated project workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-chart-line h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Sprint & Tracking</h5>
-                <p class="text-muted text-center">Configure sprints, burndown charts and progress tracking features</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Enhance with Commercial Plugins</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Extend your project management capabilities with powerful commercial plugins</p>
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Theo dõi dự án nhẹ hoàn chỉnh từ khởi tạo đến kết thúc</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row pb-4">
-        <!-- Dynamically generated plugin cards -->
-        {projectPlugins.slice(0, 6).map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/vi/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year_usd || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/vi/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-folder-network rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Hai cấp dự án + công việc</h5>
+              <p class="text-muted mt-2">Một dự án chia thành nhiều công việc, người phụ trách, thời gian bắt đầu/kết thúc, tiến độ duy trì độc lập; bảng dự án tổng quan trạng thái toàn bộ công việc.</p>
             </div>
-          );
-        })}
-      </div><!--end row-->
+          </div>
+        </div>
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/vi/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/vi/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý mốc</h5>
+              <p class="text-muted mt-2">Đặt các điểm chính làm mốc (review nguyên mẫu, internal test, go live); tiến độ dự án thể hiện theo nhịp mốc.</p>
+            </div>
+          </div>
+        </div>
 
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-triangle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Cảnh báo trễ</h5>
+              <p class="text-muted mt-2">Công việc vượt deadline tự đánh dấu đỏ, danh sách dự án trễ làm mới real-time, người quản lý nhìn rõ điểm rủi ro.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-users-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Người phụ trách và khối lượng</h5>
+              <p class="text-muted mt-2">Tổng hợp số lượng công việc và khối lượng theo người phụ trách; ai đang nhiều việc, ai rảnh, ai trễ nhiều — người quản lý nhìn rõ.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bảng trạng thái dự án</h5>
+              <p class="text-muted mt-2">Tổng hợp KPI theo loại dự án, trạng thái, người phụ trách; dự án đang chạy, đã kết thúc, đang trễ — hiển thị phân loại.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-link rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Liên kết khách hàng và tài sản</h5>
+              <p class="text-muted mt-2">Dự án có thể liên kết khách hàng (dự án bàn giao), tài sản (dự án IT); trang chi tiết khách hàng thấy lịch sử dự án liên quan.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Tính năng khác đang phát triển</h5>
+              <p class="text-muted small mt-2 mb-0">Dự kiến: biểu đồ phụ thuộc nhiệm vụ, ghi nhận thời gian & chi phí, lưu trữ sản phẩm bàn giao, biểu đồ Gantt</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with project management functionality to your environment</p>
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
               </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
             <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
               <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get project management capability</p>
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
               </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
               </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and project management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/vi/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Project management feature explanation -->
-      <div class="row justify-content-center mt-5">
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
         <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The project management system is fully integrated into the CRM template as a comprehensive module. After deployment, you can directly use the complete project management functionality within the CRM system to achieve full-process project and team management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Transform Your R&D Management?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a comprehensive R&D management solution in minutes. From requirements planning to task tracking and quality control, NocoBase adapts to your development process without writing a single line of code.
-          </p>
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Quản lý bán hàng, Help Desk, Quản lý tài sản, Quản lý nhân sự.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy Now
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseVI>
 
 <style>
-/* Project Management System Styles - Reference ticketing page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>
-

--- a/src/pages/vi/solutions/project-management.astro
+++ b/src/pages/vi/solutions/project-management.astro
@@ -94,7 +94,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
                 </div>
                 <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
                 <div class="pipeline-node">
-                  <i class="uil uil-flag-alt text-primary h3 mb-2"></i>
+                  <i class="uil uil-map-marker text-primary h3 mb-2"></i>
                   <div class="small fw-medium">Mốc</div>
                   <div class="small text-muted">Bàn giao giai đoạn</div>
                 </div>
@@ -177,7 +177,7 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-flag-alt rounded h3 mb-0"></i></div>
+            <div class="icons text-start"><i class="uil uil-map-marker rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Quản lý mốc</h5>
               <p class="text-muted mt-2">Đặt các điểm chính làm mốc (review nguyên mẫu, internal test, go live); tiến độ dự án thể hiện theo nhịp mốc.</p>

--- a/src/pages/vi/solutions/sales-management.astro
+++ b/src/pages/vi/solutions/sales-management.astro
@@ -217,36 +217,6 @@ import ShapeFooter from "../../../components/ShapeFooter.astro";
 
         <div class="col-lg-4 col-md-6 mt-4 pt-2">
           <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">KPI công nợ phải thu</h5>
-              <p class="text-muted mt-2">Danh sách công nợ quá hạn, phân tích tuổi nợ (phân nhóm 30/60/90 ngày); tổng hợp theo khách hàng, theo nhân viên bán, thu hồi nợ nhìn rõ.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Đa tệ và tỷ giá</h5>
-              <p class="text-muted mt-2">Báo giá và đơn hàng đa tệ USD/EUR/CNY; bảng tỷ giá hỗ trợ duy trì thủ công hoặc import; tự quy đổi tổng nội tệ.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
-            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Giao hàng và vận chuyển</h5>
-              <p class="text-muted mt-2">Phiếu giao hàng liên kết đơn hàng và mã vận đơn; hỗ trợ giao nhiều lần, giao một phần; trạng thái đồng bộ tự động về đơn hàng.</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
             <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
             <div class="card-body p-0 mt-4">
               <h5 class="title text-dark">Bảng bán hàng</h5>

--- a/src/pages/vi/solutions/sales-management.astro
+++ b/src/pages/vi/solutions/sales-management.astro
@@ -1,0 +1,364 @@
+---
+import BaseVI from "../../../layouts/BaseVI.astro";
+import ShapeFooter from "../../../components/ShapeFooter.astro";
+---
+
+<BaseVI
+  title="Hệ thống quản lý bán hàng — Quản lý đơn hàng và công nợ phải thu mã nguồn mở | NocoBase"
+  description="Hệ thống quản lý bán hàng mã nguồn mở dựa trên nền tảng no-code NocoBase: chuỗi hoàn chỉnh báo giá, đơn hàng, hóa đơn, thu tiền, tích hợp sẵn quy trình phê duyệt, đa tệ, KPI công nợ phải thu và phân tích quá hạn."
+  keywords="hệ thống quản lý bán hàng, quản lý đơn hàng bán, báo giá, quản lý hóa đơn, quản lý công nợ phải thu, quản lý thu tiền, quy trình bán hàng, phê duyệt bán hàng, quản lý bán hàng mã nguồn mở, báo giá đa tệ, NocoBase"
+>
+  <!-- Hero/Banner Start -->
+  <section class="bg-half-170 bg-light d-table w-100">
+    <div class="container">
+      <div class="row align-items-center">
+        <div class="col-lg-6 col-md-7 order-1 order-md-1">
+          <div class="title-heading">
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Quản lý bán hàng</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Hệ thống quản lý bán hàng</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Chuỗi hoàn chỉnh <strong>báo giá → đơn hàng → hóa đơn → thu tiền</strong>, tích hợp sẵn workflow phê duyệt bán hàng, báo giá đa tệ, KPI công nợ phải thu và phân tích quá hạn.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Báo giá đa tệ</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Workflow phê duyệt đơn hàng</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">KPI công nợ phải thu</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
+            </div>
+
+            <div class="row mt-4">
+              <div class="col-auto">
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Bán hàng B2B</span>
+                  <span class="badge bg-soft-primary me-2">Đơn hàng ngoại thương</span>
+                  <span class="badge bg-soft-primary me-2">Bán thiết bị</span>
+                  <span class="badge bg-soft-primary">Quản lý công nợ phải thu</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-sales-cover-260521.jpg" alt="Giao diện hệ thống quản lý bán hàng" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
+
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Quy trình bán hàng</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh từ báo giá đến thu tiền, phê duyệt và KPI công nợ phải thu liên thông toàn chuỗi</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Báo giá</div>
+                  <div class="small text-muted">Đa tệ</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-shopping-cart text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Đơn hàng</div>
+                  <div class="small text-muted">Workflow phê duyệt</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-truck text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Giao hàng</div>
+                  <div class="small text-muted">Theo dõi vận chuyển</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-receipt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Hóa đơn</div>
+                  <div class="small text-muted">Tự điền khách hàng</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-money-withdrawal h3 mb-2"></i>
+                  <div class="small fw-medium">Thu tiền</div>
+                  <div class="small opacity-75">KPI phải thu</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Báo giá</td>
+                      <td class="py-3 text-muted">Chọn khách hàng/sản phẩm, tạo báo giá đa tệ, hỗ trợ chiết khấu, thuế suất, thời hạn hiệu lực</td>
+                      <td class="py-3 text-muted">Báo giá, chi tiết sản phẩm, xuất PDF</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Đơn hàng</td>
+                      <td class="py-3 text-muted">Báo giá chuyển thành đơn hàng; chiết khấu vượt mức, đơn hàng giá trị lớn kích hoạt phê duyệt</td>
+                      <td class="py-3 text-muted">Đơn hàng bán, workflow phê duyệt, chi tiết đơn hàng</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Giao hàng</td>
+                      <td class="py-3 text-muted">Sau khi xác nhận đơn hàng, ghi nhận phiếu giao hàng, liên kết mã vận đơn</td>
+                      <td class="py-3 text-muted">Phiếu giao hàng, mã vận đơn, chuyển trạng thái</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Hóa đơn</td>
+                      <td class="py-3 text-muted">Xuất hóa đơn từ đơn hàng hoặc sau khi giao, mã số thuế/địa chỉ trong hồ sơ khách hàng tự điền</td>
+                      <td class="py-3 text-muted">Bản ghi hóa đơn, trạng thái xuất hóa đơn</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Thu tiền</td>
+                      <td class="py-3 text-muted">Ghi nhận thu tiền theo nhiều đợt; tổng hợp KPI phải thu theo tuổi nợ</td>
+                      <td class="py-3 text-muted">Bản ghi thu tiền, số dư phải thu, phân nhóm tuổi nợ</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
+
+  <!-- Core Features Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Toàn chuỗi báo giá, đơn hàng, hóa đơn, thu tiền + phê duyệt và phân tích công nợ phải thu</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-file-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý báo giá</h5>
+              <p class="text-muted mt-2">Báo giá đa tệ, hỗ trợ chiết khấu, thuế suất, thời hạn hiệu lực; xuất PDF gửi khách hàng bằng một thao tác; hỗ trợ chuyển thành đơn hàng bán.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-shopping-cart rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Đơn hàng bán</h5>
+              <p class="text-muted mt-2">Chuyển trạng thái đơn hàng (nháp/đang duyệt/đã xác nhận/đã giao/đã đóng), liên kết khách hàng và sản phẩm, chi tiết đơn hàng có thể chỉnh sửa theo dòng.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-process rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workflow phê duyệt đơn hàng</h5>
+              <p class="text-muted mt-2">Chiết khấu vượt mức, đơn hàng giá trị lớn, điều khoản đặc biệt kích hoạt phê duyệt; cấu hình các bước phê duyệt linh hoạt theo phòng ban, vị trí, ngưỡng giá trị.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-receipt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Quản lý hóa đơn</h5>
+              <p class="text-muted mt-2">Đơn hàng tạo hóa đơn, theo dõi trạng thái xuất hóa đơn; mã số thuế, địa chỉ, ghi chú trong hồ sơ khách hàng tự điền, giảm nhập sai bằng tay.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-money-withdrawal rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bản ghi thu tiền</h5>
+              <p class="text-muted mt-2">Thu tiền nhiều đợt, đến tiền một phần; tự tính số dư phải thu; tổng hợp trạng thái thanh toán theo khách hàng, theo đơn hàng.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-exclamation-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">KPI công nợ phải thu</h5>
+              <p class="text-muted mt-2">Danh sách công nợ quá hạn, phân tích tuổi nợ (phân nhóm 30/60/90 ngày); tổng hợp theo khách hàng, theo nhân viên bán, thu hồi nợ nhìn rõ.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-globe rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Đa tệ và tỷ giá</h5>
+              <p class="text-muted mt-2">Báo giá và đơn hàng đa tệ USD/EUR/CNY; bảng tỷ giá hỗ trợ duy trì thủ công hoặc import; tự quy đổi tổng nội tệ.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-truck rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Giao hàng và vận chuyển</h5>
+              <p class="text-muted mt-2">Phiếu giao hàng liên kết đơn hàng và mã vận đơn; hỗ trợ giao nhiều lần, giao một phần; trạng thái đồng bộ tự động về đơn hàng.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-line rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Bảng bán hàng</h5>
+              <p class="text-muted mt-2">Tổng hợp doanh số, số đơn, tỷ lệ thu hồi theo nhân viên bán, khu vực, sản phẩm; xu hướng theo tháng/quý nhìn rõ.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
+          </div>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Help Desk, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
+
+  <ShapeFooter />
+</BaseVI>
+
+<style>
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
+}
+
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
+}
+
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
+}
+</style>

--- a/src/pages/vi/solutions/ticketing-v2.astro
+++ b/src/pages/vi/solutions/ticketing-v2.astro
@@ -1,13 +1,12 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseVI from "../../../layouts/BaseVI.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import AIAvatar from "../../../components/AIAvatar.astro";
 ---
 
-<Layout
-  title="AI-Powered Intelligent Ticketing System - NocoBase"
-  description="NocoBase AI-powered intelligent ticketing system with T-shaped data architecture supporting multiple business scenarios. AI employee team for auto-classification, smart replies, and knowledge recommendations. Full SLA monitoring for complete ticket lifecycle management."
-  keywords="NocoBase ticketing system, AI ticketing, intelligent customer service, SLA management, knowledge base, ticket classification"
+<BaseVI
+  title="Help Desk — Hệ thống phiếu hỗ trợ khách hàng mã nguồn mở | NocoBase"
+  description="Hệ thống phiếu hỗ trợ mã nguồn mở dựa trên nền tảng no-code NocoBase: tiếp nhận sự cố, phân công thông minh, đếm SLA, mức ưu tiên, phân loại AI, đánh giá hài lòng, workspace nhân viên hỗ trợ. Dùng được ngay, phù hợp cho nhóm hỗ trợ khách hàng và đội hậu mãi vừa và nhỏ."
+  keywords="Help Desk, hệ thống phiếu hỗ trợ khách hàng, phiếu hỗ trợ mã nguồn mở, help desk, hệ thống ticketing, quản lý phiếu, quản lý SLA, hệ thống hậu mãi, hệ thống dịch vụ khách hàng, NocoBase"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -15,877 +14,336 @@ import AIAvatar from "../../../components/AIAvatar.astro";
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">AI-Powered<br/>Intelligent Ticketing</h1>
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk</h1>
             <p class="para-desc text-muted">
-              Let support teams focus on solving problems, not navigating complex workflows. Built on NocoBase no-code platform with T-shaped data architecture for unified multi-business management. AI employee team powers the entire ticket lifecycle from creation to closure.
+              Được xây dựng trên nền tảng no-code NocoBase. Chuỗi hoàn chỉnh <strong>khách hàng báo sự cố → phân công thông minh → xử lý → đánh giá hài lòng</strong>, tích hợp sẵn đếm SLA, quản lý mức ưu tiên, phân loại thông minh bằng AI và workspace nhân viên hỗ trợ.
             </p>
 
-            <!-- Core Values -->
             <div class="row mt-4 g-3">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Multi-source Intake</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">AI Smart Routing</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Full SLA Monitoring</span>
-                </div>
-              </div>
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <i class="uil uil-check-circle text-success me-2"></i>
-                  <span class="small">Auto Knowledge Capture</span>
-                </div>
-              </div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tự động đếm SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 mức ưu tiên</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Phân loại thông minh bằng AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
             </div>
 
-            <!-- Use Case Tags -->
             <div class="row mt-4">
               <div class="col-auto">
                 <div class="d-flex align-items-center flex-wrap">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Equipment Repair</span>
-                  <span class="badge bg-soft-primary me-2">IT Support</span>
-                  <span class="badge bg-soft-primary me-2">Customer Complaints</span>
-                  <span class="badge bg-soft-primary">Inquiries</span>
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Hỗ trợ và hậu mãi</span>
+                  <span class="badge bg-soft-primary me-2">IT Service Desk</span>
+                  <span class="badge bg-soft-primary me-2">Bảo trì thiết bị</span>
+                  <span class="badge bg-soft-primary">Hỗ trợ SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live Demo
-              </a>
-              <a href="#how-to-use" class="btn btn-outline-primary">
-                <i class="uil uil-download-alt me-1"></i>How to Use
-              </a>
-            </div>
-
-            <div class="mt-3 p-2" style="background-color: #fff3e0; border-left: 3px solid #ff9800; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle me-1"></i>Alpha version is now live. Try it out - we're actively improving.
-              </small>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <div class="position-relative">
-              <img
-                src="https://static-docs.nocobase.com/ticketing-imgs-2026-01-01-00-46-12-opt.jpg"
-                alt="Intelligent Ticketing System Interface"
-                class="img-fluid rounded shadow"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Giao diện Help Desk" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Pain Points Start -->
-  <section class="section" id="pain-points">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Are You Facing These Challenges?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Enterprises face diverse service requests with scattered sources, varying workflows, and lack of unified management</p>
+            <h4 class="title mb-4">Quy trình xử lý phiếu</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh từ khách hàng báo sự cố đến đóng phiếu và đánh giá, SLA đếm toàn bộ quá trình</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-money-bill-slash text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">High Cost, Slow Customization</h5>
-              </div>
-              <p class="text-muted mb-0">SaaS ticketing systems are expensive. Custom development takes long with unpredictable costs. Hard to adapt when business needs change.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-database text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Fragmented Systems, Data Silos</h5>
-              </div>
-              <p class="text-muted mb-0">Equipment repair, IT support, customer complaints scattered across different systems. Difficult to unify analysis and decision-making.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-hourglass text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Slow Response, No Transparency</h5>
-              </div>
-              <p class="text-muted mb-0">Requests flow inefficiently between systems. Customers can't track progress and frequently inquire, adding pressure on support.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-shield-exclamation text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Quality Hard to Ensure</h5>
-              </div>
-              <p class="text-muted mb-0">No SLA monitoring mechanism. Timeouts and negative feedback can't be warned in time. Service quality varies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-book-alt text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Knowledge Can't Accumulate</h5>
-              </div>
-              <p class="text-muted mb-0">Solutions scattered everywhere. New hires slow to onboard. Same problems solved repeatedly with low efficiency.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow-sm h-100" style="border-left: 4px solid #6c757d !important;">
-            <div class="card-body p-4">
-              <div class="d-flex align-items-center mb-3">
-                <i class="uil uil-robot text-muted h3 mb-0 me-3"></i>
-                <h5 class="mb-0">Missing AI Capabilities</h5>
-              </div>
-              <p class="text-muted mb-0">Traditional systems lack AI assistance. Manual classification is time-consuming. No smart recommendations or auto-replies.</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Pain Points End -->
-
-  <!-- Solution Overview Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Our Solution</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Universal ticketing platform built on NocoBase no-code: unified intake, smart distribution, multi-business support, closed-loop feedback</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Core Modules -->
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-exchange rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Multi-source Intake</h5>
-              <p class="text-muted mt-2">Public forms, customer portal, email parsing, API/Webhook. All channels unified with automatic deduplication</p>
-              <i class="uil uil-exchange full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-brain rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">AI Smart Routing</h5>
-              <p class="text-muted mt-2">Auto intent recognition, sentiment analysis, urgency assessment. Skill matching and load balancing for smart assignment</p>
-              <i class="uil uil-brain full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-clock rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Full SLA Monitoring</h5>
-              <p class="text-muted mt-2">P0-P3 four priority levels. Auto-tracking of response/resolution times. Timeout alerts and escalation</p>
-              <i class="uil uil-clock full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-star rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">
-              <h5 class="title text-dark">Closed-loop Feedback</h5>
-              <p class="text-muted mt-2">Multi-dimensional satisfaction ratings, NPS scores, negative feedback alerts and follow-up for continuous improvement</p>
-              <i class="uil uil-star full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Solution Overview End -->
-
-  <!-- T-shaped Architecture Start -->
-  <section class="section" id="architecture">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-success rounded-pill mb-3">Core Design</span>
-            <h4 class="title mb-4">T-Shaped Data Architecture</h4>
-            <p class="para-desc mx-auto text-muted mb-0">All tickets share a main table with unified workflows. Business-specific fields go into extension tables. Add new business types by simply adding tables</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row justify-content-center">
         <div class="col-lg-10">
           <div class="card border-0 shadow">
             <div class="card-body p-4">
-              <!-- T-shaped Architecture Diagram -->
-              <div class="text-center mb-4">
-                <div class="d-inline-block p-3 rounded" style="background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%); color: white; min-width: 400px;">
-                  <strong>Main Ticket Table (nb_tts_tickets)</strong>
-                  <div class="small mt-2 opacity-75">Ticket# | Title | Status | Priority | Assignee | SLA | AI Analysis</div>
-                </div>
-              </div>
-
-              <!-- Connection Lines -->
-              <div class="text-center mb-3">
-                <div style="width: 2px; height: 30px; background: #dee2e6; margin: 0 auto;"></div>
-                <div style="width: 60%; height: 2px; background: #dee2e6; margin: 0 auto;"></div>
-              </div>
-
-              <!-- Business Extension Tables -->
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <div class="p-3 rounded text-center" style="background: #fff3e0; border: 2px solid #ff9800; min-width: 180px;">
-                  <i class="uil uil-wrench text-warning h4 mb-2"></i>
-                  <strong class="text-dark d-block">Equipment Repair</strong>
-                  <div class="small text-muted mt-2">Serial# | Fault Code<br/>Parts List | Site Photos</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #e3f2fd; border: 2px solid #2196f3; min-width: 180px;">
-                  <i class="uil uil-desktop text-primary h4 mb-2"></i>
-                  <strong class="text-dark d-block">IT Support</strong>
-                  <div class="small text-muted mt-2">Asset ID | OS Version<br/>Remote URL | Error Code</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #fce4ec; border: 2px solid #e91e63; min-width: 180px;">
-                  <i class="uil uil-comment-exclamation text-danger h4 mb-2"></i>
-                  <strong class="text-dark d-block">Customer Complaint</strong>
-                  <div class="small text-muted mt-2">Order ID | Severity<br/>Compensation | Root Cause</div>
-                </div>
-                <div class="p-3 rounded text-center" style="background: #f5f5f5; border: 2px dashed #9e9e9e; min-width: 180px;">
-                  <i class="uil uil-plus text-muted h4 mb-2"></i>
-                  <strong class="text-muted d-block">More Business...</strong>
-                  <div class="small text-muted mt-2">Extend as needed<br/>Core flow unchanged</div>
-                </div>
-              </div>
-
-              <!-- Advantage Description -->
-              <div class="row mt-4 pt-3 border-top">
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-chart-bar text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Unified Reports</h6>
-                  <p class="text-muted small mb-0">One table for all ticket stats</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-sync text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Workflow Reuse</h6>
-                  <p class="text-muted small mb-0">Change core flow in one place</p>
-                </div>
-                <div class="col-md-4 text-center">
-                  <i class="uil uil-plus-circle text-primary h4"></i>
-                  <h6 class="mt-2 mb-1">Flexible Extension</h6>
-                  <p class="text-muted small mb-0">New business = new table</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- T-shaped Architecture End -->
-
-  <!-- AI Employees Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-primary rounded-pill mb-3">AI Native</span>
-            <h4 class="title mb-4">AI Employee Team</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Not just "adding an AI button" - AI employees are embedded in every step. Each AI has clear roles, responsibilities, and personality</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <!-- Sam -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="sam" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Sam</h5>
-              <span class="badge bg-soft-primary mb-2">Service Desk Lead</span>
-              <p class="text-muted mt-2 small">Ticket routing, priority assessment, escalation decisions, SLA risk identification</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket creation</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Grace -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="grace" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Grace</h5>
-              <span class="badge bg-soft-primary mb-2">Customer Success Expert</span>
-              <p class="text-muted mt-2 small">Reply generation, tone adjustment, complaint handling, EQ firewall</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Click "AI Reply"</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Max -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="max" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Max</h5>
-              <span class="badge bg-soft-primary mb-2">Knowledge Assistant</span>
-              <p class="text-muted mt-2 small">Similar cases, knowledge recommendations, solution synthesis, knowledge generation</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto on ticket detail page</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <!-- Lexi -->
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="text-start">
-              <AIAvatar name="lexi" class="ai-avatar-lg" />
-            </div>
-            <div class="card-body p-0 mt-3">
-              <h5 class="title text-dark">Lexi</h5>
-              <span class="badge bg-soft-primary mb-2">Translator</span>
-              <p class="text-muted mt-2 small">Multi-language translation, quality review, sensitive info interception</p>
-              <div class="border-top pt-2 mt-3">
-                <span class="small text-muted">Trigger: Auto when foreign language detected</span>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- EQ Firewall Example -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-10">
-          <div class="card border-0 shadow-sm" style="background: #f8f9fa;">
-            <div class="card-body p-4">
-              <h5 class="mb-3"><AIAvatar name="grace" class="ai-avatar-sm me-2" />Grace's EQ Firewall</h5>
-              <p class="text-muted mb-3">Automatically detects and optimizes negative expressions in support replies to prevent secondary complaints</p>
-              <div class="row">
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 mb-3 mb-md-0 border">
-                    <span class="badge bg-secondary mb-2">Original</span>
-                    <p class="mb-0 small">"That's not our problem, you configured it wrong"</p>
-                  </div>
-                </div>
-                <div class="col-md-6">
-                  <div class="bg-white rounded p-3 border">
-                    <span class="badge bg-primary mb-2">Optimized</span>
-                    <p class="mb-0 small">"After investigation, the issue is in the configuration. Let me help you adjust the settings to ensure it works properly"</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- AI Employees End -->
-
-  <!-- Knowledge Loop Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <span class="badge bg-soft-warning rounded-pill mb-3">Knowledge Management</span>
-            <h4 class="title mb-4">Knowledge Self-circulation System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Resolved tickets automatically become knowledge. AI recommends knowledge for similar issues, creating a knowledge capture-application loop</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <!-- Circulation Flow Diagram -->
-          <div class="card border-0 shadow">
-            <div class="card-body p-4">
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-check-circle text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Ticket Resolved</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-analysis text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Value Assessment</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-file-alt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Generate Article</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-eye text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Human Review</div>
-                </div>
-              </div>
-
-              <div class="text-center my-3">
-                <i class="uil uil-corner-down-left h3 text-muted"></i>
-              </div>
-
-              <div class="d-flex flex-wrap justify-content-center align-items-center gap-3">
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-book-open text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Knowledge Base</div>
-                </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
                   <i class="uil uil-ticket text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Similar Ticket</div>
+                  <div class="small fw-medium">Tạo</div>
+                  <div class="small text-muted">Đa kênh</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-lightbulb text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">AI Recommends</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Phân loại thông minh</div>
+                  <div class="small text-muted">AI nhận diện</div>
                 </div>
-                <i class="uil uil-arrow-right h4 text-muted"></i>
-                <div class="text-center p-3 rounded bg-light" style="min-width: 120px;">
-                  <i class="uil uil-bolt text-primary h3 mb-2"></i>
-                  <div class="small fw-medium">Quick Resolution</div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Phân công</div>
+                  <div class="small text-muted">Theo quy tắc nhóm</div>
                 </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Xử lý</div>
+                  <div class="small text-muted">Đếm SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Đánh giá</div>
+                  <div class="small opacity-75">Đóng và lưu trữ</div>
+                </div>
+              </div>
+
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Tạo</td>
+                      <td class="py-3 text-muted">Khách hàng gửi qua email, form, IM đa kênh; liên kết khách hàng và sản phẩm</td>
+                      <td class="py-3 text-muted">Mã phiếu, nguồn, hồ sơ khách hàng</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Phân loại thông minh</td>
+                      <td class="py-3 text-muted">AI nhận diện loại vấn đề (tài khoản/chức năng/Bug), tự đặt mức ưu tiên</td>
+                      <td class="py-3 text-muted">Nhãn phân loại, mức ưu tiên, độ tin cậy</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Phân công</td>
+                      <td class="py-3 text-muted">Phân theo quy tắc cho nhóm/nhân viên tương ứng, phiếu khẩn cấp tự thông báo người trực</td>
+                      <td class="py-3 text-muted">Người phụ trách, lịch sử phân công, hàng đợi nhóm</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Xử lý</td>
+                      <td class="py-3 text-muted">Nhân viên hỗ trợ xử lý, trao đổi với khách hàng; SLA đếm, cảnh báo trước khi quá hạn</td>
+                      <td class="py-3 text-muted">Log xử lý, trạng thái SLA, nguyên nhân chờ</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Đánh giá</td>
+                      <td class="py-3 text-muted">Gửi yêu cầu đánh giá đến khách hàng khi đóng phiếu (1-5 sao + chữ), tổng hợp theo nhân viên/sản phẩm</td>
+                      <td class="py-3 text-muted">Bản ghi hài lòng, phiếu lưu trữ, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <!-- Knowledge Conversion Criteria -->
-      <div class="row justify-content-center mt-4">
-        <div class="col-lg-10">
-          <div class="row">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-file-check-alt text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Complete Description</h6>
-                  <p class="text-muted small mb-0">Description >= 200 characters</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-comments text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Sufficient Discussion</h6>
-                  <p class="text-muted small mb-0">Comments >= 2</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-star text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Quality Standards</h6>
-                  <p class="text-muted small mb-0">AI Score >= 0.6</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Knowledge Loop End -->
-
-  <!-- SLA Config Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">SLA Service Level Management</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Set response and resolution times by priority. Auto monitoring, alerts, escalation. SLA pauses when ticket is on hold</p>
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Quản lý phiếu hỗ trợ hoàn chỉnh từ tiếp nhận đến đóng phiếu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Priority</th>
-                  <th class="border-0 py-3">Response Time</th>
-                  <th class="border-0 py-3">Resolution Time</th>
-                  <th class="border-0 py-3">Typical Scenario</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3"><span class="badge bg-dark">P0 Critical</span></td>
-                  <td class="py-3">15 minutes</td>
-                  <td class="py-3">2 hours</td>
-                  <td class="py-3 text-muted small">System down, production stopped</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-primary">P1 High</span></td>
-                  <td class="py-3">1 hour</td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3 text-muted small">Major feature failure, high impact</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-soft-primary text-primary">P2 Medium</span></td>
-                  <td class="py-3">4 hours</td>
-                  <td class="py-3">24 hours</td>
-                  <td class="py-3 text-muted small">General issues, workaround available</td>
-                </tr>
-                <tr>
-                  <td class="py-3"><span class="badge bg-secondary">P3 Low</span></td>
-                  <td class="py-3">8 hours</td>
-                  <td class="py-3">72 hours</td>
-                  <td class="py-3 text-muted small">Suggestions, feature inquiries</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="row mt-4">
-            <div class="col-md-4">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-bell text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Early Warning</h6>
-                  <p class="text-muted small mb-0">Notify assignee when &lt; 20% time left</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-exclamation-triangle text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Timeout Alert</h6>
-                  <p class="text-muted small mb-0">Notify assignee + supervisor on timeout</p>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-4 mt-3 mt-md-0">
-              <div class="d-flex align-items-start p-3 bg-white rounded shadow-sm">
-                <i class="uil uil-arrow-growth text-primary h4 me-3 mb-0"></i>
-                <div>
-                  <h6 class="mb-1">Auto Escalation</h6>
-                  <p class="text-muted small mb-0">Notify manager after 1 hour timeout</p>
-                </div>
-              </div>
+      <div class="row">
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Đếm và cảnh báo SLA</h5>
+              <p class="text-muted mt-2">Tự tính thời hạn phản hồi/giải quyết theo mức ưu tiên; cảnh báo tự động trước khi quá hạn, phiếu quá hạn chuyển đỏ; tỷ lệ đạt SLA hiển thị trên bảng điều khiển.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- SLA Config End -->
+        </div>
 
-  <!-- Value Metrics Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 mức ưu tiên</h5>
+              <p class="text-muted mt-2">Khẩn cấp, cao, trung bình, thấp — bốn mức tương ứng với các thời hạn phản hồi khác nhau; phiếu khẩn cấp tự ghim lên trên và thông báo cho người trực.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại thông minh bằng AI</h5>
+              <p class="text-muted mt-2">AI tự nhận diện loại vấn đề của phiếu mới (vấn đề tài khoản/hỏi chức năng/báo lỗi, v.v.), phân công cho nhóm tương ứng theo quy tắc.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại nguyên nhân chờ</h5>
+              <p class="text-muted mt-2">"Chờ khách hàng phản hồi", "Chờ bên thứ ba", "Cần đánh giá yêu cầu" — phiếu đang chờ không tính vào thời gian quá hạn SLA, công bằng và hợp lý.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workspace nhân viên hỗ trợ</h5>
+              <p class="text-muted mt-2">Nhân viên hỗ trợ đăng nhập là thấy ngay phiếu được phân; sắp xếp theo thời gian đến hạn, một màn hình thấy đang chờ xử lý, đang xử lý, sắp quá hạn.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard phiếu</h5>
+              <p class="text-muted mt-2">Phân bố mới/đóng/đang chờ/quá hạn của hôm nay; tổng hợp theo nhân viên hỗ trợ, khách hàng, dòng sản phẩm, người quản lý nhìn toàn cảnh.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Tính năng khác đang phát triển</h5>
+              <p class="text-muted small mt-2 mb-0">Dự kiến: đánh giá hài lòng, quy trình chuyển và leo thang, mẫu phản hồi, tích hợp cơ sở tri thức</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Value AI Brings</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Human-AI collaboration, not AI replacing humans. Let AI handle repetitive work, let humans focus on creating value</p>
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">50%+</div>
-              <h5 class="mb-2">Sorting Efficiency Up</h5>
-              <p class="text-muted small mb-0">AI auto-classification reduces manual sorting time</p>
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">30%</div>
-              <h5 class="mb-2">Secondary Complaints Down</h5>
-              <p class="text-muted small mb-0">EQ firewall optimizes reply tone</p>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
 
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">20%</div>
-              <h5 class="mb-2">Timeout Rate Down</h5>
-              <p class="text-muted small mb-0">SLA alerts enable early intervention</p>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow text-center h-100">
-            <div class="card-body p-4">
-              <div class="h1 text-primary mb-3">10%+</div>
-              <h5 class="mb-2">First-call Resolution Up</h5>
-              <p class="text-muted small mb-0">Knowledge recommendations speed up resolution</p>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Value Metrics End -->
-
-  <!-- Competitive Advantages Start -->
+  <!-- CTA Start -->
   <section class="section bg-light">
     <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Why Choose Us?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Comparison with traditional SaaS ticketing and custom-built systems</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row justify-content-center">
-        <div class="col-lg-10">
-          <div class="table-responsive">
-            <table class="table table-hover bg-white rounded shadow-sm mb-0">
-              <thead class="bg-light">
-                <tr>
-                  <th class="border-0 py-3">Comparison</th>
-                  <th class="border-0 py-3">SaaS Ticketing</th>
-                  <th class="border-0 py-3">Custom Built</th>
-                  <th class="border-0 py-3 text-primary">NocoBase Solution</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="py-3 fw-medium">Time to Launch</td>
-                  <td class="py-3 text-muted">Out of the box</td>
-                  <td class="py-3 text-muted">Months of dev</td>
-                  <td class="py-3 text-primary">Configure and go</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Customization</td>
-                  <td class="py-3 text-muted">Limited</td>
-                  <td class="py-3 text-muted">Full control</td>
-                  <td class="py-3 text-primary">No-code flexibility</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Data Security</td>
-                  <td class="py-3 text-muted">Cloud hosted</td>
-                  <td class="py-3 text-muted">Self-hosted</td>
-                  <td class="py-3 text-primary">Self-hosted, full control</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">AI Integration</td>
-                  <td class="py-3 text-muted">Limited/extra cost</td>
-                  <td class="py-3 text-muted">Build yourself</td>
-                  <td class="py-3 text-primary">AI native, deeply integrated</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Extensibility</td>
-                  <td class="py-3 text-muted">Fixed features</td>
-                  <td class="py-3 text-muted">Code changes</td>
-                  <td class="py-3 text-primary">T-shaped, extend on demand</td>
-                </tr>
-                <tr>
-                  <td class="py-3 fw-medium">Total Cost</td>
-                  <td class="py-3 text-muted">High subscription</td>
-                  <td class="py-3 text-muted">High dev cost</td>
-                  <td class="py-3 text-primary">Buy once, use forever</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Competitive Advantages End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="how-to-use">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to deploy the intelligent ticketing system to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase</h5>
-                <p class="text-muted mt-2">Follow our installation guide to deploy NocoBase to your server</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-book-open h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Learn the Solution</h5>
-                <p class="text-muted mt-2">Read the solution overview to understand features, architecture, and use cases</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/" target="_blank" class="btn btn-outline-primary">Solution Overview</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore to System</h5>
-                <p class="text-muted mt-2">Follow the restore tutorial to deploy the ticketing system to your NocoBase environment</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/solution/ticket-system/installation" target="_blank" class="btn btn-outline-primary">Restore Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- CTA Section Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-lg-8 text-center">
-          <h3 class="title mb-4">Let AI Redefine Ticket Management</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            AI-powered intelligent ticketing system built on NocoBase 2.x. If you have custom needs or want to learn more, please contact us.
-          </p>
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Quản lý bán hàng, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự.</p>
           <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live Demo
-            </a>
-            <a href="/vi/contact" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-envelope me-1"></i>Contact Us
-            </a>
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseVI>
 
 <style>
-/* Ticketing 2.0 Page Styles */
-code {
-  background: #f5f5f5;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 13px;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-.text-purple {
-  color: #9c27b0 !important;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-/* AI Avatar Styles */
-.ai-avatar-lg img {
-  width: 56px;
-  height: 56px;
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
 }
-
-.ai-avatar-sm img {
-  width: 28px;
-  height: 28px;
+.module-breadcrumb i {
   vertical-align: middle;
+  margin: 0 4px;
+}
+
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
 </style>

--- a/src/pages/vi/solutions/ticketing.astro
+++ b/src/pages/vi/solutions/ticketing.astro
@@ -1,46 +1,13 @@
 ---
-import Layout from "../../../layouts/Layout.astro";
+import BaseVI from "../../../layouts/BaseVI.astro";
 import ShapeFooter from "../../../components/ShapeFooter.astro";
-import InteractiveDemo from "../../../components/InteractiveDemo.astro";
-import { listPluginCategories } from "../../../utils";
-
-// Import interactive demo data
-import extensionDemoGuides from "../../../data/ticketing-extension-demo-en.json";
-
-// Get plugin data
-const pluginData = await listPluginCategories();
-const allPlugins = pluginData.flatMap((group: any) => group.plugins);
-
-// Define plugin names used in ticketing system
-const ticketingPluginNames = [
-  "Email Manager",
-  "Collection: Comment",
-  "File Manager",
-  "Action: Import records(Pro)",
-  "Action: Export records(Pro)",
-  "Custom variables"
-];
-
-// Match plugin data by name
-function findPluginByName(name: string) {
-  return allPlugins.find((plugin: any) => 
-    plugin.name === name || 
-    plugin.name_cn === name ||
-    plugin.package_name?.includes(name.toLowerCase())
-  );
-}
-
-// Get ticketing system related plugins
-const ticketingPlugins = ticketingPluginNames.map(name => findPluginByName(name)).filter(Boolean);
-
-// Debug info
-console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
 ---
 
-<Layout
-  title="Efficient and Convenient Ticketing Management System"
-  description="NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management, from customer contact creation to ticket assignment and processing, achieving full-process digital management."
-  keywords="NocoBase Ticketing System, Ticket Management, Customer Service System, After-sales Service, Ticket Assignment"
+<BaseVI
+  title="Help Desk — Hệ thống phiếu hỗ trợ khách hàng mã nguồn mở | NocoBase"
+  description="Hệ thống phiếu hỗ trợ mã nguồn mở dựa trên nền tảng no-code NocoBase: tiếp nhận sự cố, phân công thông minh, đếm SLA, mức ưu tiên, phân loại AI, đánh giá hài lòng, workspace nhân viên hỗ trợ. Dùng được ngay, phù hợp cho nhóm hỗ trợ khách hàng và đội hậu mãi vừa và nhỏ."
+  keywords="Help Desk, hệ thống phiếu hỗ trợ khách hàng, phiếu hỗ trợ mã nguồn mở, help desk, hệ thống ticketing, quản lý phiếu, quản lý SLA, hệ thống hậu mãi, hệ thống dịch vụ khách hàng, NocoBase"
+  canonical="/cn/solutions/ticketing-v2"
 >
   <!-- Hero/Banner Start -->
   <section class="bg-half-170 bg-light d-table w-100">
@@ -48,565 +15,336 @@ console.log('Found plugins:', ticketingPlugins.map(p => p?.name || p?.name_cn));
       <div class="row align-items-center">
         <div class="col-lg-6 col-md-7 order-1 order-md-1">
           <div class="title-heading">
-            <h1 class="fw-bold mt-2 mb-3">Efficient and Convenient<br/>Ticketing Management System</h1>
-            <p class="para-desc text-muted">NocoBase ticketing management system serves as an important complement to CRM, providing complete ticket lifecycle management. From customer contact creation to ticket entry, assignment, processing and tracking, achieving full-process digital management of after-sales service.</p>
-            <div class="mt-3 p-2" style="background-color: #f8f9fa; border-left: 3px solid #2f55d4; border-radius: 4px;">
-              <small class="text-muted">
-                <i class="uil uil-info-circle"></i> Built with NocoBase 1.x (2.0 in development)
-              </small>
+            <div class="module-breadcrumb mb-2">
+              <a href="/vi/solutions/all-in-one" class="text-muted small text-decoration-none">Hệ thống quản lý kinh doanh tích hợp</a>
+              <i class="uil uil-angle-right text-muted small"></i>
+              <span class="text-muted small">mô-đun Help Desk</span>
+            </div>
+            <h1 class="fw-bold mt-2 mb-3">Help Desk</h1>
+            <p class="para-desc text-muted">
+              Được xây dựng trên nền tảng no-code NocoBase. Chuỗi hoàn chỉnh <strong>khách hàng báo sự cố → phân công thông minh → xử lý → đánh giá hài lòng</strong>, tích hợp sẵn đếm SLA, quản lý mức ưu tiên, phân loại thông minh bằng AI và workspace nhân viên hỗ trợ.
+            </p>
+
+            <div class="row mt-4 g-3">
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Tự động đếm SLA</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">4 mức ưu tiên</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Phân loại thông minh bằng AI</span></div></div>
+              <div class="col-auto"><div class="d-flex align-items-center"><i class="uil uil-check-circle text-success me-2"></i><span class="small">Mã nguồn mở miễn phí</span></div></div>
             </div>
 
-            <!-- Tags -->
             <div class="row mt-4">
               <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Use Cases:</span>
-                  <span class="badge bg-soft-primary me-2">Customer Service</span>
-                  <span class="badge bg-soft-primary">After-sales Support</span>
+                <div class="d-flex align-items-center flex-wrap">
+                  <span class="text-muted me-2">Tình huống áp dụng:</span>
+                  <span class="badge bg-soft-primary me-2">Hỗ trợ và hậu mãi</span>
+                  <span class="badge bg-soft-primary me-2">IT Service Desk</span>
+                  <span class="badge bg-soft-primary me-2">Bảo trì thiết bị</span>
+                  <span class="badge bg-soft-primary">Hỗ trợ SaaS</span>
                 </div>
               </div>
             </div>
 
-            <!-- Developer Info -->
-            <div class="row mt-4">
-              <div class="col-auto">
-                <div class="d-flex align-items-center">
-                  <span class="text-muted me-2">Developer:</span>
-                  <a href="https://www.nocobase.com" target="_blank" class="text-primary text-decoration-none fw-medium">NocoBase</a>
-                </div>
-              </div>
-            </div>
-
-            <!-- Buttons -->
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Live demo
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
+            <div class="mt-4">
+              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+              <a href="/vi/solutions/all-in-one" class="btn btn-outline-primary"><i class="uil uil-arrow-right me-1"></i>Xem giải pháp đầy đủ</a>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 pt-2 mt-sm-0 pt-sm-0">
-          <div class="text-center">
-            <!-- Ticketing System Preview -->
-            <div class="position-relative">
-              <img 
-                src="https://static-docs.nocobase.com/img_v3_02o5_a2422688-f176-4c84-bf32-5ee0774f919g-1.png" 
-                alt="NocoBase Ticketing Management System Preview" 
-                class="img-fluid rounded shadow"
-                style="max-height: 400px; object-fit: cover;"
-              />
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div> <!--end container-->
-  </section><!--end section-->
-  <!-- Hero/Banner End -->
+        <div class="col-lg-6 col-md-5 order-2 order-md-2 mt-4 mt-sm-0 pt-2 pt-sm-0">
+          <img src="https://static-docs.nocobase.com/module-tickets-cover-260521.jpg" alt="Giao diện Help Desk" class="img-fluid rounded shadow" loading="eager" />
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Hero End -->
 
-  <!-- Features Start -->
-  <section class="section">
+  <!-- Pipeline Start -->
+  <section class="section" id="pipeline">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">NocoBase Ticketing Management System Features</h4>
-            <p class="para-desc mx-auto text-muted mb-0">As an important complement to the CRM system, providing professional customer service and after-sales support management</p>
+            <h4 class="title mb-4">Quy trình xử lý phiếu</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Vòng khép kín hoàn chỉnh từ khách hàng báo sự cố đến đóng phiếu và đánh giá, SLA đếm toàn bộ quá trình</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
-      <div class="row">
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-ticket rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Complete Ticket Lifecycle</h5>
-              <p class="text-muted mt-2">From ticket creation, assignment, processing to closure, full-process management ensures every ticket is properly handled</p>
-              <i class="uil uil-ticket full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-users-alt rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Smart Assignment & Tracking</h5>
-              <p class="text-muted mt-2">Automatically assign tasks based on ticket types and team member skills, real-time tracking of processing progress and status</p>
-              <i class="uil uil-users-alt full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-envelope rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Multi-channel Communication Records</h5>
-              <p class="text-muted mt-2">Sync email, phone, online chat and other communication channels via API, unified management of customer communication records</p>
-              <i class="uil uil-envelope full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-3 col-md-6 mt-4 pt-2">
-          <div class="card border-0 features feature-primary feature-clean course-feature p-4 overflow-hidden shadow h-100">
-            <div class="icons text-start">
-              <i class="uil uil-shield-check rounded h3 mb-0"></i>
-            </div>
-            <div class="card-body p-0 mt-4">                                            
-              <h5 class="title text-dark">Open Source, Complete Data Control</h5>
-              <p class="text-muted mt-2">Open source code, private data deployment, ensuring enterprise data security and autonomous control</p>
-              <i class="uil uil-shield-check full-img"></i>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Features End -->
-
-  <!-- Try Ticketing Extension Start -->
-  <section class="section bg-light">
-    <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-
-        <div class="mt-4" id="ticket-demo-wrap">
-          <!-- Using extension function interactive demo -->
-          <InteractiveDemo guides={extensionDemoGuides}  />
-        </div><!--end ticket-demo-wrap-->
-
-        <div class="row justify-content-center mt-4">
-          <div class="col-12 text-center">
-            <div class="mt-4 pt-2">
-              <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary me-3">
-                <i class="uil uil-play me-1"></i>Try Now
-              </a>
-              <a href="#copy-tutorial" class="btn btn-outline-primary">
-                <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-              </a>
-            </div>
-          </div><!--end col-->
-        </div><!--end row-->
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Try Ticketing Extension End -->
-
-  <!-- Development Tutorial Start -->
-  <section class="section">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Ticketing System Development Tutorial</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to build a professional ticketing management system using NocoBase from scratch</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-play h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Data Model Design</h5>
-                <p class="text-muted text-center">Learn how to create basic data structures and relationships for tickets, customers, categories, etc.</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-arrow-growth h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Workflow Configuration</h5>
-                <p class="text-muted text-center">Set up ticket assignment, status transitions and automated processing workflows</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex flex-column">
-              <div class="icon text-primary text-center">
-                <i class="uil uil-bell h2 mb-3"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h5 class="mb-3 text-center">Notifications & Reminders</h5>
-                <p class="text-muted text-center">Configure email and system notifications to ensure timely ticket processing</p>
-              </div>
-              <div class="text-center">
-                <button class="btn btn-outline-secondary btn-sm">Coming Soon</button>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Development Tutorial End -->
-
-  <!-- Commercial Plugins Start -->
-  <section class="section bg-light">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">Commercial Plugins Used in Ticketing System</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Learn how to get more powerful features through commercial plugins to enhance the professionalism and usability of your ticketing system</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row pb-4">
-        <!-- Dynamic plugin cards -->
-        {ticketingPlugins.map((plugin) => {
-          if (!plugin) return null;
-          
-          const displayName = plugin.name || plugin.name_cn;
-          const displayDescription = plugin.description || plugin.description_cn;
-          const docsUrl = plugin.docs || plugin.docs_cn;
-          
-          return (
-            <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-              <div title={displayName} style="color: inherit;" class="card rounded shadow border-0 plugin-card h-100">
-                <div class="card-body">
-                  <div class="mt-2 plugin-box">
-                    <h6 class="card-title mb-1">{displayName}</h6>
-                    <div class="plugin-developer text-muted mb-3">By <span>{plugin.developer || 'NocoBase'}</span></div>
-                    <p class="text-muted mb-2 plugin-overview">{displayDescription}
-                      {docsUrl && (
-                        <a href={docsUrl} target="_blank" style="font-size: 14px;margin-left: 5px;">Details</a>
-                      )}
-                    </p>
-                    {plugin.commercial && (
-                      <div class="plugin-footer">
-                        <h6 class="text-primary mb-0">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use, 1-year upgrade</span><br>
-                          <a href="/vi/plugins-bundles"> {plugin.points_1_year || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_1_year || 0}</span>
-                        </h6>
-                        <h6 class="text-muted mb-0" style="margin-left: auto;font-weight: normal;">
-                          <span class="text-muted" style="font-weight: normal;font-style: italic;font-size: 12px;">Lifetime use & upgrade</span><br>
-                          <a class="text-muted" href="/vi/plugins-bundles"> {plugin.point || 0} <i class="uil uil-moon-eclipse me-1"></i></a>
-                          <span class="text-muted">/</span>
-                          <span class="text-muted">${plugin.price_usd || 0}</span>
-                        </h6>
-                      </div>
-                    )}
-                  </div>
+        <div class="col-lg-10">
+          <div class="card border-0 shadow">
+            <div class="card-body p-4">
+              <div class="d-flex flex-wrap justify-content-center align-items-center gap-2 mb-4">
+                <div class="pipeline-node">
+                  <i class="uil uil-ticket text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Tạo</div>
+                  <div class="small text-muted">Đa kênh</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-robot text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Phân loại thông minh</div>
+                  <div class="small text-muted">AI nhận diện</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-users-alt text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Phân công</div>
+                  <div class="small text-muted">Theo quy tắc nhóm</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node">
+                  <i class="uil uil-wrench text-primary h3 mb-2"></i>
+                  <div class="small fw-medium">Xử lý</div>
+                  <div class="small text-muted">Đếm SLA</div>
+                </div>
+                <i class="uil uil-arrow-right h4 text-muted pipeline-arrow"></i>
+                <div class="pipeline-node pipeline-node-end">
+                  <i class="uil uil-thumbs-up h3 mb-2"></i>
+                  <div class="small fw-medium">Đánh giá</div>
+                  <div class="small opacity-75">Đóng và lưu trữ</div>
                 </div>
               </div>
-            </div>
-          );
-        })}
 
-        <!-- Placeholder card for layout -->
-        <div class="col-lg-4 col-md-6 col-12 pt-0 pb-4">
-          <div class="card rounded shadow border-0 plugin-card h-100" style="opacity: 0.6;">
-            <div class="card-body">
-              <div class="mt-2 plugin-box text-center">
-                <div class="mt-4 mb-4">
-                  <i class="uil uil-plus-circle h2 text-muted mb-3"></i>
-                  <h6 class="text-muted mb-3">More Plugins Coming Soon</h6>
-                  <p class="text-muted small">We are developing more useful commercial plugins, stay tuned</p>
-                </div>
+              <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                  <thead class="bg-light">
+                    <tr>
+                      <th class="border-0 py-3">Giai đoạn</th>
+                      <th class="border-0 py-3">Hành động chính</th>
+                      <th class="border-0 py-3">Hệ thống ghi nhận</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td class="py-3">Tạo</td>
+                      <td class="py-3 text-muted">Khách hàng gửi qua email, form, IM đa kênh; liên kết khách hàng và sản phẩm</td>
+                      <td class="py-3 text-muted">Mã phiếu, nguồn, hồ sơ khách hàng</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Phân loại thông minh</td>
+                      <td class="py-3 text-muted">AI nhận diện loại vấn đề (tài khoản/chức năng/Bug), tự đặt mức ưu tiên</td>
+                      <td class="py-3 text-muted">Nhãn phân loại, mức ưu tiên, độ tin cậy</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Phân công</td>
+                      <td class="py-3 text-muted">Phân theo quy tắc cho nhóm/nhân viên tương ứng, phiếu khẩn cấp tự thông báo người trực</td>
+                      <td class="py-3 text-muted">Người phụ trách, lịch sử phân công, hàng đợi nhóm</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Xử lý</td>
+                      <td class="py-3 text-muted">Nhân viên hỗ trợ xử lý, trao đổi với khách hàng; SLA đếm, cảnh báo trước khi quá hạn</td>
+                      <td class="py-3 text-muted">Log xử lý, trạng thái SLA, nguyên nhân chờ</td>
+                    </tr>
+                    <tr>
+                      <td class="py-3">Đánh giá</td>
+                      <td class="py-3 text-muted">Gửi yêu cầu đánh giá đến khách hàng khi đóng phiếu (1-5 sao + chữ), tổng hợp theo nhân viên/sản phẩm</td>
+                      <td class="py-3 text-muted">Bản ghi hài lòng, phiếu lưu trữ, KPI</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
         </div>
-      </div><!--end row-->
+      </div>
+    </div>
+  </section>
+  <!-- Pipeline End -->
 
-      <div class="row justify-content-center mt-4">
-        <div class="col-12 text-center">
-          <a href="/vi/plugins-commercial" class="btn btn-primary me-3">View All Commercial Plugins</a>
-          <a href="/vi/commercial" class="btn btn-outline-primary">Learn About Pricing</a>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- Commercial Plugins End -->
-
-  <!-- How to Use Start -->
-  <section class="section" id="copy-tutorial">
-    <div class="container">
-      <div class="row justify-content-center">
-        <div class="col-12">
-          <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Use?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Three steps to quickly deploy NocoBase CRM system with ticketing management functionality to your environment</p>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <div class="row">
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-download-alt h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Install NocoBase System</h5>
-                <p class="text-muted mt-2">Deploy NocoBase system to your server following our installation documentation</p>
-              </div>
-              <div class="mt-3">
-                <a href="https://v2.docs.nocobase.com/get-started/quickstart" target="_blank" class="btn btn-primary">View Installation Guide</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-cloud-download h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Download CRM System Template</h5>
-                <p class="text-muted mt-2">Download the complete CRM template to get ticketing management capability</p>
-              </div>
-              <div class="mt-3">
-                <div>
-                  <a href="https://static-docs.nocobase.com/pm_demo/demo_en_250910.zip" class="text-muted small" style="text-decoration: underline !important;">Download SQL File</a>
-                </div>
-                <a href="https://static-docs.nocobase.com/pm_demo/demo_en_20250910.nbdata" class="btn btn-outline-primary">Download Backup File (.nbdata)</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-
-        <div class="col-lg-4 col-md-6 mt-4 pt-2">
-          <div class="card border-0 text-center features feature-clean course-feature p-4 shadow h-100">
-            <div class="d-flex flex-column h-100">
-              <div class="icons text-center">
-                <i class="uil uil-upload h1 text-primary"></i>
-              </div>
-              <div class="content mt-4 flex-grow-1">
-                <h5>Restore in System</h5>
-                <p class="text-muted mt-2">Import the CRM template file into your NocoBase system to get both CRM and ticketing management capabilities</p>
-              </div>
-              <div class="mt-3">
-                <a href="/vi/tutorials/nocobase-crm-demo-deployment-guide" class="btn btn-outline-primary">Restoration Tutorial</a>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-
-      <!-- Ticketing feature explanation -->
-      <div class="row justify-content-center mt-5">
-        <div class="col-lg-8">
-          <div class="alert border-0 shadow-sm" style="background: #f8f9fa; border-left: 4px solid #007bff !important;">
-            <div class="d-flex align-items-start">
-              <div class="flex-shrink-0 me-3">
-                <i class="uil uil-info-circle h4 text-primary mb-0"></i>
-              </div>
-              <div class="flex-grow-1">
-                <h6 class="mb-2 text-dark fw-medium">Tip</h6>
-                <p class="mb-0 text-muted">The ticketing management system is fully integrated into the CRM template as an important supplementary module. After deployment, you can directly use the complete ticketing management functionality within the CRM system to achieve full-process customer service management.</p>
-              </div>
-            </div>
-          </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Use End -->
-
-  <!-- How to Extend Start -->
+  <!-- Core Features Start -->
   <section class="section bg-light">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12">
           <div class="section-title text-center mb-4 pb-2">
-            <h4 class="title mb-4">How to Extend?</h4>
-            <p class="para-desc mx-auto text-muted mb-0">Further extend and customize your ticketing management system based on business needs</p>
+            <h4 class="title mb-4">Chức năng cốt lõi</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Quản lý phiếu hỗ trợ hoàn chỉnh từ tiếp nhận đến đóng phiếu</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
+        </div>
+      </div>
 
       <div class="row">
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-plus-circle h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Ticket Types & Category Management</h5>
-                  <p class="text-muted mb-3">Create different ticket categories and processing rules based on business needs</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-stopwatch rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Đếm và cảnh báo SLA</h5>
+              <p class="text-muted mt-2">Tự tính thời hạn phản hồi/giải quyết theo mức ưu tiên; cảnh báo tự động trước khi quá hạn, phiếu quá hạn chuyển đỏ; tỷ lệ đạt SLA hiển thị trên bảng điều khiển.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-users-alt h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Team Collaboration Features</h5>
-                  <p class="text-muted mb-3">Set up team roles, permissions and collaborative workflows</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-bolt-alt rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">4 mức ưu tiên</h5>
+              <p class="text-muted mt-2">Khẩn cấp, cao, trung bình, thấp — bốn mức tương ứng với các thời hạn phản hồi khác nhau; phiếu khẩn cấp tự ghim lên trên và thông báo cho người trực.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-chart-line h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">Statistical Reports & Analytics</h5>
-                  <p class="text-muted mb-3">Build analytical reports for ticket processing status and efficiency</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-robot rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại thông minh bằng AI</h5>
+              <p class="text-muted mt-2">AI tự nhận diện loại vấn đề của phiếu mới (vấn đề tài khoản/hỏi chức năng/báo lỗi, v.v.), phân công cho nhóm tương ứng theo quy tắc.</p>
             </div>
           </div>
-        </div><!--end col-->
+        </div>
 
-        <div class="col-lg-6 mt-4 pt-2">
-          <div class="card border-0 shadow rounded h-100">
-            <div class="card-body p-4 d-flex">
-              <div class="icon text-primary">
-                <i class="uil uil-link-h h2"></i>
-              </div>
-              <div class="ms-3 d-flex flex-column flex-grow-1">
-                <div class="flex-grow-1">
-                  <h5 class="mb-2">CRM System Integration</h5>
-                  <p class="text-muted mb-3">Seamlessly integrate with existing CRM systems for data sharing</p>
-                </div>
-                <div>
-                  <button class="btn btn-sm btn-outline-secondary">Coming Soon</button>
-                </div>
-              </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-pause-circle rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Phân loại nguyên nhân chờ</h5>
+              <p class="text-muted mt-2">"Chờ khách hàng phản hồi", "Chờ bên thứ ba", "Cần đánh giá yêu cầu" — phiếu đang chờ không tính vào thời gian quá hạn SLA, công bằng và hợp lý.</p>
             </div>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- How to Extend End -->
+        </div>
 
-  <!-- CTA Section Start -->
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-clipboard-notes rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Workspace nhân viên hỗ trợ</h5>
+              <p class="text-muted mt-2">Nhân viên hỗ trợ đăng nhập là thấy ngay phiếu được phân; sắp xếp theo thời gian đến hạn, một màn hình thấy đang chờ xử lý, đang xử lý, sắp quá hạn.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 features feature-primary feature-clean p-4 shadow h-100">
+            <div class="icons text-start"><i class="uil uil-chart-pie rounded h3 mb-0"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="title text-dark">Dashboard phiếu</h5>
+              <p class="text-muted mt-2">Phân bố mới/đóng/đang chờ/quá hạn của hôm nay; tổng hợp theo nhân viên hỗ trợ, khách hàng, dòng sản phẩm, người quản lý nhìn toàn cảnh.</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mt-4 pt-2">
+          <div class="card border-0 p-4 shadow h-100 roadmap-card-grid">
+            <div class="icons text-start"><i class="uil uil-ellipsis-h h3 mb-0 text-muted"></i></div>
+            <div class="card-body p-0 mt-4">
+              <h5 class="text-muted mb-2">Tính năng khác đang phát triển</h5>
+              <p class="text-muted small mt-2 mb-0">Dự kiến: đánh giá hài lòng, quy trình chuyển và leo thang, mẫu phản hồi, tích hợp cơ sở tri thức</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Core Features End -->
+
+  <!-- Get Started Start -->
   <section class="section">
     <div class="container">
       <div class="row justify-content-center">
-        <div class="col-12 text-center">
-          <h3 class="title mb-4">Ready to Use NocoBase Ticketing Management System?</h3>
-          <p class="text-muted para-desc mx-auto mb-0">
-            Deploy a dedicated ticketing management demo in 1 minute. As an important complement to CRM, achieve a complete customer service system to improve customer satisfaction and service efficiency.
-          </p>
-          <div class="mt-4">
-            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3">
-              <i class="uil uil-play me-1"></i>Live demo
-            </a>
-            <a href="#copy-tutorial" class="btn btn-outline-primary mt-2">
-              <i class="uil uil-copy me-1"></i>Deploy to Your Environment
-            </a>
+        <div class="col-12">
+          <div class="section-title text-center mb-4 pb-2">
+            <h4 class="title mb-4">Tải xuống và triển khai</h4>
+            <p class="para-desc mx-auto text-muted mb-0">Mô-đun này nằm trong file backup mẫu của Hệ thống quản lý kinh doanh tích hợp, triển khai thống nhất</p>
           </div>
-        </div><!--end col-->
-      </div><!--end row-->
-    </div><!--end container-->
-  </section><!--end section-->
-  <!-- CTA Section End -->
+        </div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-import h1 text-primary"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Tải file backup mẫu</h5>
+                <p class="text-muted mt-2">Backup giải pháp tích hợp, sau khi khôi phục bao gồm toàn bộ dữ liệu mẫu của 6 mô-đun, trong đó có mô-đun này</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_backup_260521.nbdata" class="btn btn-primary"><i class="uil uil-download-alt me-1"></i>Tải backup .nbdata</a>
+                <a href="https://static-docs.nocobase.com/nocobase_all_in_one_sql_260521.zip" class="btn btn-link btn-sm text-muted">Hoặc tải file ZIP SQL</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-5 col-md-6 mt-2">
+          <div class="card border-0 text-center features feature-clean p-4 shadow h-100">
+            <div class="d-flex flex-column h-100">
+              <div class="icons text-center"><i class="uil uil-book-open h1 text-muted"></i></div>
+              <div class="content mt-4 flex-grow-1">
+                <h5>Xem tài liệu cài đặt</h5>
+                <p class="text-muted mt-2">Các bước khôi phục chi tiết, câu hỏi thường gặp và lưu ý đang được chuẩn bị</p>
+              </div>
+              <div class="mt-3 d-flex flex-column gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" disabled>Sắp ra mắt</button>
+                <span class="btn-link btn-sm invisible" aria-hidden="true">.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Get Started End -->
+
+  <!-- CTA Start -->
+  <section class="section bg-light">
+    <div class="container">
+      <div class="row justify-content-center text-center">
+        <div class="col-lg-8">
+          <h3 class="title mb-4">Bắt đầu sử dụng</h3>
+          <p class="text-muted para-desc mx-auto mb-0">Mô-đun này cũng được tích hợp trong <a href="/vi/solutions/all-in-one">Hệ thống quản lý kinh doanh tích hợp</a>, có thể sử dụng độc lập hoặc phối hợp với CRM, Quản lý bán hàng, Quản lý dự án, Quản lý tài sản, Quản lý nhân sự.</p>
+          <div class="mt-4">
+            <a href="https://demo.nocobase.com/new" target="_blank" class="btn btn-primary mt-2 me-3"><i class="uil uil-play me-1"></i>Trải nghiệm Demo</a>
+            <a href="/vi/contact" class="btn btn-outline-primary mt-2"><i class="uil uil-envelope me-1"></i>Liên hệ tư vấn</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- CTA End -->
 
   <ShapeFooter />
-</Layout>
+</BaseVI>
 
 <style>
-/* Ticketing management system styles - reference CRM page styles */
-#ticket-demo-wrap {
-  position: relative;
+.module-hero-illustration {
+  padding: 3rem 2rem;
+  background: rgba(47, 85, 212, 0.05);
+  border-radius: 16px;
 }
 
-/* Commercial plugin card styles */
-.plugin-card {
-  transition: all 0.3s ease;
+.pipeline-node {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  min-width: 110px;
+  background: rgba(47, 85, 212, 0.06);
+  border: 1px solid rgba(47, 85, 212, 0.18);
+}
+.pipeline-node-end {
+  background: linear-gradient(135deg, #2f55d4 0%, #1e3a8a 100%);
+  color: #fff;
+  border-color: transparent;
+}
+.pipeline-node-end .text-muted,
+.pipeline-node-end i {
+  color: #fff !important;
+}
+.pipeline-arrow {
+  color: rgba(47, 85, 212, 0.4) !important;
 }
 
-.plugin-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.module-breadcrumb a:hover {
+  color: var(--bs-primary) !important;
+}
+.module-breadcrumb i {
+  vertical-align: middle;
+  margin: 0 4px;
 }
 
-.plugin-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
+.roadmap-card-grid {
+  background: rgba(108, 117, 125, 0.03);
+  border: 1px dashed rgba(108, 117, 125, 0.25) !important;
+  opacity: 0.85;
 }
-
-.plugin-footer .badge {
-  font-size: 0.7rem;
-  padding: 0.2rem 0.4rem;
-}
-
-.plugin-developer span {
-  color: #6c757d;
-}
-
-.plugin-overview {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
-.plugin-footer h6 {
-  font-size: 0.8rem;
-}
-
-.plugin-box {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-</style> 
+</style>


### PR DESCRIPTION
- New pages: all-in-one, sales/asset/hr-management (11 langs)
- CRM/ticketing v1 kept as SEO aliases with canonical to v2
- crm-v2, ticketing-v2, project-management rewritten as module pages
- Hero badges, pipeline diagram, 6 real cards + 1 roadmap placeholder
- Download backup active; install doc link disabled pending docs deploy
- BaseCN/EN/etc: Solutions megamenu + Modules sub-column