### PR TITLE
docs: update roadmap progress across locales

### DIFF
--- a/src/pages/cn/roadmap.astro
+++ b/src/pages/cn/roadmap.astro
@@ -28,6 +28,7 @@ const keywords = page.keywords_cn || page.keywords;
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>进行中</span>
                 </span>
+                <span class="roadmap-updated">最后更新：2026-07-27</span>
               </div>
 
               <ul class="roadmap-list">
@@ -42,6 +43,10 @@ const keywords = page.keywords_cn || page.keywords;
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>支持 Sub Agent</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>支持沙箱环境及自定义 Skill</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>支持多 Agent 并行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>AI Employee Event 支持传递当前登录用户上下文</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>通过 RunJS API 在 JS 区块中触发 AI 员工任务</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>AI 知识库设置页迁移至 client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>优化知识库检索、数据查询约束和工具诊断信息</span></li>
                   </ul>
                 </li>
 
@@ -69,13 +74,39 @@ const keywords = page.keywords_cn || page.keywords;
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">全新的 /v2/ 分支</span>
+                    <span class="roadmap-title">组织与身份集成</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> 提供 client-v2</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>内核 <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>各插件提供 <code>/src/client-v2</code> 目录</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>路由新增 <code>/v2/</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>钉钉 Stream 模式组织事件同步</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>LDAP 用户数据同步</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>支持可选的 AD 部门同步</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">client-v2 演进</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> 提供 client-v2</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>内核 <code>@nocobase/client-v2</code> 已从 client-v1 分离</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>各插件提供并完善 <code>/src/client-v2</code> 目录</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>新版客户端访问路径为 <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>页面、子页面和弹窗的 Tab 支持联动规则</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>公开表单逐步迁移至 client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>记录历史、日志设置等系统插件迁移至 client-v2</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">工作流 client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>工作流设置页与 v2 画布迁移</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>JavaScript、HTTP 请求、邮件发送、JSON 计算、数据库事务等节点迁移</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>v2 审批发起和待办区块</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>保持与旧版工作流配置兼容</span></li>
                   </ul>
                 </li>
 
@@ -93,7 +124,8 @@ const keywords = page.keywords_cn || page.keywords;
                     <span class="roadmap-title">使用 Rsbuild 构建</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> 和 <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>App 生产构建与 <code>@nocobase/build</code> 已迁移至 Rsbuild</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>进一步统一 <code>yarn dev</code> 和 <code>yarn dev:umi</code> 开发工作流</span></li>
                   </ul>
                 </li>
 
@@ -108,7 +140,7 @@ const keywords = page.keywords_cn || page.keywords;
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">支持 JS Item\Action</span>
+                    <span class="roadmap-title">支持 JS Item Action</span>
                   </div>
                   <ul>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>提供不同形态的 Action</span></li>
@@ -137,16 +169,16 @@ const keywords = page.keywords_cn || page.keywords;
                 <li>
                   <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">中国行政区划字段 2.0</span>
                     </span>
                   </div>
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">自定义变量</span>
                     </span>
                   </div>
@@ -155,7 +187,7 @@ const keywords = page.keywords_cn || page.keywords;
                 <li>
                   <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">树区块 2.0</span>
                     </span>
                   </div>
@@ -164,7 +196,7 @@ const keywords = page.keywords_cn || page.keywords;
                 <li>
                   <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">日历区块 2.0</span>
                     </span>
                   </div>
@@ -173,10 +205,21 @@ const keywords = page.keywords_cn || page.keywords;
                 <li>
                   <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">看板区块 2.0</span>
                     </span>
                   </div>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">评论区块 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>新增评论区块</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>支持数据范围、默认排序和分页配置</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>支持基于标量字段配置评论归属关系</span></li>
+                  </ul>
                 </li>
 
                 <li>
@@ -209,6 +252,7 @@ const keywords = page.keywords_cn || page.keywords;
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -236,6 +280,12 @@ const keywords = page.keywords_cn || page.keywords;
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -339,6 +389,11 @@ const keywords = page.keywords_cn || page.keywords;
   }
 
   @media (max-width: 576px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
+
     .roadmap-item {
       align-items: flex-start;
       flex-direction: column;

--- a/src/pages/en/roadmap.astro
+++ b/src/pages/en/roadmap.astro
@@ -28,6 +28,7 @@ const keywords = page.keywords;
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>In Progress</span>
                 </span>
+                <span class="roadmap-updated">Last updated: July 27, 2026</span>
               </div>
 
               <ul class="roadmap-list">
@@ -42,6 +43,10 @@ const keywords = page.keywords;
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sub-agent support</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Sandbox support and custom skills</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Parallel multi-agent support</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Pass the current signed-in user context to AI Employee Events</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Trigger AI employee tasks from JS blocks through the RunJS API</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrate AI knowledge base settings to client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Improve knowledge retrieval, data query constraints, and tool diagnostics</span></li>
                   </ul>
                 </li>
 
@@ -69,13 +74,39 @@ const keywords = page.keywords;
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">New /v2/ Branch</span>
+                    <span class="roadmap-title">Organization and Identity Integrations</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> provides client-v2</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Core package <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Each plugin provides a <code>/src/client-v2</code> directory</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>New <code>/v2/</code> route</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>DingTalk Stream organization event synchronization</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>LDAP user data synchronization</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Optional Active Directory department synchronization</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">client-v2 Evolution</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> provides client-v2</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Core package <code>@nocobase/client-v2</code> is separated from client-v1</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Each plugin provides and improves its <code>/src/client-v2</code> directory</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>The modern client is available at <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Linkage rules for tabs on pages, subpages, and popups</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Gradual migration of public forms to client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrate system plugins such as record history and log settings to client-v2</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Workflow client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrate workflow settings and the workflow canvas to v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrate JavaScript, HTTP request, email, JSON calculation, and database transaction nodes</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Approval initiation and task blocks for v2 pages</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Maintain compatibility with legacy workflow configurations</span></li>
                   </ul>
                 </li>
 
@@ -93,7 +124,8 @@ const keywords = page.keywords;
                     <span class="roadmap-title">Rsbuild-Based Build System</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> and <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>App production builds and <code>@nocobase/build</code> have migrated to Rsbuild</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Further unify the <code>yarn dev</code> and <code>yarn dev:umi</code> development workflows</span></li>
                   </ul>
                 </li>
 
@@ -135,9 +167,9 @@ const keywords = page.keywords;
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">Custom Variables</span>
                     </span>
                   </div>
@@ -172,6 +204,17 @@ const keywords = page.keywords;
 
                 <li>
                   <div class="roadmap-item">
+                    <span class="roadmap-title">Comments Block 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Add a new comments block</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Support data scope, default sorting, and pagination settings</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Configure comment ownership through scalar fields</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
                     <span class="roadmap-title">Full Plugin Migration to client-v2</span>
                   </div>
                   <ul>
@@ -200,6 +243,7 @@ const keywords = page.keywords;
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -227,6 +271,12 @@ const keywords = page.keywords;
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -330,6 +380,11 @@ const keywords = page.keywords;
   }
 
   @media (max-width: 576px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
+
     .roadmap-item {
       align-items: flex-start;
       flex-direction: column;

--- a/src/pages/es/roadmap.astro
+++ b/src/pages/es/roadmap.astro
@@ -26,6 +26,7 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>En curso</span>
                 </span>
+                <span class="roadmap-updated">Última actualización: 27 de julio de 2026</span>
               </div>
 
               <ul class="roadmap-list">
@@ -40,6 +41,10 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Soporte para subagentes</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Soporte de sandbox y skills personalizadas</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Soporte multiagente en paralelo</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Pasar el contexto del usuario conectado a los eventos del empleado de IA</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Activar tareas del empleado de IA desde bloques JS mediante la API RunJS</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrar la configuración de la base de conocimiento de IA a client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Mejorar la recuperación de conocimiento, las restricciones de consulta de datos y el diagnóstico de herramientas</span></li>
                   </ul>
                 </li>
 
@@ -67,13 +72,39 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">Nueva rama /v2/</span>
+                    <span class="roadmap-title">Integraciones de organización e identidad</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> proporciona client-v2</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Paquete core <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Cada plugin incorpora un directorio <code>/src/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Nueva ruta <code>/v2/</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sincronización de eventos de organización mediante DingTalk Stream</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sincronización de datos de usuarios mediante LDAP</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sincronización opcional de departamentos de Active Directory</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Evolución de client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> proporciona client-v2</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>El paquete core <code>@nocobase/client-v2</code> está separado de client-v1</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Cada plugin proporciona y mejora su directorio <code>/src/client-v2</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>El cliente moderno está disponible en <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Reglas de vinculación para pestañas en páginas, subpáginas y ventanas emergentes</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migración gradual de formularios públicos a client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrar a client-v2 plugins del sistema como el historial de registros y la configuración de logs</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Workflow client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrar a v2 la configuración y el lienzo de workflow</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrar nodos de JavaScript, solicitudes HTTP, correo electrónico, cálculo JSON y transacciones de base de datos</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Bloques de inicio y tareas de aprobación para páginas v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Mantener la compatibilidad con configuraciones de workflow heredadas</span></li>
                   </ul>
                 </li>
 
@@ -91,7 +122,8 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
                     <span class="roadmap-title">Sistema de build basado en Rsbuild</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> y <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Los builds de producción de la aplicación y <code>@nocobase/build</code> se han migrado a Rsbuild</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Unificar aún más los flujos de desarrollo de <code>yarn dev</code> y <code>yarn dev:umi</code></span></li>
                   </ul>
                 </li>
 
@@ -133,9 +165,9 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">Variables personalizadas</span>
                     </span>
                   </div>
@@ -170,6 +202,17 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
 
                 <li>
                   <div class="roadmap-item">
+                    <span class="roadmap-title">Bloque de comentarios 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Añadir un nuevo bloque de comentarios</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Permitir configurar el alcance de datos, el orden predeterminado y la paginación</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Configurar la autoría de comentarios mediante campos escalares</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
                     <span class="roadmap-title">Migración completa de los plugins a client-v2</span>
                   </div>
                   <ul>
@@ -198,6 +241,7 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -225,6 +269,12 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -326,6 +376,11 @@ const keywords = "NocoBase, hoja de ruta, producto, funciones, desarrollo";
   }
 
   @media (max-width: 767px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
+
     .roadmap-item {
       align-items: flex-start;
       flex-direction: column;

--- a/src/pages/id/roadmap.astro
+++ b/src/pages/id/roadmap.astro
@@ -26,6 +26,7 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>Sedang berjalan</span>
                 </span>
+                <span class="roadmap-updated">Terakhir diperbarui: 27 Juli 2026</span>
               </div>
 
               <ul class="roadmap-list">
@@ -40,6 +41,10 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Dukungan untuk sub-agent</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Dukungan sandbox dan skill kustom</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Dukungan multi-agent paralel</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Meneruskan konteks pengguna yang sedang login ke AI Employee Events</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Memicu tugas pegawai AI dari blok JS melalui RunJS API</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Memigrasikan pengaturan basis pengetahuan AI ke client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Meningkatkan pengambilan pengetahuan, batasan kueri data, dan diagnostik alat</span></li>
                   </ul>
                 </li>
 
@@ -67,13 +72,39 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">Branch baru /v2/</span>
+                    <span class="roadmap-title">Integrasi Organisasi dan Identitas</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> menyediakan client-v2</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Paket inti <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Setiap plugin menyertakan direktori <code>/src/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Rute baru <code>/v2/</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sinkronisasi event organisasi melalui DingTalk Stream</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sinkronisasi data pengguna LDAP</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sinkronisasi departemen Active Directory opsional</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Evolusi client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> menyediakan client-v2</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Paket inti <code>@nocobase/client-v2</code> dipisahkan dari client-v1</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Setiap plugin menyediakan dan meningkatkan direktori <code>/src/client-v2</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Client modern tersedia di <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Aturan keterkaitan tab pada halaman, subhalaman, dan popup</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrasi bertahap formulir publik ke client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrasikan plugin sistem seperti riwayat record dan pengaturan log ke client-v2</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Workflow client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrasikan pengaturan workflow dan workflow canvas ke v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Migrasikan node JavaScript, HTTP request, email, kalkulasi JSON, dan transaksi database</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Blok inisiasi approval dan tugas untuk halaman v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Mempertahankan kompatibilitas dengan konfigurasi workflow lama</span></li>
                   </ul>
                 </li>
 
@@ -91,7 +122,8 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
                     <span class="roadmap-title">Sistem build berbasis Rsbuild</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> dan <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Build production aplikasi dan <code>@nocobase/build</code> telah dimigrasikan ke Rsbuild</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Menyatukan lebih lanjut alur pengembangan <code>yarn dev</code> dan <code>yarn dev:umi</code></span></li>
                   </ul>
                 </li>
 
@@ -133,9 +165,9 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">Variabel kustom</span>
                     </span>
                   </div>
@@ -170,6 +202,17 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
 
                 <li>
                   <div class="roadmap-item">
+                    <span class="roadmap-title">Comments Block 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Menambahkan comments block baru</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Mendukung pengaturan cakupan data, pengurutan default, dan paginasi</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Mengonfigurasi kepemilikan komentar melalui field scalar</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
                     <span class="roadmap-title">Migrasi penuh semua plugin ke client-v2</span>
                   </div>
                   <ul>
@@ -198,6 +241,7 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -225,6 +269,12 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -306,5 +356,12 @@ const keywords = "NocoBase, roadmap, produk, fitur, pengembangan";
     border-radius: 0.35rem;
     padding: 0.12rem 0.4rem;
     font-size: 0.92em;
+  }
+
+  @media (max-width: 767px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
   }
 </style>

--- a/src/pages/ja/roadmap.astro
+++ b/src/pages/ja/roadmap.astro
@@ -28,6 +28,7 @@ const keywords = page.keywords_ja || page.keywords;
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>進行中</span>
                 </span>
+                <span class="roadmap-updated">最終更新：2026-07-27</span>
               </div>
 
               <ul class="roadmap-list">
@@ -42,6 +43,10 @@ const keywords = page.keywords_ja || page.keywords;
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Sub-agent のサポート</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>サンドボックス環境とカスタム Skill のサポート</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>複数 Agent の並列サポート</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>AI Employee イベントで現在のログインユーザー情報を受け渡す</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>RunJS API を使用して JS ブロックから AI Employee タスクを実行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>AI ナレッジベース設定ページを client-v2 へ移行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>ナレッジ検索、データクエリ制約、ツール診断情報を改善</span></li>
                   </ul>
                 </li>
 
@@ -69,13 +74,39 @@ const keywords = page.keywords_ja || page.keywords;
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">新しい /v2/ ブランチ</span>
+                    <span class="roadmap-title">組織・ID 連携</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> が client-v2 を提供</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>コアパッケージ <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>各プラグインが <code>/src/client-v2</code> ディレクトリを提供</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>新しい <code>/v2/</code> ルート</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>DingTalk Stream による組織イベント同期</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>LDAP ユーザーデータ同期</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>任意の Active Directory 部門同期</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">client-v2 の進化</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> が client-v2 を提供</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>コアパッケージ <code>@nocobase/client-v2</code> を client-v1 から分離</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>各プラグインが <code>/src/client-v2</code> を提供・改善</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>モダンクライアントのアクセスパスは <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>ページ、サブページ、ポップアップの Tab で連動ルールをサポート</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>公開フォームを段階的に client-v2 へ移行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>履歴、ログ設定などのシステムプラグインを client-v2 へ移行</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">ワークフロー client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>ワークフロー設定ページと v2 キャンバスを移行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>JavaScript、HTTP リクエスト、メール送信、JSON 計算、データベーストランザクションノードを移行</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>v2 ページ向けの承認開始・タスクブロック</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>旧版ワークフロー設定との互換性を維持</span></li>
                   </ul>
                 </li>
 
@@ -93,7 +124,8 @@ const keywords = page.keywords_ja || page.keywords;
                     <span class="roadmap-title">Rsbuild ベースのビルドシステム</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> と <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>App の本番ビルドと <code>@nocobase/build</code> を Rsbuild へ移行済み</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> と <code>yarn dev:umi</code> の開発ワークフローをさらに統一</span></li>
                   </ul>
                 </li>
 
@@ -135,9 +167,9 @@ const keywords = page.keywords_ja || page.keywords;
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">カスタム変数</span>
                     </span>
                   </div>
@@ -172,6 +204,17 @@ const keywords = page.keywords_ja || page.keywords;
 
                 <li>
                   <div class="roadmap-item">
+                    <span class="roadmap-title">コメントブロック 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>新しいコメントブロックを追加</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>データ範囲、デフォルトの並び順、ページネーション設定をサポート</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>スカラーフィールドによるコメント所有関係の設定をサポート</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
                     <span class="roadmap-title">全プラグインの client-v2 への移行</span>
                   </div>
                   <ul>
@@ -200,6 +243,7 @@ const keywords = page.keywords_ja || page.keywords;
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -227,6 +271,12 @@ const keywords = page.keywords_ja || page.keywords;
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -330,6 +380,11 @@ const keywords = page.keywords_ja || page.keywords;
   }
 
   @media (max-width: 576px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
+
     .roadmap-item {
       align-items: flex-start;
       flex-direction: column;

--- a/src/pages/vi/roadmap.astro
+++ b/src/pages/vi/roadmap.astro
@@ -26,6 +26,7 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
                   <i class="uil uil-clock-three legend-icon legend-icon-progress"></i>
                   <span>Dang thuc hien</span>
                 </span>
+                <span class="roadmap-updated">Cap nhat lan cuoi: 27/07/2026</span>
               </div>
 
               <ul class="roadmap-list">
@@ -40,6 +41,10 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
                     <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Ho tro sub-agent</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Ho tro sandbox va skill tuy chinh</span></li>
                     <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Ho tro da agent chay song song</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Truyen ngu canh nguoi dung dang dang nhap vao AI Employee Events</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Kich hoat tac vu nhan vien AI tu JS block thong qua RunJS API</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Chuyen cai dat co so tri thuc AI sang client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Cai tien truy xuat tri thuc, rang buoc truy van du lieu va chan doan cong cu</span></li>
                   </ul>
                 </li>
 
@@ -67,13 +72,39 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
 
                 <li>
                   <div class="roadmap-item">
-                    <span class="roadmap-title">Nhanh moi /v2/</span>
+                    <span class="roadmap-title">Tich hop to chuc va danh tinh</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>@nocobase/app</code> cung cap client-v2</span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Goi core <code>@nocobase/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Moi plugin deu co thu muc <code>/src/client-v2</code></span></li>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Tuyen duong moi <code>/v2/</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Dong bo su kien to chuc qua DingTalk Stream</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Dong bo du lieu nguoi dung LDAP</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Tuy chon dong bo phong ban Active Directory</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Tien trien client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span><code>@nocobase/app</code> cung cap client-v2</span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Goi core <code>@nocobase/client-v2</code> duoc tach khoi client-v1</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Moi plugin cung cap va cai tien thu muc <code>/src/client-v2</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Client hien dai kha dung tai <code>/v/</code></span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Quy tac lien ket tab tren trang, trang con va popup</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Chuyen doi tung buoc public form sang client-v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Chuyen cac plugin he thong nhu lich su ban ghi va cai dat log sang client-v2</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
+                    <span class="roadmap-title">Workflow client-v2</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Chuyen cai dat workflow va workflow canvas sang v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Chuyen cac node JavaScript, HTTP request, email, tinh toan JSON va transaction co so du lieu</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Block khoi tao phe duyet va tac vu cho trang v2</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Duy tri kha nang tuong thich voi cau hinh workflow cu</span></li>
                   </ul>
                 </li>
 
@@ -91,7 +122,8 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
                     <span class="roadmap-title">He thong build dua tren Rsbuild</span>
                   </div>
                   <ul>
-                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span><code>yarn dev</code> va <code>yarn dev:umi</code></span></li>
+                    <li class="status-done"><i class="uil uil-check-circle align-middle"></i><span>Build production cua ung dung va <code>@nocobase/build</code> da chuyen sang Rsbuild</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Tiep tuc hop nhat luong phat trien <code>yarn dev</code> va <code>yarn dev:umi</code></span></li>
                   </ul>
                 </li>
 
@@ -133,9 +165,9 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
                 </li>
 
                 <li>
-                  <div class="roadmap-item roadmap-item-status status-progress">
+                  <div class="roadmap-item roadmap-item-status status-done">
                     <span class="roadmap-title-wrap">
-                      <i class="uil uil-clock-three align-middle"></i>
+                      <i class="uil uil-check-circle align-middle"></i>
                       <span class="roadmap-title">Bien tuy chinh</span>
                     </span>
                   </div>
@@ -170,6 +202,17 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
 
                 <li>
                   <div class="roadmap-item">
+                    <span class="roadmap-title">Comments block 2.0</span>
+                  </div>
+                  <ul>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Them comments block moi</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Ho tro cai dat pham vi du lieu, sap xep mac dinh va phan trang</span></li>
+                    <li class="status-progress"><i class="uil uil-clock-three align-middle"></i><span>Cau hinh chu so huu binh luan bang truong scalar</span></li>
+                  </ul>
+                </li>
+
+                <li>
+                  <div class="roadmap-item">
                     <span class="roadmap-title">Chuyen doi toan bo plugin sang client-v2</span>
                   </div>
                   <ul>
@@ -198,6 +241,7 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
   .roadmap-legend {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 1.25rem;
     padding: 0.85rem 1rem;
@@ -225,6 +269,12 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
 
   .legend-icon-progress {
     color: #f59e0b;
+  }
+
+  .roadmap-updated {
+    margin-left: auto;
+    color: #64748b;
+    font-size: 0.85rem;
   }
 
   .roadmap-list,
@@ -306,5 +356,12 @@ const keywords = "NocoBase, lo trinh, san pham, tinh nang, phat trien";
     border-radius: 0.35rem;
     padding: 0.12rem 0.4rem;
     font-size: 0.92em;
+  }
+
+  @media (max-width: 767px) {
+    .roadmap-updated {
+      width: 100%;
+      margin-left: 0;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

- update roadmap progress to reflect current product delivery
- add AI employee, identity integration, client-v2, workflow, Rsbuild, and Comments Block updates
- synchronize content across Chinese, English, Japanese, Spanish, Vietnamese, and Indonesian pages
- preserve the existing vertical roadmap layout

## Verification

- git diff --check
- confirmed only six localized Roadmap files are included
- verified /cn/roadmap, /en/roadmap, /ja/roadmap, /es/roadmap, /vi/roadmap, and /id/roadmap return HTTP 200 locally