### PR TITLE
chore: update homepage SEO titles

### DIFF
--- a/src/layouts/BaseCN.astro
+++ b/src/layouts/BaseCN.astro
@@ -56,7 +56,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - 开源、私有部署的 AI 驱动的零代码和低代码开发平台",
+      : "NocoBase - 开源 AI 零代码平台",
   description:
       description ||
       "NocoBase 是一个开源的 “AI + 无代码” 开发平台，用于快速开发企业业务系统。不同于让 AI 从零生成代码，NocoBase 提供经过生产验证的基础设施和所见即所得的无代码界面，让 AI 与人高效协同，既保证开发速度又保证系统可靠性。",

--- a/src/layouts/BaseDE.astro
+++ b/src/layouts/BaseDE.astro
@@ -64,7 +64,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Open-Source-No-Code- und Low-Code-Plattform, leichtgewichtig, self-hosted und KI-gestützt",
+      : "NocoBase - Open-Source-KI-No-Code-Plattform",
   description:
       description ||
       "NocoBase ist eine leichtgewichtige, hochgradig erweiterbare Open-Source-No-Code- und Low-Code-Plattform mit KI-Unterstützung. Betreiben Sie sie in Ihrer eigenen Infrastruktur und behalten Sie die volle Kontrolle über Daten und Anwendungen.",

--- a/src/layouts/BaseEN.astro
+++ b/src/layouts/BaseEN.astro
@@ -56,7 +56,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - AI-driven, Open source, self-hosted, lightweight no-code & low-code development platform",
+      : "NocoBase - Open-source AI no-code platform",
   description:
       description ||
       "NocoBase is an AI-driven lightweight, extremely extensible open source no-code and low-code development platform. Quickly deploy to gain a private, controllable no-code solution!",

--- a/src/layouts/BaseEN.astro
+++ b/src/layouts/BaseEN.astro
@@ -56,7 +56,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Open-source AI no-code platform",
+      : "NocoBase – Open-Source AI No-Code Platform",
   description:
       description ||
       "NocoBase is an AI-driven lightweight, extremely extensible open source no-code and low-code development platform. Quickly deploy to gain a private, controllable no-code solution!",

--- a/src/layouts/BaseES.astro
+++ b/src/layouts/BaseES.astro
@@ -56,7 +56,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Plataforma open source de no-code y low-code, autogestionada e impulsada por IA",
+      : "NocoBase - Plataforma no-code de IA de código abierto",
   description:
       description ||
       "NocoBase es una plataforma open source de no-code y low-code, ligera, extensible e impulsada por IA. Despliega en tu propia infraestructura y mantén el control total de tus datos y aplicaciones.",

--- a/src/layouts/BaseFR.astro
+++ b/src/layouts/BaseFR.astro
@@ -56,7 +56,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Plateforme no-code & low-code open source, auto-hébergée et pilotée par l’IA",
+      : "NocoBase - Plateforme no-code IA open source",
   description:
       description ||
       "NocoBase est une plateforme no-code et low-code légère, extrêmement extensible, open source et enrichie par l’IA. Déployez-la rapidement dans votre propre infrastructure et gardez un contrôle total sur vos données et vos applications.",

--- a/src/layouts/BaseID.astro
+++ b/src/layouts/BaseID.astro
@@ -63,7 +63,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Platform no-code dan low-code open source, ringan, self-hosted, dan didukung AI",
+      : "NocoBase - Platform no-code AI sumber terbuka",
   description:
       description ||
       "NocoBase adalah platform no-code dan low-code open source yang ringan, sangat fleksibel, dan didukung AI. Deploy di infrastruktur Anda sendiri dan tetap pegang kendali penuh atas data serta aplikasi.",

--- a/src/layouts/BaseJA.astro
+++ b/src/layouts/BaseJA.astro
@@ -57,7 +57,7 @@ const meta = {
     image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
     title: title
         ? `${title} - NocoBase`
-        : "NocoBase - オープンソース、自社ホスティング、軽量なノーコード＆ローコード開発プラットフォーム",
+        : "NocoBase - オープンソースのAIノーコードプラットフォーム",
     description:
         description ||
         "NocoBaseは軽量で非常に拡張性の高いオープンソースのノーコード＆ローコード開発プラットフォームです。迅速にデプロイして、プライベートでコントロール可能なノーコードソリューションを手に入れましょう！",

--- a/src/layouts/BasePT.astro
+++ b/src/layouts/BasePT.astro
@@ -64,7 +64,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Plataforma open source de no-code e low-code, leve, auto-hospedada e impulsionada por IA",
+      : "NocoBase - Plataforma no-code de IA open source",
   description:
       description ||
       "NocoBase é uma plataforma open source de no-code e low-code, leve, altamente extensível e impulsionada por IA. Implante na sua própria infraestrutura e mantenha total controle sobre dados e aplicações.",

--- a/src/layouts/BaseTW.astro
+++ b/src/layouts/BaseTW.astro
@@ -66,7 +66,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - 開源、私有部署的 AI 驅動的零代碼和低代碼開發平臺",
+      : "NocoBase - 開源 AI 零代碼平台",
   description:
       description ||
       "NocoBase 是一個開源的 “AI + 無代碼” 開發平臺，用於快速開發企業業務系統。不同於讓 AI 從零生成代碼，NocoBase 提供經過生產驗證的基礎設施和所見即所得的無代碼界面，讓 AI 與人高效協同，既保證開發速度又保證系統可靠性。",

--- a/src/layouts/BaseVI.astro
+++ b/src/layouts/BaseVI.astro
@@ -64,7 +64,7 @@ const meta = {
   image: image || 'https://static-docs.nocobase.com/20260513-og-github-v3.jpg',
   title: title
       ? `${title} - NocoBase`
-      : "NocoBase - Nền tảng no-code và low-code mã nguồn mở, nhẹ, self-hosted và được tăng cường bởi AI",
+      : "NocoBase - Nền tảng no-code AI mã nguồn mở",
   description:
       description ||
       "NocoBase là nền tảng no-code và low-code mã nguồn mở, nhẹ, có khả năng mở rộng cao và được tăng cường bởi AI. Triển khai trên hạ tầng riêng của bạn để kiểm soát hoàn toàn dữ liệu và ứng dụng.",


### PR DESCRIPTION
## Summary

- shorten the default homepage SEO title across 10 localized layouts
- align the titles around the open-source AI no-code platform positioning
- refine the English title wording and punctuation

## Testing

- Not run (copy-only metadata changes)