### PR TITLE
fix(sync): resolve CMS permanent /files attachment URLs to direct CDN…

### DIFF
--- a/content/articles/2.2.0-beta/metadata.json
+++ b/content/articles/2.2.0-beta/metadata.json
@@ -109,8 +109,8 @@
     "mimetype": "image/png",
     "meta": {},
     "path": "",
-    "url": "/files/main/main/articleAttachments/2637.png",
-    "preview": "/files/main/main/articleAttachments/2637.png?preview=1",
+    "url": "https://static-docs.nocobase.com/2.2-beta-2kf9fd.png",
+    "preview": "https://static-docs.nocobase.com/2.2-beta-2kf9fd.png",
     "storageId": 2,
     "createdById": 1,
     "updatedById": 1

--- a/scripts/download-content.js
+++ b/scripts/download-content.js
@@ -6,6 +6,36 @@ import axios from 'axios';
 const baseURL = 'https://your-cms-url.com/api/';
 const token = 'your_api_token_here';
 
+// --- permanent attachment URL resolver (same as sync-recent-content.js) -------------
+// CMS 2.2 returns attachment url/preview as authenticated permanent routes
+// (`/files/...`); resolve them to the storage's direct (CDN) URL at sync time.
+const cmsOrigin = baseURL.replace(/\/api\/?$/, '');
+async function resolveAttachmentURL(attachment) {
+  if (!attachment || typeof attachment.url !== 'string' || !attachment.url.startsWith('/files/')) {
+    return attachment || null;
+  }
+  const resolveOne = async (relative) => {
+    const sep = relative.includes('?') ? '&' : '?';
+    const res = await axios.get(`${cmsOrigin}${relative}${sep}token=${token}`, {
+      maxRedirects: 0,
+      timeout: 30000,
+      validateStatus: (s) => s === 301 || s === 302,
+    });
+    return res.headers.location;
+  };
+  try {
+    const url = await resolveOne(attachment.url);
+    let preview = url;
+    if (typeof attachment.preview === 'string' && attachment.preview.startsWith('/files/')) {
+      try { preview = await resolveOne(attachment.preview); } catch (e) { /* fall back to url */ }
+    }
+    return { ...attachment, url, preview };
+  } catch (error) {
+    console.warn(`Failed to resolve attachment URL ${attachment.url}: ${error.message}`);
+    return attachment;
+  }
+}
+
 // Create an axios instance with a timeout setting
 const api = axios.create({
   timeout: 30000, // 30-second timeout
@@ -84,7 +114,7 @@ async function downloadArticles() {
         tags: article.tags || [],
         sub_tags: article.sub_tags || [],
         category: article.category || null,
-        cover: article.cover || null,
+        cover: await resolveAttachmentURL(article.cover),
         hideOnListPage: article.hideOnListPage || false,
         hideOnBlog: article.hideOnBlog || false,
         author: article.author || null,

--- a/scripts/sync-recent-content.js
+++ b/scripts/sync-recent-content.js
@@ -38,6 +38,40 @@ const CONFIG = {
   debugMode: true
 };
 
+// --- permanent attachment URL resolver ---------------------------------------------
+// Since CMS 2.2, attachment `url`/`preview` come back as app-relative permanent routes
+// (`/files/{app}/{ds}/{collection}/{id}`) that 302-redirect to the storage's real URL
+// only for AUTHENTICATED requests. The website is anonymous, so a relative `/files/...`
+// 404s on www — resolve to the final direct (CDN) URL here at sync time instead.
+// Direct http(s) URLs (legacy data) pass through unchanged.
+const cmsOrigin = baseURL.replace(/\/api\/?$/, '');
+async function resolveAttachmentURL(attachment) {
+  if (!attachment || typeof attachment.url !== 'string' || !attachment.url.startsWith('/files/')) {
+    return attachment || null;
+  }
+  const resolveOne = async (relative) => {
+    const sep = relative.includes('?') ? '&' : '?';
+    const res = await axios.get(`${cmsOrigin}${relative}${sep}token=${token}`, {
+      maxRedirects: 0,
+      timeout: 30000,
+      validateStatus: (s) => s === 301 || s === 302,
+    });
+    return res.headers.location;
+  };
+  try {
+    const url = await resolveOne(attachment.url);
+    let preview = url;
+    if (typeof attachment.preview === 'string' && attachment.preview.startsWith('/files/')) {
+      try { preview = await resolveOne(attachment.preview); } catch (e) { /* fall back to url */ }
+    }
+    console.log(`Resolved attachment #${attachment.id || '?'} to direct URL`);
+    return { ...attachment, url, preview };
+  } catch (error) {
+    console.warn(`Failed to resolve attachment URL ${attachment.url}: ${error.message}`);
+    return attachment;
+  }
+}
+
 // API client with timeout and retry
 const api = axios.create({
   timeout: 30000, // 30-second timeout
@@ -530,7 +564,7 @@ async function syncRecentArticles() {
         tags: article.tags || [],
         sub_tags: article.sub_tags || [],
         category: article.category || null,
-        cover: article.cover || null,
+        cover: await resolveAttachmentURL(article.cover),
         hideOnListPage: article.hideOnListPage || false,
         hideOnBlog: article.hideOnBlog || false,
         hideDetailPage: article.hideDetailPage || false,
@@ -674,7 +708,7 @@ async function syncRecentLightSolutions() {
         publishedAt: solution.publishedAt,
         status: solution.status,
         tags: solution.tags || [],
-        cover: solution.cover || null,
+        cover: await resolveAttachmentURL(solution.cover),
         author: solution.author || null,
         prompt: solution.prompt || null,
         prompt_cn: solution.prompt_cn || null,


### PR DESCRIPTION
… URLs

Since CMS 2.2, attachment url/preview come back as app-relative permanent routes (/files/{app}/{ds}/{collection}/{id}) that 302-redirect to the real storage URL only for authenticated requests. The website is anonymous, so a relative /files/... 404s on www — covers of newly synced articles broke (first hit: the 2.2-beta announcement).

- sync-recent-content.js / download-content.js: resolve /files/... covers to the final direct (CDN) URL at sync time by following the authenticated 302; direct legacy URLs pass through unchanged
- content/articles/2.2.0-beta: re-resolve the announcement cover (/files/.../2637.png -> https://static-docs.nocobase.com/2.2-beta-2kf9fd.png)

Verified with a local SSR build: /en/blog renders the announcement cover from static-docs and has zero /files remnants.