### PR TITLE
fix(sync): fallback to filename-composed static-docs URL when /files resolution fails

### DIFF
--- a/content/articles/2.2.0-beta/metadata.json
+++ b/content/articles/2.2.0-beta/metadata.json
@@ -109,8 +109,8 @@
     "mimetype": "image/png",
     "meta": {},
     "path": "",
-    "url": "/files/main/main/articleAttachments/2637.png",
-    "preview": "/files/main/main/articleAttachments/2637.png?preview=1",
+    "url": "https://static-docs.nocobase.com/2.2-beta-2kf9fd.png",
+    "preview": "https://static-docs.nocobase.com/2.2-beta-2kf9fd.png",
     "storageId": 2,
     "createdById": 1,
     "updatedById": 1

--- a/scripts/download-content.js
+++ b/scripts/download-content.js
@@ -32,6 +32,13 @@ async function resolveAttachmentURL(attachment) {
     return { ...attachment, url, preview };
   } catch (error) {
     console.warn(`Failed to resolve attachment URL ${attachment.url}: ${error.message}`);
+    // Fallback: compose the direct URL from the attachment filename. This CMS keeps
+    // public assets on a single OSS storage served at static-docs; composing beats
+    // shipping an authenticated-only /files URL that 404s for anonymous visitors.
+    if (typeof attachment.filename === 'string' && attachment.filename) {
+      const composed = `https://static-docs.nocobase.com/${encodeURIComponent(attachment.filename)}`;
+      return { ...attachment, url: composed, preview: composed };
+    }
     return attachment;
   }
 }

--- a/scripts/sync-recent-content.js
+++ b/scripts/sync-recent-content.js
@@ -68,6 +68,13 @@ async function resolveAttachmentURL(attachment) {
     return { ...attachment, url, preview };
   } catch (error) {
     console.warn(`Failed to resolve attachment URL ${attachment.url}: ${error.message}`);
+    // Fallback: compose the direct URL from the attachment filename. This CMS keeps
+    // public assets on a single OSS storage served at static-docs; composing beats
+    // shipping an authenticated-only /files URL that 404s for anonymous visitors.
+    if (typeof attachment.filename === 'string' && attachment.filename) {
+      const composed = `https://static-docs.nocobase.com/${encodeURIComponent(attachment.filename)}`;
+      return { ...attachment, url: composed, preview: composed };
+    }
     return attachment;
   }
 }


### PR DESCRIPTION
Follow-up to #173. The scheduled sync bot overwrote the resolved cover again at 04:56/06:56 (it either runs an older copy of the script, or its token cannot follow the authenticated /files redirect).

- resolver now falls back to composing the direct URL from the attachment filename (`https://static-docs.nocobase.com/<filename>`) whenever the 302 resolution fails — any runner executing this repo's script now always emits a direct URL
- re-fix the 2.2-beta announcement cover metadata

Note for ops: if the next sync commit after this merge still rewrites the cover to `/files/...`, the scheduled runner is executing its own stale copy of `sync-recent-content.js` and needs to be updated wherever the cron lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)